### PR TITLE
Finish algorithm

### DIFF
--- a/examples/sample-article.xml
+++ b/examples/sample-article.xml
@@ -2250,6 +2250,7 @@ the xsltproc executable.
                                 <li>If <c>p</c> is now the last element of the list, stop</li>
                                 <li>Otherwise, set <c>p</c> to the element of the list immediately after current <c>p</c></li>
                             </ol></li>
+                        <li>Output: the remaining elements of the list</li>
                     </ol>
                 </statement>
 


### PR DESCRIPTION
The algorithm should make it 100% clear what the output is; after all, an algorithm could create a list and then not do anything with it.  More importantly, Python requires a `return` statement, unlike (say) R!