### PR TITLE
Table enhancements

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2431,6 +2431,35 @@ the xsltproc executable.
                 </tabular>
             </table>
 
+            <p>Table cells can have multiline content using <tag>line</tag> elements. This is not the same thing as a paragraph cell<mdash />line breaking will happen precisely where the author tells it to. A line will not break, even on a narrow screen. If a cell uses a <tag>line</tag>, it must only use a sequence of <tag>line</tag>s and no other content.</p>
+
+            <table xml:id="table-multiline-cells">
+                <caption><abbr>Dr.</abbr> Seuss lines</caption>
+                <tabular top="medium" left="medium" bottom="medium" right="medium">
+                    <row>
+                        <cell>
+                             <line>One Fish</line>
+                             <line>Two Fish</line>
+                             <line>Red Fish</line>
+                             <line>Blue Fish</line>
+                        </cell>
+                        <cell>
+                             <line>I am the Lorax.</line>
+                             <line>I speak for the trees.</line>
+                        </cell>
+                        <cell>
+                             <line>Look at me!</line>
+                             <line>Look at me!</line>
+                             <line>Look at me NOW!</line>
+                             <line>It is fun to have fun.</line>
+                             <line>But you have</line>
+                             <line>to know how.</line>
+                        </cell>
+                    </row>
+                </tabular>
+            </table>
+
+
         </section>
 
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2136,9 +2136,9 @@ the xsltproc executable.
                     </row>
                     <row>
                         <cell><c>valign</c></cell>
-                        <cell>p</cell>
-                        <cell>p</cell>
-                        <cell>p</cell>
+                        <cell><m>\times</m></cell>
+                        <cell></cell>
+                        <cell><m>\times</m></cell>
                         <cell></cell>
                         <cell>top, middle, bottom</cell>
                     </row>
@@ -2431,12 +2431,12 @@ the xsltproc executable.
                 </tabular>
             </table>
 
-            <p>Table cells can have multiline content using <tag>line</tag> elements. This is not the same thing as a paragraph cell<mdash />line breaking will happen precisely where the author tells it to. A line will not break, even on a narrow screen. If a cell uses a <tag>line</tag>, it must only use a sequence of <tag>line</tag>s and no other content.</p>
+            <p>Table cells can have multiline content using <tag>line</tag> elements. This is not the same thing as a paragraph cell<mdash />line breaking will happen precisely where the author tells it to. A line will not break, even on a narrow screen. If a cell uses a <tag>line</tag>, it must only use a sequence of <tag>line</tag>s and no other content. This is also a good time to demonstrate the <attribute>valign</attribute> attribute.</p>
 
             <table xml:id="table-multiline-cells">
                 <caption><abbr>Dr.</abbr> Seuss lines</caption>
                 <tabular top="medium" left="medium" bottom="medium" right="medium">
-                    <row>
+                    <row valign="bottom">
                         <cell>
                              <line>One Fish</line>
                              <line>Two Fish</line>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1187,7 +1187,7 @@
                                     <cell>two</cell>
                                     <cell><m>\lfloor\pi\rfloor</m></cell>
                                 </row>
-                                <row>
+                                <row valign="bottom">
                                     <cell bottom="minor"><line><m>\text{I}+\text{I}</m></line><line><m>{}+\text{I}+\text{I}</m></line></cell>
                                     <cell><var name="$x" form="none"/></cell>
                                     <cell>six</cell>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1188,7 +1188,7 @@
                                     <cell><m>\lfloor\pi\rfloor</m></cell>
                                 </row>
                                 <row>
-                                    <cell bottom="minor"><m>\text{I}+\text{I}+\text{I}+\text{I}</m></cell>
+                                    <cell bottom="minor"><line><m>\text{I}+\text{I}</m></line><line><m>{}+\text{I}+\text{I}</m></line></cell>
                                     <cell><var name="$x" form="none"/></cell>
                                     <cell>six</cell>
                                 </row>

--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -297,7 +297,8 @@ lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk
     <!ATTLIST row left          (none|minor|medium|major)  #IMPLIED>
     <!ATTLIST row halign        (left|center|right)        #IMPLIED>
 
