### PR TITLE
feature/sfrac

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -2605,6 +2605,24 @@ MathJax.Hub.Config({
         scale: 88,
     },
 });
+    <xsl:if test="//m[contains(text(),'sfrac')] or //md[contains(text(),'sfrac')] or //me[contains(text(),'sfrac')] or //mrow[contains(text(),'sfrac')]">
+    /* support for the sfrac command in MathJax (Beveled fraction)
+        see: https://github.com/mathjax/MathJax-docs/wiki/Beveled-fraction-like-sfrac,-nicefrac-bfrac */
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var MML = MathJax.ElementJax.mml,
+      TEX = MathJax.InputJax.TeX;
+
+  TEX.Definitions.macros.sfrac = "myBevelFraction";
+
+  TEX.Parse.Augment({
+    myBevelFraction: function (name) {
+      var num = this.ParseArg(name),
+          den = this.ParseArg(name);
+      this.Push(MML.mfrac(num,den).With({bevelled: true}));
+    }
+  });
+});
+    </xsl:if>
 </script>
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full" />
 </xsl:template>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -332,6 +332,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Need CDATA here to protect inequalities as part of an XML file -->
     <xsl:text><![CDATA[\newcommand{\lt}{<}]]>&#xa;</xsl:text>
     <xsl:text><![CDATA[\newcommand{\gt}{>}]]>&#xa;</xsl:text>
+    <xsl:if test="//m[contains(text(),'sfrac')] or //md[contains(text(),'sfrac')] or //me[contains(text(),'sfrac')] or //mrow[contains(text(),'sfrac')]">
+        <xsl:text>%% xfrac package for 'beveled fractions': http://tex.stackexchange.com/questions/3372/how-do-i-typeset-arbitrary-fractions-like-the-standard-symbol-for-5-%C2%BD&#xa;</xsl:text>
+        <xsl:text>\usepackage{xfrac}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>%% Semantic Macros&#xa;</xsl:text>
     <xsl:text>%% To preserve meaning in a LaTeX file&#xa;</xsl:text>
     <xsl:text>%% Only defined here if required in this document&#xa;</xsl:text>


### PR DESCRIPTION
Hi Rob,
As Alex mentioned in https://github.com/rbeezer/mathbook/pull/26, we're working on a project which uses the `xml` approach you demonstrated to us in June 2013. We've made quite a few new features, and are in the process of re-doing them in a way that allows us to submit them to your original project, and `pull` your updates; hopefully some of our features will be useful!

This pull request implements a 'beveled' fraction in both the `.tex` and the `.html` versions. It conditionally loads the `xfrac` package in the `.tex` version, and conditionally updates the `MathJax` in the `.html` version. You'll see that I've provided links within the code, but for reference, here they are:
- https://github.com/mathjax/MathJax-docs/wiki/Beveled-fraction-like-sfrac,-nicefrac-bfrac
- http://tex.stackexchange.com/questions/3372/how-do-i-typeset-arbitrary-fractions-like-the-standard-symbol-for-5-%C2%BD

To test it, add (for example) `\sfrac{2}{13}` to any of the math elements in `examples/sample-article.xml` and then run the translation scripts. You should see that the `\sfrac` produces a beveled fraction :)

Best
Chris 