### PR TITLE
Add Music Capabilities

### DIFF
--- a/examples/humanities/hia.xml
+++ b/examples/humanities/hia.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mathbook xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
+    <docinfo/>
     <book xml:id="hia">
         <title>Humanities in Action</title>
         <frontmatter xml:id="index">
@@ -15,5 +16,6 @@
             </preface>
         </frontmatter>
         <xi:include href="poetry.xml"/>
+        <xi:include href="music.xml"/>
     </book>
 </mathbook>

--- a/examples/humanities/music.xml
+++ b/examples/humanities/music.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xml:id="music">
+    <title>Music</title>
+    <section xml:id="symbols">
+        <title>Musical Symbols</title>
+        <example>
+            <title>Accidentals</title>
+            <ul>
+                <li><p><c>&lt;doublesharp/&gt;</c>: <doublesharp/></p></li>
+                <li><p><c>&lt;sharp/&gt;</c>: <sharp/></p></li>
+                <li><p><c>&lt;natural/&gt;</c>: <natural/></p></li>
+                <li><p><c>&lt;flat/&gt;</c>: <flat/></p></li>
+                <li><p><c>&lt;doubleflat/&gt;</c>: <doubleflat/></p></li>
+            </ul>
+        </example>
+    </section>
+    <section xml:id="scaledegs">
+        <title>Scale Degrees</title>
+        <p>Scale degrees are created using the <c>&lt;scaledeg&gt;</c> tag which places a <q>diacritic circumflex</q> over the degree. The circumflex looks best when attached to single-digit numbers.</p>
+        <example>
+            <title>Scale Degrees</title>
+            <ul cols="2">
+                <li><p><c>&lt;scaledeg&gt;0&lt;/scaledeg&gt;</c>: <scaledeg>0</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;1&lt;/scaledeg&gt;</c>: <scaledeg>1</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;2&lt;/scaledeg&gt;</c>: <scaledeg>2</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;3&lt;/scaledeg&gt;</c>: <scaledeg>3</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;4&lt;/scaledeg&gt;</c>: <scaledeg>4</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;5&lt;/scaledeg&gt;</c>: <scaledeg>5</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;6&lt;/scaledeg&gt;</c>: <scaledeg>6</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;7&lt;/scaledeg&gt;</c>: <scaledeg>7</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;8&lt;/scaledeg&gt;</c>: <scaledeg>8</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;9&lt;/scaledeg&gt;</c>: <scaledeg>9</scaledeg></p></li>
+                <li><p><c>&lt;scaledeg&gt;10&lt;/scaledeg&gt;</c>: <scaledeg>10</scaledeg></p></li>
+            </ul>
+        </example>
+    </section>
+    <section xml:id="notes">
+        <title>Notes</title>
+        <p>Notes are created using the <c>&lt;n&gt;</c> tag with a pitch class, <c>@pc</c>. Optional attributes include accidentals, <c>@acc</c>, and octaves, <c>@octave</c>. Please note, accidentals precede numeric pitch classes.</p>
+        <p>For example, <c>&lt;n pc="C" acc="sharp" octave="4"/&gt;</c> results in <n pc="C" acc="sharp" octave="4"/> while <c>&lt;n pc="5" acc="flat"/&gt;</c> results in <n pc="5" acc="flat"/>.</p>
+        <example>
+            <title>Alphabetic Pitch Classes</title>
+            <ul cols="5">
+                <li><p><n pc="A" acc="doublesharp" octave="2"/></p></li>
+                <li><p><n pc="B" acc="doublesharp"/></p></li>
+                <li><p><n pc="C" acc="doublesharp" octave="3"/></p></li>
+                <li><p><n pc="D" acc="doublesharp"/></p></li>
+                <li><p><n pc="E" acc="doublesharp" octave="4"/></p></li>
+                <li><p><n pc="F" acc="doublesharp"/></p></li>
+                <li><p><n pc="G" acc="doublesharp" octave="5"/></p></li>
+
+                <li><p><n pc="A" acc="sharp" octave="2"/></p></li>
+                <li><p><n pc="B" acc="sharp"/></p></li>
+                <li><p><n pc="C" acc="sharp" octave="3"/></p></li>
+                <li><p><n pc="D" acc="sharp"/></p></li>
+                <li><p><n pc="E" acc="sharp" octave="4"/></p></li>
+                <li><p><n pc="F" acc="sharp"/></p></li>
+                <li><p><n pc="G" acc="sharp" octave="5"/></p></li>
+
+                <li><p><n pc="A" octave="2"/></p></li>
+                <li><p><n pc="B"/></p></li>
+                <li><p><n pc="C" octave="3"/></p></li>
+                <li><p><n pc="D"/></p></li>
+                <li><p><n pc="E" octave="4"/></p></li>
+                <li><p><n pc="F"/></p></li>
+                <li><p><n pc="G" octave="5"/></p></li>
+
+                <li><p><n pc="A" acc="flat" octave="2"/></p></li>
+                <li><p><n pc="B" acc="flat"/></p></li>
+                <li><p><n pc="C" acc="flat" octave="3"/></p></li>
+                <li><p><n pc="D" acc="flat"/></p></li>
+                <li><p><n pc="E" acc="flat" octave="4"/></p></li>
+                <li><p><n pc="F" acc="flat"/></p></li>
+                <li><p><n pc="G" acc="flat" octave="5"/></p></li>
+
+                <li><p><n pc="A" acc="doubleflat" octave="2"/></p></li>
+                <li><p><n pc="B" acc="doubleflat"/></p></li>
+                <li><p><n pc="C" acc="doubleflat" octave="3"/></p></li>
+                <li><p><n pc="D" acc="doubleflat"/></p></li>
+                <li><p><n pc="E" acc="doubleflat" octave="4"/></p></li>
+                <li><p><n pc="F" acc="doubleflat"/></p></li>
+                <li><p><n pc="G" acc="doubleflat" octave="5"/></p></li>
+            </ul>
+        </example>
+        <example>
+            <title>Numeric Pitch Classes</title>
+            <ul cols="5">
+                <li><p><n pc="1" acc="doublesharp" octave="5"/></p></li>
+                <li><p><n pc="2" acc="doublesharp"/></p></li>
+                <li><p><n pc="3" acc="sharp" octave="4"/></p></li>
+                <li><p><n pc="4" acc="sharp"/></p></li>
+                <li><p><n pc="5" octave="3"/></p></li>
+                <li><p><n pc="6"/></p></li>
+                <li><p><n pc="7" acc="flat" octave="2"/></p></li>
+                <li><p><n pc="8" acc="flat"/></p></li>
+                <li><p><n pc="9" acc="doubleflat" octave="1"/></p></li>
+                <li><p><n pc="10" acc="doubleflat"/></p></li>
+            </ul>
+        </example>
+    </section>
+    <section xml:id="chords">
+        <title>Chords</title>
+        <p>Chords are created using a combination of the <c>&lt;chord&gt;</c> and <c>&lt;alteration&gt;</c> tags. The <c>&lt;chord&gt;</c> tag can have any combination of the following attributes: <c>@root</c>, <c>@mode</c>, <c>@bps</c>, <c>@suspended</c>, <c>@parentheses</c>, and <c>@bass</c>. For alterations to chords, we place each alteration in an <c>&lt;alteration&gt;</c> tag, which are contained within the <c>&lt;chord&gt;</c> tag. To accommodate different styles of chord notation, the <c>&lt;chord&gt;</c> attribute <c>@parentheses</c> (<c>parentheses="yes|no"</c>) will toggle the parentheses surrounding the alterations. With regard to the <q>mode</q> or <q>characteristic</q> of the chord, whatever text is entered will be used verbatim <em>except</em> in the cases of <c>augmented</c>, <c>major</c>, <c>minor</c>, <c>halfdiminished</c>, and <c>diminished</c>. In these cases, the standard chord symbol representation will be used (<chord mode="augmented"/>, <chord mode="major"/>, <chord mode="minor"/>, <chord mode="halfdiminished"/>, and <chord mode="diminished"/> respectively).</p>
+        <p>For example, <c>&lt;chord root="C" bps="4 3"/&gt;</c> will result in <chord root="C" bps="4 3"/> while</p>
+        <pre>
+            &lt;chord root="B doublesharp" mode="min major" bps="6 5"
+                   suspended="yes" parentheses="yes" bass="G"&gt;
+                &lt;alteration&gt;&lt;sharp/&gt;9&lt;/alteration&gt;
+                &lt;alteration&gt;add 11&lt;/alteration&gt;
+            &lt;/chord&gt;
+        </pre>
+        <p>will result in <chord root="B doublesharp" mode="min major" bps="6 5" suspended="yes" parentheses="yes" bass="G"><alteration><sharp/>9</alteration><alteration>add 11</alteration></chord>.</p>
+        <example>
+            <title>Chords</title>
+            <ul cols="4">
+                <li><p><chord root="N.C."/></p></li>
+                <li><p><chord root="C"><alteration>bass</alteration></chord></p></li>
+                <li><p><chord root="A"/></p></li>
+                <li><p><chord root="B" mode="ma"/></p></li>
+                <li><p><chord root="C" mode="maj"/></p></li>
+                <li><p><chord root="D" mode="major"/></p></li>
+                <li><p><chord root="E" mode="mi"/></p></li>
+                <li><p><chord root="F" mode="min"/></p></li>
+                <li><p><chord root="G" mode="minor"/></p></li>
+                <li><p><chord root="A flat" mode="aug"/></p></li>
+                <li><p><chord root="B flat" mode="augmented"/></p></li>
+                <li><p><chord root="C flat" mode="dim"/></p></li>
+                <li><p><chord root="D flat" mode="diminished"/></p></li>
+                <li><p><chord root="E flat" bps="6"/></p></li>
+                <li><p><chord root="F flat" bps="6 9"/></p></li>
+                <li><p><chord root="G flat" bps="7"/></p></li>
+                <li><p><chord root="A sharp" mode="dom" bps="7"/></p></li>
+                <li><p><chord root="B sharp" mode="maj" bps="7"/></p></li>
+                <li><p><chord root="C sharp" mode="major" bps="7"/></p></li>
+                <li><p><chord root="D sharp" mode="m" bps="7"/></p></li>
+                <li><p><chord root="E sharp" mode="min" bps="7"/></p></li>
+                <li><p><chord root="F sharp" mode="minor" bps="7"/></p></li>
+                <li><p><chord root="G sharp" mode="aug" bps="7"/></p></li>
+                <li><p><chord root="A doubleflat" mode="augmented" bps="7"/></p></li>
+                <li><p><chord root="B doubleflat" mode="dim" bps="7"/></p></li>
+                <li><p><chord root="C doubleflat" mode="diminished" bps="7"/></p></li>
+                <li><p><chord root="D doubleflat" mode="halfdiminished"/></p></li>
+                <li><p><chord root="E doubleflat" mode="halfdiminished" bps="7"/></p></li>
+                <li><p><chord root="F doubleflat" mode="major" bps="7"/></p></li>
+                <li><p><chord root="G doubleflat" mode="min maj" bps="7"/></p></li>
+                <li><p><chord root="A doublesharp" mode="m M" bps="7"/></p></li>
+                <li><p><chord root="B doublesharp" mode="minor major" bps="7"/></p></li>
+                <li><p><chord root="C doublesharp" mode="major" bps="7"><alteration><sharp/>5</alteration></chord></p></li>
+                <li><p><chord root="D doublesharp" mode="augmented major" bps="7"/></p></li>
+                <li><p><chord root="E doublesharp" mode="min" bps="7"><alteration>dim 5</alteration></chord></p></li>
+                <li><p><chord root="F doublesharp" mode="dom" bps="7"><alteration>dim 5</alteration></chord></p></li>
+                <li><p><chord root="G doublesharp" mode="ma" bps="7" suspended="yes" bass="D doublesharp"/></p></li>
+                <li><p><chord root="A natural"><alteration>add 9</alteration><alteration>omit 3</alteration></chord></p></li>
+                <li><p><chord root="B natural" bps="7"><alteration><sharp/>11</alteration><alteration><flat/>9</alteration></chord></p></li>
+                <li><p><chord root="C natural" bps="7"><alteration>add 11</alteration><alteration>omit 5</alteration></chord></p></li>
+                <li><p><chord root="D natural" mode="major" bps="7" bass="E"><alteration><sharp/>5</alteration></chord></p></li>
+                <li><p><chord root="E natural" mode="m" bps="7" suspended="yes" parentheses="no"><alteration>add 3</alteration></chord></p></li>
+                <li><p><chord root="F natural" bass="B doubleflat"/></p></li>
+                <li><p><chord root="G natural" mode="augmented"><alteration>add <sharp/>9</alteration><alteration>add <flat/>9</alteration></chord></p></li>
+            </ul>
+        </example>
+        <example>
+            <title>Chord Comparisons</title>
+            <p>While there are different ways to notate chords, some are clearer than others.</p>
+            <ul>
+                <li><p><chord root="F" mode="maj"/> vs ​<chord root="F" mode="M"/></p></li>
+                <li><p><chord root="C" mode="min major" bps="7"/> vs <chord root="C" mode="minor major" bps="7"/></p></li>
+                <li><p><chord root="C" mode="major" bps="7"><alteration><sharp/>5</alteration></chord> vs <chord root="C" mode="augmented major" bps="7"/> vs <chord root="C" mode="aug maj" bps="7"/></p></li>
+            </ul>
+        </example>
+    </section>
+</chapter>

