### PR TITLE
Latex image to png

### DIFF
--- a/examples/sample-article.xml
+++ b/examples/sample-article.xml
@@ -855,7 +855,7 @@ the xsltproc executable.
             <subsection>
                 <title><latex /> images</title>
 
-                <p>There are several graphics engine packages that a <latex /> document can employ. Code from these packages renders diagrams automatically as part of normal processing of <latex /> files.  For HTML output the <c>mbx</c> script produces SVG versions of the pictures.  The packages should be loaded in docinfo/latex-image-preamble, which is also where global package settings should be made. These first examples are from the <url href="http://www.texample.net/tikz/examples/">TeXample.net</url> site.</p>
+                <p>There are several graphics engine packages that a <latex /> document can employ. Code from these packages renders diagrams automatically as part of normal processing of <latex /> files.  For HTML output the <c>mbx</c> script produces SVG versions of the pictures.  The script can also produce standalone TEX source files, PDFs, PNGs, and EPSs. The packages should be loaded in docinfo/latex-image-preamble, which is also where global package settings should be made. These first examples are from the <url href="http://www.texample.net/tikz/examples/">TeXample.net</url> site.</p>
 
                 <!-- http://www.texample.net/media/tikz/examples/TEX/noise-shaper.tex -->
                 <figure xml:id="figure-tikz-electronics">

--- a/script/mbx
+++ b/script/mbx
@@ -190,23 +190,25 @@ def latex_image_conversion(xml_source, dest_dir, outformat):
             latex_cmd = [tex_executable, latex_image]
             _verbose("converting {} to {}".format(latex_image, latex_image_pdf))
             subprocess.call(latex_cmd, stdout=devnull, stderr=subprocess.STDOUT)
-            if outformat == 'svg':
+            if outformat == 'all':
+                shutil.copy2(latex_image, dest_dir)
+            if (outformat == 'pdf' or outformat == 'all'):
+                shutil.copy2(latex_image_pdf, dest_dir)
+            if (outformat == 'svg' or outformat == 'all'):
                 svg_cmd = [pdfsvg_executable, latex_image_pdf, latex_image_svg]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_svg))
                 subprocess.call(svg_cmd)
                 shutil.copy2(latex_image_svg, dest_dir)
-            if outformat == 'png':
+            if (outformat == 'png' or outformat == 'all'):
                 png_cmd = [pdfpng_executable, latex_image_pdf, latex_image_png]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_png))
                 subprocess.call(png_cmd)
                 shutil.copy2(latex_image_png, dest_dir)
-            if outformat == 'eps':
+            if (outformat == 'eps' or outformat == 'all'):
                 eps_cmd = [pdfeps_executable, '-eps', latex_image_pdf, latex_image_eps]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_eps))
                 subprocess.call(eps_cmd)
                 shutil.copy2(latex_image_eps, dest_dir)
-            if outformat == 'pdf':
-                shutil.copy2(latex_image_pdf, dest_dir)
 
 #######################################
 #
@@ -538,6 +540,7 @@ def get_cli_arguments():
         ('latex', 'LaTeX source file'),
         ('html', 'HyperText Markup Language (web pages)'),
         ('sagenb', 'Sage *.sws archive of worksheets'),
+        ('all', 'All available output formats'),
     ]
     format_help = 'Output formats are:\n' + '\n'.join(['  {} - {}'.format(info[0], info[1]) for info in format_info])
     parser.add_argument('-f', '--format', help=format_help, action="store", dest='format')
@@ -639,6 +642,8 @@ elif args.component == 'latex-image':
         latex_image_conversion(args.xml_file, args.dir, 'png')
     elif args.format == 'eps':
         latex_image_conversion(args.xml_file, args.dir, 'eps')
+    elif args.format == 'all':
+        latex_image_conversion(args.xml_file, args.dir, 'all')
     else:
         raise NotImplementedError('cannot make LaTeX pictures in "{}" format'.format(args.format))
 elif args.component == 'all':

--- a/script/mbx
+++ b/script/mbx
@@ -161,6 +161,10 @@ def latex_image_conversion(xml_source, dest_dir, outformat):
     _debug("tex executable: {}".format(tex_executable))
     pdfsvg_executable = get_executable(config, 'pdfsvg')
     _debug("pdfsvg executable: {}".format(pdfsvg_executable))
