### PR TITLE
Fix small misspellings

### DIFF
--- a/doc/author-guide/mbx-script.xml
+++ b/doc/author-guide/mbx-script.xml
@@ -26,7 +26,7 @@
             <li><p>Provide complete debugging output with bug reports</p></li>
         </ul>
 
-        <p>Much like the build advice at the end of <xref ref="processing-file-management" />, the <c>mbx</c> script collects necessary bits into a system-created temporary directory, does its work, and copies out the desired results.  Some insight into failures can be found in this directory (which we leave behind for the ssytem to clean-up later).  Early in the <c>-vv</c> doubly-verbose output, this directory is reported afer the string <c>temporary directory:</c>.</p>
+        <p>Much like the build advice at the end of <xref ref="processing-file-management" />, the <c>mbx</c> script collects necessary bits into a system-created temporary directory, does its work, and copies out the desired results.  Some insight into failures can be found in this directory (which we leave behind for the system to clean-up later).  Early in the <c>-vv</c> doubly-verbose output, this directory is reported after the string <c>temporary directory:</c>.</p>
 
         <p>An example:</p>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -117,7 +117,7 @@ the xsltproc executable.
 
         You can make a document-specific, global override.  Here we
         decide we have no need for any "proposition"s and repurpose
-        that enviroment in US English as a "Conundrum."
+        that environment in US English as a "Conundrum."
 
         See the localization file for more on language codes, and realize
         that US English is the default if there is no "lang" attribute
@@ -499,7 +499,7 @@ the xsltproc executable.
             <subsection>
                 <title>Theorem-Like Environments</title>
 
-                <p>There are a variety of pre-defined enviroments in MathBook XML.  All take a title, and must have a statement.  Some have proofs (theorems, corollaries, <etc />), while some do not have proofs (conjectures, axioms, principles).</p>
+                <p>There are a variety of pre-defined environments in MathBook XML.  All take a title, and must have a statement.  Some have proofs (theorems, corollaries, <etc />), while some do not have proofs (conjectures, axioms, principles).</p>
 
                 <principle xml:id="principle-principle">
                     <title>The Title Principle</title>

--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -166,7 +166,7 @@
 <!ELEMENT definition   (title?, index*, notation*, statement)>
     <!ATTLIST definition xml:id ID #IMPLIED>
 
-<!-- theorem-like, ie with proof -->
+<!-- theorem-like, i.e. with proof -->
 <!ELEMENT theorem   (title?, index*, statement, proof*)>
     <!ATTLIST theorem xml:id ID #IMPLIED>
 <!ELEMENT corollary (title?, index*, statement, proof*)>
@@ -182,7 +182,7 @@
 <!ELEMENT fact     (title?, index*, statement, proof*)>
     <!ATTLIST fact     xml:id ID #IMPLIED>
 
-<!-- conjecture-like, ie no proof -->
+<!-- conjecture-like, i.e. no proof -->
 <!ELEMENT conjecture (title?, index*, statement)>
     <!ATTLIST conjecture xml:id ID #IMPLIED>
 <!ELEMENT axiom (title?, index*, statement)>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -1750,7 +1750,7 @@ See  xsl/mathbook-html.xsl  and  xsl:mathbook-latex.xsl  for two different nontr
 <!--                                                        -->
 <!-- There are six numbering schemes in place:              -->
 <!-- 1) divisions: sections, subsections, etc.              -->
-<!-- 2) enviroments: theorems, examples, exercises, figures -->
+<!-- 2) environments: theorems, examples, exercises, figures -->
 <!-- 3) equations: display mathematics                      -->
 <!-- 4) exercises: as part of a section of exercises        -->
 <!-- 5) bibliographic items: in multiple sections           -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -353,7 +353,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\usepackage{amsmath}&#xa;</xsl:text>
     <xsl:text>\usepackage{amssymb}&#xa;</xsl:text>
     <xsl:text>%% allow more columns to a matrix&#xa;</xsl:text>