--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -37,9 +37,8 @@
 <!-- Elements that could be inside a single line of text -->
 <!-- For example, an <ndash>, but not a <me>             -->
 <!-- Precede these by a #PCDATA, wrap with ( )*          -->
-<!ENTITY % characters "nbsp|ndash|mdash|ampersand|less|greater|hash|dollar|percent|circumflex|underscore|lbrace|rbrace|
-lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk|lq|rq|lsq|rsq|ellipsis|midpoint|swungdash|permille|pilcrow|section-mark|times|slash|solidus|copyright|ie|eg|etc|circa|tex|latex|webwork|trademark|registered|fillin|today|timeofday">
-<!ENTITY % markup "xref|url|m|c|em|alert|insert|delete|stale|q|sq|braces|brackets|dblbrackets|angles|term|foreign|abbr|quantity|acro|init|booktitle">
+<!ENTITY % characters "nbsp|ndash|mdash|ampersand|less|greater|hash|dollar|percent|circumflex|underscore|lbrace|rbrace|lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk|lq|rq|lsq|rsq|ellipsis|midpoint|swungdash|permille|pilcrow|section-mark|times|slash|solidus|copyright|ie|eg|etc|circa|tex|latex|webwork|trademark|registered|fillin|today|timeofday|doublesharp|sharp|natural|flat|doubleflat">
+<!ENTITY % markup "xref|url|m|c|em|alert|insert|delete|stale|q|sq|braces|brackets|dblbrackets|angles|term|foreign|abbr|quantity|acro|init|booktitle|n|scaledeg|chord">
 <!ENTITY % linear "%characters; | %markup;">
 
 <!-- Multiline Content -->
