### PR TITLE
Feature/figure description

### DIFF
--- a/examples/sample-article.xml
+++ b/examples/sample-article.xml
@@ -532,6 +532,7 @@ the xsltproc executable.
             <figure xml:id="figure-function-derivative">
                 <caption>A function and its derivative</caption>
                 <image width="350" source="images/cubic-function.png" />
+                <description>This graph shows the function, f, that has formula f(x)=(x-3)*(x-1)*(x+2), and its derivative f'(x).</description>
             </figure>
 
             <p>Lists can have multiple columns.  With <acro>HTML</acro> items displayed in row-major order (horizontally first) and with <latex /> items are displayed in column-major order (vertically first).  When one order, or the other, becomes workable in both variants, maybe we will be consistent in presentation.  (Note that with just one row, it makes no difference.)  We used it above for the two items <mdash /> derivatives and integrals <mdash /> where each item was a list of its own.  Here are two more examples, one with short snippets and lots of columns, the other with lots of text in paragraphs.<index xml:id="index-start-multicolumn" finish="index-finish-multicolumn"><main>Lists</main><sub>multicolumn</sub></index></p>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1397,8 +1397,30 @@ is just flat out on the page, as if printed there.
         <xsl:attribute name="height"><xsl:value-of select="@height" /></xsl:attribute>
     </xsl:if>
     <xsl:attribute name="src"><xsl:value-of select="@source" /></xsl:attribute>
+    <xsl:call-template name="figuredescription"/>
 </xsl:element>
 </xsl:template>
+
+<xsl:template name="figuredescription">
+    <!-- test to see if <description> exists, otherwise put a message -->
+    <xsl:choose>
+        <xsl:when test="../description!=''">
+            <xsl:attribute name="title">
+              <xsl:value-of select="../description"/>
+            </xsl:attribute>
+            <xsl:attribute name="alt">
+                <xsl:value-of select="../description"/>
+            </xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:attribute name="title">DESCRIPTION NEEDED!</xsl:attribute>
+            <xsl:attribute name="alt">DESCRIPTION NEEDED!</xsl:attribute>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- create an empty template for figure descriptions -->
+<xsl:template match="figure/description"/>
 
 <!-- tikz graphics language       -->
 <!-- SVG's produced by mbx script -->
@@ -1453,6 +1475,7 @@ is just flat out on the page, as if printed there.
                 <xsl:apply-templates select="." mode="internal-id" />
                 <xsl:text>.png</xsl:text>
             </xsl:attribute>
+            <xsl:call-template name="figuredescription"/>
         </xsl:element>
     </xsl:element>
 </xsl:template>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1928,6 +1928,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text><xsl:value-of select="@source" /><xsl:text>}</xsl:text>
 </xsl:template>
 
+<!-- create an empty template for figure descriptions -->
+<xsl:template match="figure/description"/>
+
 <!-- tikz graphics language -->
 <!-- preliminary (cursory) support -->
 <!-- http://tex.stackexchange.com/questions/4338/correctly-scaling-a-tikzpicture -->


### PR DESCRIPTION
An implementation of the `description` tag for a `figure`. You'll see a demonstration in `sample-article.xml`.

It adds the `description` text to both the `alt` and the `title` attritbute in the `html` version; it does nothing for the `.tex` version.