-    <xsl:text>%% can make this even bigger by overiding with  latex.preamble.late  processing option&#xa;</xsl:text>
+    <xsl:text>%% can make this even bigger by overriding with  latex.preamble.late  processing option&#xa;</xsl:text>
     <xsl:text>\setcounter{MaxMatrixCols}{30}&#xa;</xsl:text>
     <xsl:if test="//m[contains(text(),'sfrac')] or //md[contains(text(),'sfrac')] or //me[contains(text(),'sfrac')] or //mrow[contains(text(),'sfrac')]">
         <xsl:text>%% xfrac package for 'beveled fractions': http://tex.stackexchange.com/questions/3372/how-do-i-typeset-arbitrary-fractions-like-the-standard-symbol-for-5-%C2%BD&#xa;</xsl:text>
@@ -418,7 +418,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}&#xa;</xsl:text>
     <!-- Could condition following on existence of any amsthm environment -->
     <xsl:text>%% Environments with amsthm package&#xa;</xsl:text>
-    <xsl:text>%% Theorem-like enviroments in "plain" style, with or without proof&#xa;</xsl:text>
+    <xsl:text>%% Theorem-like environments in "plain" style, with or without proof&#xa;</xsl:text>
     <xsl:text>\usepackage{amsthm}&#xa;</xsl:text>
     <xsl:text>\theoremstyle{plain}&#xa;</xsl:text>
     <xsl:text>%% Numbering for Theorems, Conjectures, Examples, Figures, etc&#xa;</xsl:text>
@@ -518,7 +518,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
     </xsl:if>
     <!-- Localize various standard names in use         -->
-    <!-- Many enviroments addressed upon creation above -->
+    <!-- Many environments addressed upon creation above -->
     <!-- Figure and Table addressed elsewhere           -->
     <!-- Index, table of contents done elsewhere        -->
     <!-- http://www.tex.ac.uk/FAQ-fixnam.html           -->
@@ -622,7 +622,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%%   1) New mbxfigure and/or mbxtable environments are defined with float package&#xa;</xsl:text>
         <xsl:text>%%   2) Standard LaTeX environments redefined to use new environments&#xa;</xsl:text>
         <xsl:text>%%   3) Standard LaTeX environments redefined to step theorem counter&#xa;</xsl:text>
-        <xsl:text>%%   4) Counter for new enviroments is set to the theorem counter before caption&#xa;</xsl:text>
+        <xsl:text>%%   4) Counter for new environments is set to the theorem counter before caption&#xa;</xsl:text>
         <xsl:text>%% You can remove all this figure/table setup, to restore standard LaTeX behavior&#xa;</xsl:text>
         <xsl:text>%% HOWEVER, numbering of figures/tables AND theorems/examples/remarks, etc&#xa;</xsl:text>
         <xsl:text>%% WILL ALL de-synchronize with the numbering in the HTML version&#xa;</xsl:text>
@@ -882,7 +882,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:if test="//ol or //ul or //dl or //exercises or //references">
         <xsl:text>%% More flexible list management, esp. for references and exercises&#xa;</xsl:text>
-        <xsl:text>%% But also for specifying labels (ie custom order) on nested lists&#xa;</xsl:text>
+        <xsl:text>%% But also for specifying labels (i.e. custom order) on nested lists&#xa;</xsl:text>
         <xsl:text>\usepackage{enumitem}&#xa;</xsl:text>
         <xsl:if test="//exercises or //references">
             <xsl:if test="//references">
@@ -1105,7 +1105,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- LaTeX's title page is not very robust, so we totally redo it         -->
 <!-- Template produces a single page, followed by a \clearpage            -->
-<!-- Customize with an overide of this template in an imported stylesheet -->
+<!-- Customize with an override of this template in an imported stylesheet -->
 <!-- For a two-page spread, consider modifying the "ad-card" template     -->
 <!-- For "\centering" to work properly, obey the following scheme:              -->
 <!-- Each group, but first, should begin with [<length>]&#xa; as vertical break -->


### PR DESCRIPTION
I ran spellcheck on the tex output from the webwork chapter I just added, and it caught a few more misspellings in the rest of the tex output. They traced back to either the latex.xsl or other xml parts from the author guide. Then I grepped for the same misspellings in all of mathbook and found them a few more places. (Often, just in comments.) So just because why not, I fixed them. 