-<!ELEMENT cell    (#PCDATA|%sentence;)*>
+<!ELEMENT cell    (#PCDATA|%sentence;|line)*>
+<!-- Should be (#PCDATA|%sentence;)* xor (line+), but DTD cannot express this -->
     <!ATTLIST cell bottom       (none|minor|medium|major)  #IMPLIED>
     <!ATTLIST cell right        (none|minor|medium|major)  #IMPLIED>
     <!ATTLIST cell halign       (left|center|right)        #IMPLIED>

--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -296,6 +296,7 @@ lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk
     <!ATTLIST row bottom        (none|minor|medium|major)  #IMPLIED>
     <!ATTLIST row left          (none|minor|medium|major)  #IMPLIED>
     <!ATTLIST row halign        (left|center|right)        #IMPLIED>
+    <!ATTLIST row valign        (left|center|right)        #IMPLIED>
 
 <!ELEMENT cell    (#PCDATA|%sentence;|line)*>
 <!-- Should be (#PCDATA|%sentence;)* xor (line+), but DTD cannot express this -->

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -2676,6 +2676,29 @@ See  xsl/mathbook-html.xsl  and  xsl:mathbook-latex.xsl  for two different nontr
     </xsl:choose>
 </xsl:template>
 
+<!-- Translate vertical alignment to CSS short name         -->
+<!-- HTML:  makes portion of CSS class names for cells      -->
+<!-- LaTeX: provides one standard LaTeX vertical alignment  -->
+<!-- PG: provide LaTeX-style alignment string for           -->
+<!-- DataTable macro from niceTable.pl                      -->
+<xsl:template name="valign-specification">
+    <xsl:param name="align" />
+    <xsl:choose>
+        <xsl:when test="$align='top'">
+            <xsl:text>t</xsl:text>
+        </xsl:when>
+        <xsl:when test="$align='middle'">
+            <xsl:text>m</xsl:text>
+        </xsl:when>
+        <xsl:when test="$align='bottom'">
+            <xsl:text>b</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>MBX:WARNING: tabular vertical alignment attribute not recognized: use top, middle, bottom</xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- ################ -->
 <!-- Cross-References -->
 <!-- ################ -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -3116,6 +3116,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
+        <!-- vertical alignment -->
+        <xsl:variable name="valignment">
+            <xsl:choose>
+                <!-- parent row attribute first -->
+                <xsl:when test="$the-cell/ancestor::row/@valign">
+                    <xsl:value-of select="$the-cell/ancestor::row/@valign" />
+                </xsl:when>
+                <!-- table attribute last -->
+                <xsl:when test="$the-cell/ancestor::tabular/@valign">
+                    <xsl:value-of select="$the-cell/ancestor::tabular/@valign" />
+                </xsl:when>
+                <!-- HTML default is "baseline", not supported by MBX           -->
+                <!-- Instead we default to "middle" to be consistent with LaTeX -->
+                <xsl:otherwise>
+                    <xsl:text>middle</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
         <!-- bottom borders -->
         <xsl:variable name="bottom">
             <xsl:choose>
@@ -3215,9 +3233,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:element name="td">
             <!-- and the class attribute -->
             <xsl:attribute name="class">
-                <!-- always write alignmant, so *precede* all subsequent with a space -->
+                <!-- always write alignment, so *precede* all subsequent with a space -->
                 <xsl:call-template name="halign-specification">
                     <xsl:with-param name="align" select="$alignment" />
+                </xsl:call-template>
+                <!-- vertical alignment -->
+                <xsl:text> </xsl:text>
+                <xsl:call-template name="valign-specification">
+                    <xsl:with-param name="align" select="$valignment" />
                 </xsl:call-template>
                 <!-- bottom border -->
                 <xsl:text> b</xsl:text>
@@ -3280,8 +3303,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- "thickness-specification" : param "width"    -->
 <!--     none, minor, medium, major -> 0, 1, 2, 3 -->
 
-<!-- "halign-specification" : param "width"       -->
+<!-- "halign-specification" : param "align"       -->
 <!--     left, right, center -> l, c, r           -->
+
+<!-- "valign-specification" : param "align"       -->
+<!--     top, middle, bottom -> t, m, b           -->
 
 <!-- ######## -->
 <!-- Captions -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -3239,6 +3239,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:call-template name="thickness-specification">
                     <xsl:with-param name="width" select="$top" />
                 </xsl:call-template>
+                <!-- uses lines -->
+                <xsl:if test="$the-cell/line">
+                    <xsl:text> lines</xsl:text>
+                </xsl:if>
             </xsl:attribute>
             <xsl:if test="not($column-span = 1)">
                 <xsl:attribute name="colspan">
@@ -3256,6 +3260,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <!-- Arrive here only when we have no cell so      -->
     <!-- we bail out of recursion with no action taken -->
+</xsl:template>
+
+<xsl:template match="mathbook//tabular//line">
+    <xsl:apply-templates />
+    <!-- is there a next line to separate? -->
+    <xsl:if test="following-sibling::line">
+        <br />
+    </xsl:if>
 </xsl:template>
 
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -4479,6 +4479,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="table-bottom" select="$table-bottom" />
         <xsl:with-param name="table-right" select="$table-right" />
         <xsl:with-param name="table-halign" select="$table-halign" />
+        <xsl:with-param name="table-valign" select="$table-valign" />
     </xsl:apply-templates>
     <!-- mandatory finish, exclusive of any final row specifications -->
     <xsl:text>\end{tabular}&#xa;</xsl:text>
@@ -4579,6 +4580,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="table-bottom" />
     <xsl:param name="table-right" />
     <xsl:param name="table-halign" />
+    <xsl:param name="table-valign" />
     <!-- inherit global table-wide values    -->
     <!-- or replace with row-specific values -->
     <xsl:variable name="row-left">
@@ -4615,6 +4617,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="table-bottom" select="$table-bottom"/>
         <xsl:with-param name="table-right" select="$table-right" />
         <xsl:with-param name="table-halign" select="$table-halign" />
+        <xsl:with-param name="table-valign" select="$table-valign" />
         <xsl:with-param name="row-left" select="$row-left" />
         <xsl:with-param name="row-bottom" select="$row-bottom" />
         <xsl:with-param name="prior-bottom" select="'undefined'" />
@@ -4640,6 +4643,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="table-bottom" />
     <xsl:param name="table-right" />
     <xsl:param name="table-halign" />
+    <xsl:param name="table-valign" />
     <xsl:param name="row-left" />
     <xsl:param name="row-bottom" />
     <xsl:param name="prior-bottom" />
@@ -4717,6 +4721,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
+    <!-- Use row attributes for vertical alignment                -->
+    <!-- recreate the row specification for vertical alignment    -->
+    <!-- either a per-row value, or the global, table-wide value  -->
+    <xsl:variable name="row-valign">
+        <xsl:choose>
+            <xsl:when test="$the-cell/parent::*[1]/@valign">
+                <xsl:value-of select="$the-cell/parent::*[1]/@valign" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$table-valign" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <!-- Look ahead to next cell, anticipating recursion   -->
     <!-- but also probing for end of row (no more cells),  -->
     <!-- which is needed when flushing cline specification -->
@@ -4753,6 +4770,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:call-template name="table-cell-lines">
                     <xsl:with-param name="the-cell" select="$the-cell" />
                     <xsl:with-param name="halign" select="$cell-halign" />
+                    <xsl:with-param name="valign" select="$row-valign" />
                 </xsl:call-template>
                 <xsl:text>}</xsl:text>
             </xsl:when>
@@ -4760,6 +4778,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:call-template name="table-cell-lines">
                     <xsl:with-param name="the-cell" select="$the-cell" />
                     <xsl:with-param name="halign" select="$cell-halign" />
+                    <xsl:with-param name="valign" select="$row-valign" />
                 </xsl:call-template>
             </xsl:otherwise>
         </xsl:choose>
@@ -4836,6 +4855,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="table-bottom" select="$table-bottom" />
                 <xsl:with-param name="table-right" select="$table-right" />
                 <xsl:with-param name="table-halign" select="$table-halign" />
+                <xsl:with-param name="table-valign" select="$table-valign" />
                 <!-- next line correct, only allow discrepancy on first use -->
                 <xsl:with-param name="row-left" select="$table-left" />
                 <xsl:with-param name="row-bottom" select="$row-bottom" />
@@ -4864,8 +4884,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Some utilities are defined in xsl/mathbook-common.xsl -->
 
-<!-- "halign-specification" : param "width" -->
+<!-- "halign-specification" : param "align" -->
 <!--     left, right, center -> l, c, r     -->
+
+<!-- "valign-specification" : param "align" -->
+<!--     top, middle, bottom -> t, m, b     -->
 
 <!-- Translate vertical rule width to a LaTeX "new" column specification -->
 <xsl:template name="vrule-specification">
@@ -4947,13 +4970,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="table-cell-lines">
     <xsl:param name="the-cell" />
     <xsl:param name="halign" />
+    <xsl:param name="valign" />
     <xsl:choose>
         <xsl:when test="$the-cell[line]">
             <xsl:text>\tablecelllines{</xsl:text>
             <xsl:call-template name="halign-specification">
                 <xsl:with-param name="align" select="$halign" />
             </xsl:call-template>
-            <xsl:text>}{c}&#xa;</xsl:text>
+            <xsl:text>}{</xsl:text>
+            <xsl:call-template name="valign-specification">
+                <xsl:with-param name="align" select="$valign" />
+            </xsl:call-template>
+            <xsl:text>}&#xa;</xsl:text>
             <xsl:text>{</xsl:text>
             <xsl:apply-templates select="$the-cell/line" />
             <xsl:text>}&#xa;</xsl:text>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -596,6 +596,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:call-template>
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
+    <!-- Tables -->
     <xsl:if test="//tabular">
         <xsl:text>%% For improved tables&#xa;</xsl:text>
         <xsl:text>\usepackage{array}&#xa;</xsl:text>
@@ -636,6 +637,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newcolumntype{B}{!{\vrule width 0.07em}}&#xa;</xsl:text>
         <xsl:text>\newcolumntype{C}{!{\vrule width 0.11em}}&#xa;</xsl:text>
         <xsl:text>\makeatother&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="//cell/line">
+        <xsl:text>\newcommand{\tablecelllines}[3]%&#xa;</xsl:text>
+        <xsl:text>{\begin{tabular}[#2]{@{}#1@{}}#3\end{tabular}}&#xa;</xsl:text>
     </xsl:if>
     <!-- Float package allows for placment [H]ere                    -->
     <!-- Numbering happens along with theorem counter above,         -->
@@ -4719,12 +4724,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="next-cell" select="$the-cell/following-sibling::cell[1]" /> <!-- possibly empty -->
     <xsl:variable name="next-col"  select="$right-col/following-sibling::col[1]" />
     <!-- Write the cell's contents -->
-    <!-- if the left border, alignment or right border        -->
-    <!-- conflict with the column specification, then we      -->
-    <!-- wrap in a multicolumn to specify the overrides.      -->
-    <!-- Or if we have a colspan, then we use a multicolumn   -->
-    <!-- $table-left and $row-left *can* differ on first use, -->
-    <!-- but row-left is subsequently set to $table-left     -->
+    <!-- if the left border, horizontal alignment or right border -->
+    <!-- conflict with the column specification, then we          -->
+    <!-- wrap in a multicolumn to specify the overrides.          -->
+    <!-- Or if we have a colspan, then we use a multicolumn       -->
+    <!-- $table-left and $row-left *can* differ on first use,     -->
+    <!-- but row-left is subsequently set to $table-left.         -->
+    <!-- table-cell-lines handles cells with line elements        -->
     <xsl:if test="$the-cell">
         <xsl:choose>
             <xsl:when test="not($table-left = $row-left) or not($column-halign = $cell-halign) or not($column-right = $cell-right) or ($column-span > 1)">
@@ -4744,11 +4750,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:with-param name="width" select="$cell-right" />
                 </xsl:call-template>
                 <xsl:text>}{</xsl:text>
-                <xsl:apply-templates select="$the-cell" />
+                <xsl:call-template name="table-cell-lines">
+                    <xsl:with-param name="the-cell" select="$the-cell" />
+                    <xsl:with-param name="halign" select="$cell-halign" />
+                </xsl:call-template>
                 <xsl:text>}</xsl:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="$the-cell" />
+                <xsl:call-template name="table-cell-lines">
+                    <xsl:with-param name="the-cell" select="$the-cell" />
+                    <xsl:with-param name="halign" select="$cell-halign" />
+                </xsl:call-template>
             </xsl:otherwise>
         </xsl:choose>
         <xsl:if test="$the-cell/following-sibling::cell">
@@ -4929,6 +4941,34 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>-</xsl:text>
         <xsl:value-of select="$finish" />
         <xsl:text>}</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="table-cell-lines">
+    <xsl:param name="the-cell" />
+    <xsl:param name="halign" />
+    <xsl:choose>
+        <xsl:when test="$the-cell[line]">
+            <xsl:text>\tablecelllines{</xsl:text>
+            <xsl:call-template name="halign-specification">
+                <xsl:with-param name="align" select="$halign" />
+            </xsl:call-template>
+            <xsl:text>}{c}&#xa;</xsl:text>
+            <xsl:text>{</xsl:text>
+            <xsl:apply-templates select="$the-cell/line" />
+            <xsl:text>}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="$the-cell" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="mathbook//cell/line">
+    <xsl:apply-templates />
+    <!-- is there a next line to separate? -->
+    <xsl:if test="following-sibling::*">
+        <xsl:text>\\&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -278,47 +278,47 @@
     </xsl:call-template>
     <!-- three standard macros always, order and placement is critical -->
     <xsl:variable name="standard-macros">
-        <xsl:text>    "PGstandard.pl",&#xa;</xsl:text>
-        <xsl:text>    "MathObjects.pl",&#xa;</xsl:text>
-        <xsl:text>    "PGML.pl",&#xa;</xsl:text>
+        <xsl:text>  "PGstandard.pl",&#xa;</xsl:text>
+        <xsl:text>  "MathObjects.pl",&#xa;</xsl:text>
+        <xsl:text>  "PGML.pl",&#xa;</xsl:text>
     </xsl:variable>
     <!-- accumulate macros evidenced by some aspect of problem design -->
     <xsl:variable name="implied-macros">
         <!-- tables -->
         <xsl:if test=".//tabular">
-            <xsl:text>    "niceTables.pl",&#xa;</xsl:text>
+            <xsl:text>  "niceTables.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- popup menu multiple choice answers -->
         <xsl:if test=".//var[@form='popup']">
-            <xsl:text>    "parserPopUp.pl",&#xa;</xsl:text>
+            <xsl:text>  "parserPopUp.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- radio buttons multiple choice answers -->
         <xsl:if test=".//var[@form='buttons']">
-            <xsl:text>    "parserRadioButtons.pl",&#xa;</xsl:text>
+            <xsl:text>  "parserRadioButtons.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- checkboxes multiple choice answers-->
         <xsl:if test=".//var[@form='checkboxes']">
-            <xsl:text>    "PGchoicemacros.pl",&#xa;</xsl:text>
+            <xsl:text>  "PGchoicemacros.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- essay answers -->
         <xsl:if test=".//var[@form='essay']">
-            <xsl:text>    "PGessaymacros.pl",&#xa;</xsl:text>
+            <xsl:text>  "PGessaymacros.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- multistage problems ("scaffolded") -->
         <xsl:if test=".//stage">
-            <xsl:text>    "scaffold.pl",&#xa;</xsl:text>
+            <xsl:text>  "scaffold.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- links to syntax help following answer blanks -->
         <xsl:if test="$pg.answer.form.help = 'yes'">
-            <xsl:text>    "AnswerFormatHelp.pl",&#xa;</xsl:text>
+            <xsl:text>  "AnswerFormatHelp.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- targeted feedback messages for specific wrong answers       -->
         <xsl:if test="contains(./setup/pg-code,'AnswerHints')">
-            <xsl:text>    "answerHints.pl",&#xa;</xsl:text>
+            <xsl:text>  "answerHints.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- when there is a PGgraphmacros graph                         -->
         <xsl:if test="./statement//image[@pg-name]">
-            <xsl:text>    "PGgraphmacros.pl",&#xa;</xsl:text>
+            <xsl:text>  "PGgraphmacros.pl",&#xa;</xsl:text>
         </xsl:if>
     </xsl:variable>
     <!-- capture problem root to use inside upcoming for-each -->
@@ -342,7 +342,7 @@
                     <xsl:apply-templates select="." mode="location-report" />
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:text>    </xsl:text>
+                    <xsl:text>  </xsl:text>
                     <xsl:value-of select="$fenced-macro" />
                     <xsl:text>,&#xa;</xsl:text>
                 </xsl:otherwise>
@@ -360,7 +360,7 @@
                 <xsl:apply-templates select="." mode="location-report" />
             </xsl:when>
             <xsl:otherwise>
-                <xsl:text>    </xsl:text>
+                <xsl:text>  </xsl:text>
                 <xsl:value-of select="$fenced-macro" />
                 <xsl:text>,&#xa;</xsl:text>
             </xsl:otherwise>
@@ -373,7 +373,13 @@
     <xsl:value-of select="$user-macros" />
     <xsl:value-of select="$course-macro" />
     <xsl:text>);&#xa;</xsl:text>
+    <!-- shorten name of PGML::Format to save characters for base64 url -->
+    <!-- only used within table cells                                  -->
+    <xsl:if test=".//tabular">
+        <xsl:text>sub PF {PGML::Format(@_)};&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
+
 
 <!-- ############## -->
 <!-- PERL Variables -->
@@ -473,31 +479,6 @@
         <xsl:value-of select="$width"/>
         <xsl:text>}</xsl:text>
     </xsl:if>
-</xsl:template>
-
-<!-- (presumed) MathObject answers inside a tabular                       -->
-<!-- For answer blanks in tables (and possibly more things in the future) -->
-<!-- we cannot simply insert PGML syntax. But otherwise, we do just that. -->
-<xsl:template match="var[(@width|@form) and ancestor::tabular]" mode="field">
-    <xsl:text>".PGML::Format('[__]{</xsl:text>
-    <xsl:choose>
-        <xsl:when test="@evaluator">
-            <xsl:value-of select="@evaluator" />
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:value-of select="@name" />
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>}{width => </xsl:text>
-    <xsl:choose>
-        <xsl:when test="@width">
-            <xsl:value-of select="@width"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text>5</xsl:text>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>}')."</xsl:text>
 </xsl:template>
 
 <!-- Checkbox answers -->
