### PR TITLE
added option to only put LaTeX label on objects that have an ID

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -74,6 +74,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- on an <xref> where it is unjustified or a problem    -->
 <!-- Default is to have this feature off                  -->
 <xsl:param name="autoname" select="'no'" />
+<!-- Chapters, sections, figures, tables, exercises, etc         -->
+<!-- can receive a generic \label{<object name>-<object number>} -->
+<!-- or not, according to the value of labelObjectsWithoutID     -->
+<xsl:param name="labelObjectsWithoutID" select="'yes'" />
 <!-- How many levels to table of contents  -->
 <!-- Not peculiar to HTML or LaTeX or etc. -->
 <!-- Sentinel indicates no choice made     -->
@@ -843,9 +847,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Calls to this template need come from where LaTeX likes -->
 <!-- a \label, generally someplace that can be numbered      -->
 <xsl:template match="*" mode="label">
-    <xsl:text>\label{</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
-    <xsl:text>}</xsl:text>
+    <xsl:if test="$labelObjectsWithoutID='yes' or @xml:id or local-name(.)='notation'">
+      <xsl:text>\label{</xsl:text>
+      <xsl:apply-templates select="." mode="internal-id" />
+      <xsl:text>}</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- Visual Identifiers -->

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -77,7 +77,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Chapters, sections, figures, tables, exercises, etc         -->
 <!-- can receive a generic \label{<object name>-<object number>} -->
 <!-- or not, according to the value of labelObjectsWithoutID     -->
-<xsl:param name="labelObjectsWithoutID" select="'yes'" />
+<!-- If you'd like to guarantee that certain objects always get  -->
+<!-- an ID, add it to alwaysGiveLabel                            -->
+<xsl:param name="labelObjectsWithoutID" select="'no'" />
+<xsl:param name="alwaysGiveLabel" select="'notation section'" />
 <!-- How many levels to table of contents  -->
 <!-- Not peculiar to HTML or LaTeX or etc. -->
 <!-- Sentinel indicates no choice made     -->
@@ -847,7 +850,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Calls to this template need come from where LaTeX likes -->
 <!-- a \label, generally someplace that can be numbered      -->
 <xsl:template match="*" mode="label">
-    <xsl:if test="$labelObjectsWithoutID='yes' or @xml:id or local-name(.)='notation'">
+    <xsl:if test="$labelObjectsWithoutID='yes' or @xml:id or contains($alwaysGiveLabel, local-name(.))">
       <xsl:text>\label{</xsl:text>
       <xsl:apply-templates select="." mode="internal-id" />
       <xsl:text>}</xsl:text>


### PR DESCRIPTION
This pull request adds a switch so that numbered objects such as chapters, sections, figures will only receive a `\label` in the `latex` version when they have an `xml:id` attribute.

The parameter that controls this is in `xsl/mathbook-common.xsl`:

    <xsl:param name="labelObjectsWithoutID" select="'yes'" />

If you run `xsltproc xsl/mathbook-latex.xsl examples/sample-article.xml` and you have `labelObjectsWithoutID` set to `yes`, then you'll see that everything that has a number will receive a generic label, such as `\label{section-1}` (i.e, the original behaviour). If you change `labelObjectsWithoutID` to `no` then you'll see that only the objects that have an `xml:id` will receive a label.

----
PS: Rob, we're making quite a few updates to `openMathDocs` and are submitting them to you with no pressure at all :) If you like them, we'd love them to be part of your project, but if you don't like them or you need parts of them tweaked, please do let us know--we certainly could benefit a lot from your feedback.