### PR TITLE
Fixwebworkknowls

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -127,6 +127,16 @@ sample-chapter-latex:
 	xelatex sample-ww-chapter.tex; \
 	xelatex sample-ww-chapter.tex
 
+# HTML for a minimal WeBWorK cell
+# Useful for debugging
+# Output is:  $(HTMLOUT)/webwork-mini.html
+webwork-mini-html:
+	install -d $(HTMLOUT)
+	-rm $(HTMLOUT)/*.html
+	-rm $(HTMLOUT)/knowl/*.html
+	cd $(HTMLOUT); \
+	xsltproc --stringparam webwork.server $(SERVER) --stringparam html.knowl.exercise.inline no $(MBXSL)/mathbook-html.xsl $(WWEXAMPLE)/minimal/mini.xml
+
 ###########
 # Utilities
 ###########
@@ -145,13 +155,8 @@ sample-chapter-check:
 	-xmllint --xinclude --postvalid --noout --dtdvalid $(DTD)/mathbook.dtd $(WWEXAMPLE)/sample-chapter/sample-chapter.xml 2> $(SCRATCH)/dtderrors.txt
 	less $(SCRATCH)/dtderrors.txt
 
-###################################
-# Everything below here is OBSOLETE
-###################################
-
-minimal-obsolete:
-	install -d $(PGOUT) $(MBUSR)
-	-rm $(PGOUT)/*.pg
-	cp $(WWXSL)/mathbook-webwork-archive.xsl $(WWXSL)/mathbook-webwork-pg.xsl $(MBUSR)
-	cd $(PGOUT); \
-	xsltproc --stringparam webwork.server https://webwork.pcc.edu $(MBUSR)/mathbook-webwork-archive.xsl $(WWMBX)/examples/minimal/mini.xml
+webwork-mini-check:
+	install -d $(SCRATCH)
+	-rm $(SCRATCH)/dtderrors.*
+	-xmllint --xinclude --postvalid --noout --dtdvalid $(DTD)/mathbook.dtd $(WWEXAMPLE)/minimal/mini.xml 2> $(SCRATCH)/dtderrors.txt
+	less $(SCRATCH)/dtderrors.txt

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE webwork SYSTEM "../../schema/dtd/webwork.dtd">
 
 <!-- ********************************************************************* -->
 <!-- Copyright 2015                                                        -->
@@ -28,39 +27,39 @@
 <!-- variable assignments in  mathbook-common.xsl. -->
 
 <mathbook>
-<article>
-
-<webwork xml:id="integer-addition">
-    <title>Integer Addition</title>
-
-    <setup>
-        <var name="$a">
-            <static>9</static>
-        </var>
-        <var name="$b">
-            <static>8</static>
-        </var>
-        <var name="$c">
-            <static>13</static>
-        </var>
-
-        <pg-code>
-            $a = Compute(random(1, 9, 1));
-            $b = Compute(random(1, 9, 1));
-            $c = $a + $b;
-        </pg-code>
-    </setup>
-
-    <statement>
-        <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
-        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="2" /></p>
-    </statement>
-
-
-    <solution>
-        <p><m><var name="$a" /> + <var name="$b" /> = <var name="$c" /></m>.</p>
-    </solution>
-</webwork>
-
-</article>
+    <docinfo />
+    <article xml:id="webwork-mini">
+        <title><webwork /> Minimal Example</title>
+        <section>
+            <title><webwork /> Minimal Section</title>
+            <exercise>
+                <webwork>
+                    <title>Integer Addition</title>
+                    <setup>
+                        <var name="$a">
+                            <static>9</static>
+                        </var>
+                        <var name="$b">
+                            <static>8</static>
+                        </var>
+                        <var name="$c">
+                            <static>17</static>
+                        </var>
+                        <pg-code>
+                            $a = Compute(random(1, 9, 1));
+                            $b = Compute(random(1, 9, 1));
+                            $c = $a + $b;
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
+                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="2" /></p>
+                    </statement>
+                    <solution>
+                        <p><m><var name="$a" /> + <var name="$b" /> = <var name="$c" /></m>.</p>
+                    </solution>
+                </webwork>
+            </exercise>
+        </section>
+    </article>
 </mathbook>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -5081,7 +5081,7 @@ $(function () {
 <!-- 2014/03/07: http://flowplayer.org/docs/setup.html#global-configuration -->
 <xsl:template name="video">
     <link rel="stylesheet" href="//releases.flowplayer.org/5.4.6/skin/minimalist.css" />
-    <script src="//releases.flowplayer.org/5.4.6/flowplayer.min.js"></script>
+    <script src="https://releases.flowplayer.org/5.4.6/flowplayer.min.js"></script>
     <script>flowplayer.conf = {
     };</script>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -4070,13 +4070,13 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
 <!-- Incorporated only if "webwork" element is present -->
 <xsl:template name="webwork">
     <link href="{$webwork-server}/webwork2_files/js/apps/MathView/mathview.css" rel="stylesheet" />
+    <script type="text/javascript" src="{$webwork-server}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
 </xsl:template>
 
 <!-- The request for a "knowlized" webwork problem comes       -->
 <!-- from deep within the environment/knowl scheme             -->
 <!-- Package as a knowl with a source URL or base64 version    -->
 <xsl:template match="webwork" mode="knowlized">
-    <script type="text/javascript" src="{$webwork-server}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
     <!-- Clickable, cribbed from "environment-hidden-factory" template -->
     <xsl:element name="div">
         <xsl:attribute name="class">
@@ -4199,11 +4199,14 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
             <meta name="Keywords" content="Authored in MathBook XML" />
             <!-- http://webdesignerwall.com/tutorials/responsive-design-in-3-steps -->
             <meta name="viewport" content="width=device-width,  initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0" />
+            <!-- jquery used by sage, webwork, knowls -->
+            <xsl:call-template name="jquery" />
             <xsl:call-template name="mathjax" />
-            <xsl:call-template name="sagecell" />
-            <xsl:if test="//webwork">
+            <!-- webwork's iframeResizer needs to come before sage -->
+            <xsl:if test="//webwork[@*|node()]">
                 <xsl:call-template name="webwork" />
             </xsl:if>
+            <xsl:call-template name="sagecell" />
             <xsl:if test="/mathbook//program">
                 <xsl:call-template name="goggle-code-prettifier" />
             </xsl:if>
@@ -4284,11 +4287,15 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
         <head>
             <meta name="Keywords" content="Authored in MathBook XML" />
             <meta name="viewport" content="width=device-width,  initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0" />
+
+            <!-- jquery used by sage, webwork, knowls -->
+            <xsl:call-template name="jquery" />
             <xsl:call-template name="mathjax" />
-            <xsl:call-template name="sagecell" />
-            <xsl:if test="//webwork">
+            <!-- webwork's iframeResizer needs to come before sage -->
+            <xsl:if test="//webwork[@*|node()]">
                 <xsl:call-template name="webwork" />
             </xsl:if>
+            <xsl:call-template name="sagecell" />
             <xsl:call-template name="knowl" />
             <xsl:call-template name="fonts" />
             <xsl:call-template name="css" />
@@ -4968,11 +4975,17 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
 <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full" />
 </xsl:template>
 
+<!-- jQuery -->
+<!-- used by sage, webwork, knowls                  -->
+<!-- essential to use the version from sagemath.org -->
+<xsl:template name="jquery">
+    <script type="text/javascript" src="https://sagecell.sagemath.org/static/jquery.min.js"></script>
+</xsl:template>
+
 <!-- Sage Cell header -->
 <!-- TODO: internationalize button labels, strings below -->
 <!-- TODO: make an initialization cell which links with the sage-compute cells -->
 <xsl:template name="sagecell">
-    <script type="text/javascript" src="https://sagecell.sagemath.org/static/jquery.min.js"></script>
     <script type="text/javascript" src="https://sagecell.sagemath.org/embedded_sagecell.js"></script>
     <script>
 $(function () {
@@ -4998,7 +5011,6 @@ $(function () {
 
 <!-- Knowl header -->
 <xsl:template name="knowl">
-<script type="text/javascript" src="https://code.jquery.com/jquery-latest.min.js"></script>
 <link href="https://aimath.org/knowlstyle.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript" src="https://aimath.org/knowl.js"></script>
 


### PR DESCRIPTION
This is all to address the issues from https://groups.google.com/d/msg/mathbook-xml-support/FLYOt5XaUpg/21k_T1HaBwAJ

Ultimately this is just about reordering js loads, so that iframeResizer works. I tested for unintended consequences by making a simple article with every js utility that MBX uses all on one page, and there were no errors on Firefox, Chrome, or Safari (aside from the errors that espy is failing to load properly, a separate issue that has been around for a while).