### PR TITLE
Add mpg and kph to units

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -519,7 +519,7 @@
 
 <!ENTITY % prefix "yocto|zepto|atto|femto|pico|nano|micro|milli|centi|deci|deca|deka|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta">
 
-<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|gallon">
+<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|kilometerperhour|kilometreperhour|gallon|milepergallon">
 
 <!ELEMENT quantity   (mag*, unit*, per*)>
 

--- a/xsl/mathbook-units.xsl
+++ b/xsl/mathbook-units.xsl
@@ -143,10 +143,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <base full='mile'              short='mi'       siunitx='none' />
 
     <!-- Speed                                                                      -->
+    <base full='kilometerperhour'  short='kph'      siunitx='none' />
+    <base full='kilometreperhour'  short='kph'      siunitx='none' />
     <base full='mileperhour'       short='mph'      siunitx='none' />
 
     <!-- Volume                                                                     -->
     <base full='gallon'            short='gal'      siunitx='none' />
+
+    <!-- Distance per Volume                                                        -->
+    <base full='milepergallon'     short='mpg'      siunitx='none' />
 
 </xsl:variable>
 


### PR DESCRIPTION
Adds "kilometerperhour", "kilometreperhour", and "milepergallon" to the options for a base attribute for a unit or per element. Result is "kph", "kph", and "mpg" respectively.