### PR TITLE
Optional List Conclusion

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -205,7 +205,7 @@ lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk
 <!ELEMENT problem (title?, index*, ((%para;)*|(statement, solution)))>
     <!ATTLIST problem xml:id ID #IMPLIED>
 
-<!ELEMENT list (title?, index*, introduction?, (ol|ul|dl), conclusion)>
+<!ELEMENT list (title?, index*, introduction?, (ol|ul|dl), conclusion?)>
     <!ATTLIST list xml:id ID #IMPLIED>
 <!ELEMENT remark (title?, index*, (%para;)*)>
     <!ATTLIST remark xml:id ID #IMPLIED>


### PR DESCRIPTION
According to the DTD the `conclusion` of a `list` is not optional:

```
<!ELEMENT list (title?, index*, introduction?, (ol|ul|dl), conclusion)>
```

The DTD should have the `conclusion` of a `list` be optional just like the `introduction`:

```
<!ELEMENT list (title?, index*, introduction?, (ol|ul|dl), conclusion?)>
```