### PR TITLE
Fix typo in case entry in DTD.

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -168,7 +168,7 @@
 <!ELEMENT proof (%para;|case)*>
     <!ATTLIST proof xml:id ID #IMPLIED>
 
-<!ELEMENT case  (title?, index*, %para;)*>
+<!ELEMENT case  (title?, index*, (%para;)*)>
     <!ATTLIST case   xml:id   ID                    #IMPLIED>
     <!ATTLIST case   direction  (forward|backward)  #IMPLIED>
 


### PR DESCRIPTION
Went to try to validate my book this morning and the validator threw an error from the DTD. As best as I can tell, this is what was intended.