### PR TITLE
id attribure for figure in html

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1381,7 +1381,8 @@ is just flat out on the page, as if printed there.
 <!-- Figures and their captions -->
 <!-- TODO: class="wrap" is possible -->
 <xsl:template match="figure">
-    <figure>
+    <xsl:variable name="ident"><xsl:apply-templates select="." mode="internal-id" /></xsl:variable>
+    <figure id="{$ident}">
         <xsl:apply-templates select="*[not(self::caption)]"/>
         <xsl:apply-templates select="caption"/>
     </figure>


### PR DESCRIPTION
I noticed when I clicked on a link to a figure reference, there was no target id. Thought about submitting an issue, but then I thought this might be more helpful as long as I did it right. 