@@ -747,13 +728,6 @@
     <xsl:call-template name="select-latex-macros"/>
     <xsl:apply-templates select="text()|var" />
     <xsl:text>`]</xsl:text>
-</xsl:template>
-
-<xsl:template match= "webwork//tabular//m">
-    <xsl:text>".PGML::Format('[`</xsl:text>
-    <xsl:call-template name="select-latex-macros"/>
-    <xsl:apply-templates select="text()|var" />
-    <xsl:text>`]')."</xsl:text>
 </xsl:template>
 
 <xsl:template match="webwork//me">
@@ -1178,7 +1152,7 @@
     <xsl:apply-templates select="row"/>
     <xsl:text>  ],&#xa;</xsl:text>
     <xsl:if test="ancestor::table/caption">
-        <xsl:text>  caption   => '</xsl:text>
+        <xsl:text>  caption => '</xsl:text>
             <xsl:apply-templates select="parent::*" mode="type-name"/>
             <xsl:text> </xsl:text>
             <xsl:apply-templates select="parent::*" mode="number"/>
@@ -1219,7 +1193,7 @@
     <!-- Build latex column specification                         -->
     <!--   vertical borders (left side, right side, three widths) -->
     <!--   horizontal alignment (left, center, right)             -->
-    <xsl:text>  align     => '</xsl:text>
+    <xsl:text>  align => '</xsl:text>
         <!-- start with left vertical border -->
         <xsl:call-template name="vrule-specification">
             <xsl:with-param name="width" select="$table-left" />
@@ -1284,7 +1258,7 @@
     <!-- kill all of niceTable's column left/right border thickness in colgroup/col css; just let cellcss control border thickness -->
     <xsl:variable name="columns-css">
         <xsl:if test="col[@right] or @left">
-            <xsl:text>[</xsl:text>
+            <xsl:text>    [</xsl:text>
                 <xsl:for-each select="col">
                     <xsl:text>'</xsl:text>
                     <xsl:if test="not($table-left='none') and (count(preceding-sibling::col)=0)">
@@ -1304,7 +1278,7 @@
                     <xsl:text> ',</xsl:text>
                     <xsl:choose>
                         <xsl:when test="following-sibling::col">
-                            <xsl:text>&#xa;                 </xsl:text>
+                            <xsl:text>&#xa;     </xsl:text>
                         </xsl:when>
                     </xsl:choose>
                 </xsl:for-each>
@@ -1312,7 +1286,7 @@
         </xsl:if>
     </xsl:variable>
     <xsl:if test="not($columns-css='')">
-        <xsl:text>  columnscss => </xsl:text>
+        <xsl:text>  columnscss =>&#xa;</xsl:text>
         <xsl:value-of select="$columns-css"/>
         <xsl:text>,&#xa;</xsl:text>
     </xsl:if>
@@ -1447,22 +1421,24 @@
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="rowcss">
-        <xsl:choose>
-            <xsl:when test="parent::row/@bottom">
-                <xsl:text>border-bottom: </xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="parent::row/@bottom" />
-                </xsl:call-template>
-                <xsl:text>px solid;</xsl:text>
-            </xsl:when>
-            <xsl:when test="ancestor::tabular/@bottom">
-                <xsl:text>border-bottom: </xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="ancestor::tabular/@bottom" />
-                </xsl:call-template>
-                <xsl:text>px solid;</xsl:text>
-            </xsl:when>
-        </xsl:choose>
+        <xsl:if test="position()=1">
+            <xsl:choose>
+                <xsl:when test="parent::row/@bottom">
+                    <xsl:text>border-bottom: </xsl:text>
+                    <xsl:call-template name="thickness-specification">
+                        <xsl:with-param name="width" select="parent::row/@bottom" />
+                    </xsl:call-template>
+                    <xsl:text>px solid;</xsl:text>
+                </xsl:when>
+                <xsl:when test="ancestor::tabular/@bottom">
+                    <xsl:text>border-bottom: </xsl:text>
+                    <xsl:call-template name="thickness-specification">
+                        <xsl:with-param name="width" select="ancestor::tabular/@bottom" />
+                    </xsl:call-template>
+                    <xsl:text>px solid;</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:if>
     </xsl:variable>
     <xsl:variable name="cell-bottom-css">
         <xsl:if test="@bottom">
@@ -1551,19 +1527,19 @@
                 <xsl:value-of select="$cell-bottom-css"/>
             </xsl:if>
             <xsl:if test="not($cell-bottom-css='') and (not($cell-top-css='') or not($cell-left-css='') or not($cell-right-css=''))">
-                <xsl:text>&#xa;                   </xsl:text>
+                <xsl:text>&#xa;                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-top-css='')">
                 <xsl:value-of select="$cell-top-css"/>
             </xsl:if>
             <xsl:if test="not($cell-top-css='') and (not($cell-left-css='') or not($cell-right-css=''))">
-                <xsl:text>&#xa;                   </xsl:text>
+                <xsl:text>&#xa;                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-left-css='')">
                 <xsl:value-of select="$cell-left-css"/>
             </xsl:if>
             <xsl:if test="not($cell-left-css='') and not($cell-right-css='')">
-                <xsl:text>&#xa;                   </xsl:text>
+                <xsl:text>&#xa;                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-right-css='')">
                 <xsl:value-of select="$cell-right-css"/>
@@ -1573,45 +1549,45 @@
 
     <xsl:choose>
         <xsl:when test="not(preceding-sibling::cell)">
-            <xsl:text> </xsl:text>
+            <xsl:text></xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:text>      </xsl:text>
+            <xsl:text>     </xsl:text>
         </xsl:otherwise>
     </xsl:choose>
 
     <xsl:choose>
         <xsl:when test="($halign='') and ($midrule='') and ($rowcss='') and ($cellcss='') and not(descendant::m) and not(descendant::var[@width|@form]) and not(@colspan)">
-            <xsl:text>"</xsl:text>
+            <xsl:text>PF('</xsl:text>
             <xsl:apply-templates/>
-            <xsl:text>",&#xa;</xsl:text>
+            <xsl:text>'),&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:text>["</xsl:text>
+            <xsl:text>[PF('</xsl:text>
             <xsl:apply-templates/>
-            <xsl:text>",</xsl:text>
+            <xsl:text>'),</xsl:text>
             <xsl:if test="@colspan">
-                <xsl:text>&#xa;           colspan => '</xsl:text>
+                <xsl:text>&#xa;      colspan => '</xsl:text>
                 <xsl:value-of select="@colspan"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($halign='')">
-                <xsl:text>&#xa;           halign  => '</xsl:text>
+                <xsl:text>&#xa;      halign  => '</xsl:text>
                 <xsl:value-of select="$halign"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="$midrule='1' and not(preceding-sibling::cell)">
-                <xsl:text>&#xa;           midrule => '</xsl:text>
+                <xsl:text>&#xa;      midrule => '</xsl:text>
                 <xsl:value-of select="$midrule"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($rowcss='')">
-                <xsl:text>&#xa;           rowcss  => '</xsl:text>
+                <xsl:text>&#xa;      rowcss  => '</xsl:text>
                 <xsl:value-of select="$rowcss"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($cellcss='')">
-                <xsl:text>&#xa;           cellcss => '</xsl:text>
+                <xsl:text>&#xa;      cellcss => '</xsl:text>
                 <xsl:value-of select="$cellcss"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
@@ -1650,11 +1626,12 @@
 <xsl:template name="begin-block">
     <xsl:param name="block-title"/>
     <xsl:text>&#xa;</xsl:text>
-    <xsl:text>############################################################&#xa;</xsl:text>
+    <!-- short string of octothorpes to save on base64 url characters -->
+    <xsl:text>####################&#xa;</xsl:text>
     <xsl:text># </xsl:text>
     <xsl:value-of select="$block-title"/>
     <xsl:text>&#xa;</xsl:text>
-    <xsl:text>############################################################&#xa;</xsl:text>
+    <xsl:text>####################&#xa;</xsl:text>
 </xsl:template>
 
 <!-- Recursively prepend to multiple lines -->

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -823,10 +823,9 @@
 
 <!-- http://webwork.maa.org/wiki/Introduction_to_PGML#Basic_Formatting -->
 
-<!-- two spaces at line-end is a newline -->
-<!-- TODO - an "attribution" is the only place this could happen -->
-<!-- make this much more restrictive?                            -->
-<xsl:template match="webwork//br">
+<!-- two spaces at line-end makes a newline in PGML-->
+<xsl:template match="webwork//cell/line">
+    <xsl:apply-templates />
     <xsl:text>  &#xa;</xsl:text>
 </xsl:template>
 

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -1427,14 +1427,26 @@
                     <xsl:call-template name="thickness-specification">
                         <xsl:with-param name="width" select="parent::row/@bottom" />
                     </xsl:call-template>
-                    <xsl:text>px solid;</xsl:text>
+                    <xsl:text>px solid; </xsl:text>
                 </xsl:when>
                 <xsl:when test="ancestor::tabular/@bottom">
                     <xsl:text>border-bottom: </xsl:text>
                     <xsl:call-template name="thickness-specification">
                         <xsl:with-param name="width" select="ancestor::tabular/@bottom" />
                     </xsl:call-template>
-                    <xsl:text>px solid;</xsl:text>
+                    <xsl:text>px solid; </xsl:text>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="parent::row/@valign">
+                    <xsl:text>vertical-align: </xsl:text>
+                    <xsl:value-of select="parent::row/@valign" />
+                    <xsl:text>; </xsl:text>
+                </xsl:when>
+                <xsl:when test="ancestor::tabular/@valign">
+                    <xsl:text>vertical-align: </xsl:text>
+                    <xsl:value-of select="ancestor::tabular/@valign" />
+                    <xsl:text>; </xsl:text>
                 </xsl:when>
             </xsl:choose>
         </xsl:if>


### PR DESCRIPTION
Table cells can have a sequence of lines (LaTeX, HTML, WeBWorK)
Vertical alignment: top, middle, bottom can be defined as tabular attribute or as row attribute 
Part of getting this to work with WeBWorK involved other changes there, and one commit ties these things in with shortening the base64 string.

There is a base64 bug I'll report later. A multiline cell in a WeBWorK works fine in the extracted problem, but when translated to base64, sometimes the lines come out squashed together in one line. Again though, all is well with direct PG extraction, so this is a separate base64 issue to pursue.

Once this is vetted, I can move on to paragraph cells. Later today I will post a request for input as to how authors should specify paragraph cells.