@@ -388,6 +387,23 @@ lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk
 <!-- <!ELEMENT line      (#PCDATA|%linear;)*> -->
 
 
+<!-- ##### -->
+<!-- Music -->
+<!-- ##### -->
+<!ELEMENT     scaledeg              (#PCDATA)              >
+<!ELEMENT     n                     EMPTY                  >
+    <!ATTLIST n         pc          CDATA #IMPLIED         >
+    <!ATTLIST n         acc         CDATA #IMPLIED         >
+    <!ATTLIST n         octave      CDATA #IMPLIED         >
+<!ELEMENT     chord                 (alteration)*          >
+    <!ATTLIST chord     root        CDATA #IMPLIED         >
+    <!ATTLIST chord     mode        CDATA #IMPLIED         >
+    <!ATTLIST chord     bps         CDATA #IMPLIED         >
+    <!ATTLIST chord     bass        CDATA #IMPLIED         >
+    <!ATTLIST chord     suspended   CDATA #IMPLIED         >
+    <!ATTLIST chord     parentheses CDATA #IMPLIED         >
+<!ELEMENT     alteration            (#PCDATA|%characters;)*>
+
 <!-- ################## -->
 <!-- Special Characters -->
 <!-- ################## -->
@@ -430,6 +446,13 @@ lbracket|rbracket|ldblbracket|rdblbracket|langle|rangle|tilde|backslash|asterisk
 <!ELEMENT times         EMPTY>
 <!ELEMENT slash         EMPTY>
 <!ELEMENT solidus       EMPTY>
+<!--      musical symbols  -->
+<!ELEMENT doublesharp   EMPTY>
+<!ELEMENT sharp         EMPTY>
+<!ELEMENT natural       EMPTY>
+<!ELEMENT flat          EMPTY>
+<!ELEMENT doubleflat    EMPTY>
+
 
 <!-- ############################ -->
 <!-- Abbreviations, Special Terms -->

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -2753,6 +2753,359 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     </xsl:choose>
 </xsl:template>
 
+<!-- ##### -->
+<!-- Music -->
+<!-- ##### -->
+
+<!-- Note -->
+<xsl:template match="n">
+    <xsl:text>\(</xsl:text>
+    <!-- Test that pitch class is NOT castable as a number -->
+    <xsl:if test="not(number(@pc) = number(@pc))">
+        <xsl:text>\text{</xsl:text>
+        <xsl:value-of select="@pc"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <!-- Provide something to place accidental -->
+    <!-- on if the pitch class is numeric.     -->
+    <xsl:if test="number(@pc) = number(@pc) and @acc">
+        <xsl:text>{}</xsl:text>
+    </xsl:if>
+    <!-- Add an accidental if applicable -->
+    <xsl:if test="@acc">
+        <xsl:text>^</xsl:text>
+        <xsl:call-template name="accidentals">
+            <xsl:with-param name="accidental"><xsl:value-of select="@acc"/></xsl:with-param>
+        </xsl:call-template>
+    </xsl:if>
+    <!-- Test that pitch class IS castable as a number -->
+    <!-- Accidentals precede numeric pitch classes     -->
+    <xsl:if test="number(@pc) = number(@pc)">
+        <xsl:value-of select="@pc"/>
+    </xsl:if>
+    <!-- Add an octave number if applicable -->
+    <xsl:if test="@octave">
+        <!-- Consideration: should we accommodate other octave notations?    -->
+        <!-- Current support is for scientific pitch notation (the standard), -->
+        <!-- other octave notation exists such as "Helmholtz pitch notation"  -->
+        <xsl:text>_{</xsl:text>
+        <xsl:value-of select="@octave"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <xsl:text>\)</xsl:text>
+</xsl:template>
+
+<!-- Scale Degrees -->
+<xsl:template match="scaledeg">
+    <!-- Arabic numeral with circumflex accent above)-->
+    <xsl:text>\(\hat{</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>}\) </xsl:text>
+</xsl:template>
+
+<!-- Chord -->
+<xsl:template match="chord">
+    <xsl:text>\(\left.</xsl:text>
+    <!-- Root -->
+    <xsl:choose>
+        <!-- There is an accidental -->
+        <xsl:when test="contains(@root, ' ')">
+            <!-- Pitch Class -->
+            <xsl:text>\text{</xsl:text>
+            <xsl:value-of select="substring-before(@root, ' ')"/>
+            <xsl:text>}</xsl:text>
+            <!-- Accidental -->
+            <xsl:text>^</xsl:text>
+            <xsl:call-template name="accidentals">
+                <xsl:with-param name="accidental"><xsl:value-of select="substring-after(@root, ' ')"/></xsl:with-param>
+            </xsl:call-template>
+            <!-- prevent "double superscript" error -->
+            <xsl:text>{}</xsl:text>
+        </xsl:when>
+        <!-- There is not an accidental -->
+        <xsl:otherwise>
+            <xsl:text>\text{</xsl:text>
+            <xsl:value-of select="@root"/>
+            <xsl:text>}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <!-- Mode (augmented, major, minor, half-diminished, diminished, etc.) -->
+    <xsl:if test="@mode">
+        <xsl:choose>
+            <!-- There is a two part mode -->
+            <xsl:when test="contains(@mode, ' ')">
+                <!-- Lower Mode -->
+                <xsl:call-template name="chordsymbols">
+                    <xsl:with-param name="mode"><xsl:value-of select="substring-before(@mode, ' ')"/></xsl:with-param>
+                </xsl:call-template>
+                <!-- Raise to be in line with bps -->
+                <xsl:text>^</xsl:text>
+                <!-- Higher Mode -->
+                <xsl:call-template name="chordsymbols">
+                    <xsl:with-param name="mode"><xsl:value-of select="substring-after(@mode, ' ')"/></xsl:with-param>
+                </xsl:call-template>
+                <!-- prevent "double superscript" error -->
+                <xsl:text>{}</xsl:text>
+            </xsl:when>
+            <!-- There is a single mode -->
+            <xsl:otherwise>
+                <xsl:call-template name="chordsymbols">
+                    <xsl:with-param name="mode"><xsl:value-of select="@mode"/></xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+    <!-- Bass Position Symbol -->
+    <xsl:if test="@bps">
+        <!-- Consideration: Even if it is not standard practice, -->
+        <!-- will anyone ever want more than two bps numbers?    -->
+        <xsl:choose>
+            <!-- We use a space to delineate the breaking point of the bps -->
+            <!-- e.g. for 6/4 we write "6 4" -->
+            <xsl:when test="contains(@bps, ' ')">
+                <xsl:text>^{</xsl:text>
+                <xsl:value-of select="substring-before(@bps, ' ')"/>
+                <xsl:text>}</xsl:text>
+                <xsl:text>_{</xsl:text>
+                <xsl:value-of select="substring-after(@bps, ' ')"/>
+                <xsl:text>}</xsl:text>
+            </xsl:when>
+            <!-- If there is no space, then we only need a superscript -->
+            <xsl:otherwise>
+                <xsl:text>^{</xsl:text>
+                <xsl:value-of select="@bps"/>
+                <xsl:text>}</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+    <!-- Suspended -->
+    <xsl:if test="@suspended = 'yes'">
+        <!-- Consideration: should we make "sus" localized/customizable? -->
+        <xsl:text>\text{sus}</xsl:text>
+    </xsl:if>
+    <!-- Chord Alterations -->
+    <xsl:if test="./*">
+        <xsl:choose>
+            <!-- Turning off parentheses is usually for showing why parenthesization clarifies meaning. -->
+            <xsl:when test="@parentheses = 'no'">
+                <xsl:text>\left.</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>\left(</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+        <!-- We only use a smallmatrix if we have more than one alteration         -->
+        <!-- Using smallmatrix with a single entry makes the alteration too small. -->
+        <xsl:if test="count(*) > 1">
+            <xsl:text>\begin{smallmatrix}</xsl:text>
+        </xsl:if>
+        <xsl:apply-templates select="*"/>
+        <xsl:if test="count(*) > 1">
+            <xsl:text>\end{smallmatrix}</xsl:text>
+        </xsl:if>
+        <xsl:choose>
+            <xsl:when test="@parentheses = 'no'">
+                <xsl:text>\right.</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>\right)</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+    <!-- Alternate Bass Note (e.g. C/G) -->
+    <xsl:if test="@bass">
+        <!-- Resizes based on components of chord -->
+        <xsl:text>\middle/</xsl:text>
+        <xsl:choose>
+            <!-- Bass note has an accidental -->
+            <xsl:when test="contains(@bass, ' ')">
+                <!-- Pitch Class -->
+                <xsl:text>\text{</xsl:text>
+                <xsl:value-of select="substring-before(@bass, ' ')"/>
+                <xsl:text>}</xsl:text>
+                <!-- Accidental -->
+                <xsl:text>^{</xsl:text>
+                <xsl:call-template name="accidentals">
+                    <xsl:with-param name="accidental"><xsl:value-of select="substring-after(@bass, ' ')"/></xsl:with-param>
+                </xsl:call-template>
+                <xsl:text>}</xsl:text>
+            </xsl:when>
+            <!-- Bass note does not have an accidental -->
+            <xsl:otherwise>
+                <!-- Pitch Class -->
+                <xsl:text>\text{</xsl:text>
+                <xsl:value-of select="@bass"/>
+                <xsl:text>}</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+    <xsl:text>\right.\)</xsl:text>
+</xsl:template>
+
+<!-- Chord Alteration -->
+<!-- Put a break after each alteration that is not the last -->
+<xsl:template match="chord/alteration">
+    <xsl:text>\text{</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>}</xsl:text>
+    <!-- Separate alterations -->
+    <xsl:if test="following-sibling::*">
+        <xsl:text>\\</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!--                 -->
+<!-- Musical Symbols -->
+<!--                 -->
+
+<!-- Accidentals -->
+
+<!-- TODO: If requested, add semi- and sesqui- versions of sharp and flat -->
+<!-- (Easy with LilyPond in LaTeX) -->
+<!-- (For HTML ,there are Unicode characters, though font support may be iffy) -->
+
+<!-- Double-Sharp -->
+<xsl:template match="doublesharp">
+    <xsl:call-template name="doublesharp"/>
+</xsl:template>
+
+<!-- Sharp -->
+<xsl:template match="sharp">
+    <xsl:call-template name="sharp"/>
+</xsl:template>
+
+<!-- Natural -->
+<xsl:template match="natural">
+    <xsl:call-template name="natural"/>
+</xsl:template>
+
+<!-- Flat -->
+<xsl:template match="flat">
+    <xsl:call-template name="flat"/>
+</xsl:template>
+
+<!-- Double-Flat -->
+<xsl:template match="doubleflat">
+    <xsl:call-template name="doubleflat"/>
+</xsl:template>
+
+<!-- Insert the correct accidental -->
+<!-- (For use in <n> and <chord>)  -->
+<xsl:template name="accidentals">
+    <xsl:param name="accidental"/>
+    <xsl:choose>
+        <xsl:when test="$accidental = 'doubleflat'">
+            <xsl:call-template name="doubleflat"/>
+        </xsl:when>
+        <xsl:when test="$accidental = 'flat'">
+            <xsl:call-template name="flat"/>
+        </xsl:when>
+        <xsl:when test="$accidental = 'natural'">
+            <xsl:call-template name="natural"/>
+        </xsl:when>
+        <xsl:when test="$accidental = 'sharp'">
+            <xsl:call-template name="sharp"/>
+        </xsl:when>
+        <xsl:when test="$accidental = 'doublesharp'">
+            <xsl:call-template name="doublesharp"/>
+        </xsl:when>
+        <!-- For unknown accidentals, use the given value wrapped in \text{} -->
+        <xsl:otherwise>
+            <xsl:text>\text{</xsl:text>
+            <xsl:value-of select="$accidental"/>
+            <xsl:text>}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Fall-Back values for Accidentals -->
+
+<!-- Double-Sharp -->
+<xsl:template name="doublesharp">
+    <xsl:text>[DOUBLESHARP]</xsl:text>
+</xsl:template>
+
+<!-- Sharp -->
+<xsl:template name="sharp">
+    <xsl:text>[SHARP]</xsl:text>
+</xsl:template>
+
+<!-- Natural -->
+<xsl:template name="natural">
+    <xsl:text>[NATURAL]</xsl:text>
+</xsl:template>
+
+<!-- Flat -->
+<xsl:template name="flat">
+    <xsl:text>[FLAT]</xsl:text>
+</xsl:template>
+
+<!-- Double-Flat -->
+<xsl:template name="doubleflat">
+    <xsl:text>[DOUBLEFLAT]</xsl:text>
+</xsl:template>
+
+<!-- Insert the correct chord symbol -->
+<!-- (For use in <chord>)  -->
+<xsl:template name="chordsymbols">
+    <xsl:param name="mode"/>
+    <xsl:choose>
+        <xsl:when test="$mode = 'augmented'">
+            <xsl:call-template name="augmentedchordsymbol"/>
+        </xsl:when>
+        <xsl:when test="$mode = 'major'">
+            <xsl:call-template name="majorchordsymbol"/>
+        </xsl:when>
+        <xsl:when test="$mode = 'minor'">
+            <xsl:call-template name="minorchordsymbol"/>
+        </xsl:when>
+        <xsl:when test="$mode = 'halfdiminished'">
+            <xsl:text>^</xsl:text>
+            <xsl:call-template name="halfdiminishedchordsymbol"/>
+            <xsl:text>{}</xsl:text>
+        </xsl:when>
+        <xsl:when test="$mode = 'diminished'">
+            <xsl:text>^</xsl:text>
+            <xsl:call-template name="diminishedchordsymbol"/>
+            <xsl:text>{}</xsl:text>
+        </xsl:when>
+        <!-- For unknown chord symbols, use the given value wrapped in \text{} -->
+        <!-- e.g. mode="maj" will use \text{maj}                               -->
+        <xsl:otherwise>
+            <xsl:text>\text{</xsl:text>
+            <xsl:value-of select="$mode"/>
+            <xsl:text>}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Chord Symbols -->
+
+<!-- Augmented -->
+<xsl:template name="augmentedchordsymbol">
+    <xsl:text>{+}</xsl:text>
+</xsl:template>
+
+<!-- Major -->
+<xsl:template name="majorchordsymbol">
+    <xsl:text>{\Delta}</xsl:text>
+</xsl:template>
+
+<!-- Minor -->
+<xsl:template name="minorchordsymbol">
+    <xsl:text>{-}</xsl:text>
+</xsl:template>
+
+<!-- Half Diminished -->
+<xsl:template name="halfdiminishedchordsymbol">
+    <xsl:text>\text{\o}</xsl:text>
+</xsl:template>
+
+<!-- Diminished -->
+<xsl:template name="diminishedchordsymbol">
+    <xsl:text>{\circ}</xsl:text>
+</xsl:template>
+
 <!-- ################ -->
 <!-- Cross-References -->
 <!-- ################ -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -4934,6 +4934,61 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!--       -->
+<!-- Music -->
+<!--       -->
+
+<!--                 -->
+<!-- Musical Symbols -->
+<!--                 -->
+
+<!-- Accidentals -->
+
+<!-- TODO: If requested, add semi- and sesqui- versions of sharp and flat -->
+
+<!-- Double Sharp -->
+<!-- Unicode Character 'MUSICAL SYMBOL DOUBLE SHARP' (U+1D12A)    -->
+<!-- http://www.fileformat.info/info/unicode/char/1d12a/index.htm -->
+<xsl:template name="doublesharp">
+    <xsl:text>&#x1D12A;</xsl:text>
+</xsl:template>
+
+<!-- Sharp -->
+<!-- Unicode Character 'MUSIC SHARP SIGN' (U+266F)               -->
+<!-- http://www.fileformat.info/info/unicode/char/266f/index.htm -->
+<xsl:template name="sharp">
+    <xsl:text>&#x266F;</xsl:text>
+</xsl:template>
+
+<!-- Natural -->
+<!-- Unicode Character 'MUSIC NATURAL SIGN' (U+266E)             -->
+<!-- http://www.fileformat.info/info/unicode/char/266e/index.htm -->
+<xsl:template name="natural">
+    <xsl:text>&#x266E;</xsl:text>
+</xsl:template>
+
+<!-- Flat -->
+<!-- Unicode Character 'MUSIC FLAT SIGN' (U+266D)                -->
+<!-- http://www.fileformat.info/info/unicode/char/266d/index.htm -->
+<xsl:template name="flat">
+    <xsl:text>&#x266D;</xsl:text>
+</xsl:template>
+
+<!-- Double Flat -->
+<!-- Unicode Character 'MUSICAL SYMBOL DOUBLE FLAT' (U+1D12B)     -->
+<!-- http://www.fileformat.info/info/unicode/char/1d12b/index.htm -->
+<xsl:template name="doubleflat">
+    <xsl:text>&#x1D12B;</xsl:text>
+</xsl:template>
+
+<!-- Half Diminished -->
+<!-- (MathJax does not support "\o") -->
+<!-- Unicode Character 'LATIN SMALL LETTER O WITH STROKE' (U+00F8) -->
+<!-- http://www.fileformat.info/info/unicode/char/00F8/index.htm -->
+<xsl:template name="halfdiminishedchordsymbol">
+    <xsl:text>&#x00F8;</xsl:text>
+</xsl:template>
+
 <!-- Raw Bibliographic Entry Formatting              -->
 <!-- Markup really, not full-blown data preservation -->
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1038,11 +1038,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newcommand{\poemlinecenter}[1]{{\centering{#1}\par}\vspace{-\parskip}}&#xa;</xsl:text>
         <xsl:text>\newcommand{\poemlineright}[1]{{\raggedleft{#1}\par}\vspace{-\parskip}}&#xa;</xsl:text>
     </xsl:if>
+    <!-- Music -->
+    <xsl:if test="//n or //scaledeg or //chord">
+        <xsl:text>%% Musical Symbol Support&#xa;</xsl:text>
+        <xsl:text>\usepackage{fontspec}&#xa;</xsl:text>
+        <xsl:text>\usepackage{lilyglyphs}&#xa;</xsl:text>
+        <xsl:text>\lilyGlobalOptions{scale=0.8}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>%% Raster graphics inclusion, wrapped figures in paragraphs&#xa;</xsl:text>
     <xsl:text>\usepackage{graphicx}&#xa;</xsl:text>
     <!-- Color support automatically, could be conditional -->
     <xsl:text>%% Colors for Sage boxes, author tools (red hilites), red/green edits&#xa;</xsl:text>
-    <xsl:text>\usepackage[usenames,dvipsnames,svgnames,table]{xcolor}&#xa;</xsl:text>
+    <!-- Avoid option conflicts causing errors: -->
+    <!-- http://tex.stackexchange.com/questions/57364/option-clash-for-package-xcolor -->
+    <xsl:text>\PassOptionsToPackage{usenames,dvipsnames,svgnames,table}{xcolor}&#xa;</xsl:text>
+    <xsl:text>\usepackage{xcolor}&#xa;</xsl:text>
     <!-- Inconsolata font, sponsored by TUG: http://levien.com/type/myfonts/inconsolata.html            -->
     <!-- As seen on: http://tex.stackexchange.com/questions/50810/good-monospace-font-for-code-in-latex -->
     <!-- "Fonts for Displaying Program Code in LaTeX":  http://nepsweb.co.uk/docs%/progfonts.pdf        -->
@@ -5620,6 +5630,43 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:call-template>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!--       -->
+<!-- Music -->
+<!--       -->
+
+<!--                 -->
+<!-- Musical Symbols -->
+<!--                 -->
+
+<!-- Accidentals -->
+
+<!-- TODO: If requested, add semi- and sesqui- versions of sharp and flat -->
+
+<!-- Double Sharp -->
+<xsl:template name="doublesharp">
+    <xsl:text>{\doublesharp}</xsl:text>
+</xsl:template>
+
+<!-- Sharp -->
+<xsl:template name="sharp">
+    <xsl:text>{\sharp}</xsl:text>
+</xsl:template>
+
+<!-- Natural -->
+<xsl:template name="natural">
+    <xsl:text>{\natural}</xsl:text>
+</xsl:template>
+
+<!-- Flat -->
+<xsl:template name="flat">
+    <xsl:text>{\flat}</xsl:text>
+</xsl:template>
+
+<!-- Double Flat -->
+<xsl:template name="doubleflat">
+    <xsl:text>{\flatflat}</xsl:text>
 </xsl:template>
 
 <!-- Footnotes               -->


### PR DESCRIPTION
Added examples and documentation to *Humanities in Action* (available in `/examples/humanities/`).

Added empty tags for standard accidentals in western music.
`<doublesharp/>`, `<sharp/>`, `<natural/>`, `<flat/>`, and `<doubleflat/>`

Added markup for scale-degrees.
`<scaledeg>5</scaledeg>`

Added note construction which properly formats both alphabetic and numeric pitch classes with accidentals and octave designations used in scientific pitch notation.
`<n pc="C" acc="sharp" octave="4"/>`

Added chord construction for creating chord labels with optional alterations.
Simple Chord:
```
<chord root="A" mode="major"/>
```
Complex Chord:
```
<chord root="C sharp" mode="minor" bps="7" suspended="yes" bass="E" parentheses="no">
    <alteration>omit 5</alteration>
</chord>
```