+    pdfpng_executable = get_executable(config, 'pdfpng')
+    _debug("pdfpng executable: {}".format(pdfpng_executable))
+    pdfeps_executable = get_executable(config, 'pdfeps')
+    _debug("pdfeps executable: {}".format(pdfeps_executable))
     # http://stackoverflow.com/questions/11269575/how-to-hide-output-of-subprocess-in-python-2-7
     devnull = open(os.devnull, 'w')
     convert_cmd = [xslt_executable,
@@ -181,6 +185,8 @@ def latex_image_conversion(xml_source, dest_dir, outformat):
             filebase, _ = os.path.splitext(latex_image)
             latex_image_pdf = "{}.pdf".format(filebase)
             latex_image_svg = "{}.svg".format(filebase)
+            latex_image_png = "{}.png".format(filebase)
+            latex_image_eps = "{}.eps".format(filebase)
             latex_cmd = [tex_executable, latex_image]
             _verbose("converting {} to {}".format(latex_image, latex_image_pdf))
             subprocess.call(latex_cmd, stdout=devnull, stderr=subprocess.STDOUT)
@@ -189,6 +195,16 @@ def latex_image_conversion(xml_source, dest_dir, outformat):
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_svg))
                 subprocess.call(svg_cmd)
                 shutil.copy2(latex_image_svg, dest_dir)
+            if outformat == 'png':
+                png_cmd = [pdfpng_executable, latex_image_pdf, latex_image_png]
+                _verbose("converting {} to {}".format(latex_image_pdf, latex_image_png))
+                subprocess.call(png_cmd)
+                shutil.copy2(latex_image_png, dest_dir)
+            if outformat == 'eps':
+                eps_cmd = [pdfeps_executable, '-eps', latex_image_pdf, latex_image_eps]
+                _verbose("converting {} to {}".format(latex_image_pdf, latex_image_eps))
+                subprocess.call(eps_cmd)
+                shutil.copy2(latex_image_eps, dest_dir)
             if outformat == 'pdf':
                 shutil.copy2(latex_image_pdf, dest_dir)
 
@@ -516,6 +532,8 @@ def get_cli_arguments():
     format_info = [
         ('svg', 'Scalable Vector Graphicsfile(s)'),
         ('pdf', 'Portable Document Format file(s)'),
+        ('png', 'Portable Network Graphics file(s)'),
+        ('eps', 'Encapsulated Post Script file(s)'),
         ('source', 'Standalone source files'),
         ('latex', 'LaTeX source file'),
         ('html', 'HyperText Markup Language (web pages)'),
@@ -549,6 +567,8 @@ def get_config_info(script_dir):
     defaults['xslt'] = 'xsltproc'
     defaults['tex'] = 'xelatex'
     defaults['pdfsvg'] = 'pdf2svg'
+    defaults['pdfpng'] = 'convert'
+    defaults['pdfeps'] = 'pdftops'
     defaults['asy'] = 'asy'
     defaults['sage'] = 'sage'
     config_file = os.path.join(script_dir, "mbx.cfg")
@@ -615,6 +635,10 @@ elif args.component == 'latex-image':
         latex_image_conversion(args.xml_file, args.dir, 'svg')
     elif args.format == 'source':
         latex_image_conversion(args.xml_file, args.dir, 'source')
+    elif args.format == 'png':
+        latex_image_conversion(args.xml_file, args.dir, 'png')
+    elif args.format == 'eps':
+        latex_image_conversion(args.xml_file, args.dir, 'eps')
     else:
         raise NotImplementedError('cannot make LaTeX pictures in "{}" format'.format(args.format))
 elif args.component == 'all':

--- a/script/mbx.cfg
+++ b/script/mbx.cfg
@@ -25,3 +25,5 @@ tex = xelatex
 pdfsvg = pdf2svg
 asy = asy
 sage = /sage/sage-6.3.beta2/sage
+pdfpng = convert
+pdfeps = pdftops


### PR DESCRIPTION
Adds png, eps, and all (tex, pdf, svg, png, eps) options for the output from latex-image components when the mbx script is used. 

Note that previously, mbx had no newline character at the end of the file. According to http://stackoverflow.com/questions/729692/why-should-files-end-with-a-newline, files should end with a newline character.