### PR TITLE
Let exercisegroups have cols

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1836,7 +1836,7 @@ the xsltproc executable.
 
                     <exercise>
                         <statement>
-                            <p><m>f(x)=x^3</m>, <m>\frac{df}{dx}</m>.  This sentence is just a bunch of gibberish to be certain that the problem's left margin aligns with the problem number's indentation.</p>
+                            <p><m>f(x)=x^3</m>, <m>\frac{df}{dx}</m>.  This sentence is just a bunch of gibberish to check where the second line of the problem begins relative to the first line.</p>
                         </statement>
                     </exercise>
 
@@ -1907,6 +1907,26 @@ the xsltproc executable.
                         <statement><p>Second exercise of second group.</p></statement>
                     </exercise>
                     <conclusion><p>Conclusion to second exercise group.</p></conclusion>
+                </exercisegroup>
+
+                <exercisegroup cols="4">
+                    <introduction><p>An <c>&lt;exercisegroup&gt;</c> can have a <c>cols</c> attribute taking a value from 1<ndash />6. Exercises will progress by row, in so many columns. On a small screen, the HTML exercises may reorganize into fewer columns.</p></introduction>
+                    <exercise>
+                        <statement><p><m>1+2</m></p></statement>
+                    </exercise>
+                    <exercise>
+                        <statement><p><m>3+4</m></p></statement>
+                    </exercise>
+                    <exercise>
+                        <statement><p><m>5+6</m></p></statement>
+                    </exercise>
+                    <exercise>
+                        <statement><p>Add seven to eight.</p></statement>
+                    </exercise>
+                    <exercise>
+                        <statement><p><m>9+10</m></p></statement>
+                    </exercise>
+                    <conclusion><p>This feature was designed with short <q>drill</q> exercises in mind.</p></conclusion>
                 </exercisegroup>
 
             </exercises>

--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -580,6 +580,7 @@
 
 <!ELEMENT exercisegroup (introduction?, exercise+, conclusion?)>
     <!ATTLIST exercisegroup xml:id ID    #IMPLIED>
+    <!ATTLIST exercisegroup cols   CDATA #IMPLIED>
 
 <!ELEMENT exercise (title?, index*, ((statement, hint*, answer*, solution*)|(introduction?, webwork, conclusion?)))>
     <!ATTLIST exercise xml:id ID    #IMPLIED>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -2761,10 +2761,30 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Never hidden so calling hidden-knowl-text raises error -->
 <!-- There is no head ever -->
 <xsl:template match="exercisegroup" mode="head" />
-<!-- Body is just all content             -->
-<!-- introducttion, exercises, conclusion -->
+<!-- Body is introduction,       -->
+<!-- exercises wrapped in a div, -->
+<!-- conclusion                  -->
 <xsl:template match="exercisegroup" mode="body">
-    <xsl:apply-templates />
+    <xsl:apply-templates select="introduction"/>
+    <xsl:element name="div">
+        <xsl:attribute name="class">
+            <xsl:text>exercisegroup-exercises</xsl:text>
+            <xsl:text> cols</xsl:text>
+            <xsl:choose>
+                <xsl:when test="not(@cols)">
+                    <xsl:text>1</xsl:text>
+                </xsl:when>
+                <xsl:when test="@cols = 1 or @cols = 2 or @cols = 3 or @cols = 4 or @cols = 5 or @cols = 6">
+                    <xsl:value-of select="@cols" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:message terminate="yes">MBX:ERROR: invalid value <xsl:value-of select="@cols" /> for cols attribute of exercisegroup</xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+        <xsl:apply-templates select="exercise" />
+    </xsl:element>
+    <xsl:apply-templates select="conclusion"/>
 </xsl:template>
 <!-- No posterior  -->
 <xsl:template match="exercisegroup" mode="posterior" />

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -2496,7 +2496,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="exercisegroup/introduction">
-    <xsl:apply-templates select="." mode="console-typeout" />
     <xsl:text>\par\noindent </xsl:text>
     <xsl:apply-templates select="*" />
 </xsl:template>
@@ -2512,7 +2511,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="exercisegroup/conclusion">
-    <xsl:apply-templates select="." mode="console-typeout" />
     <xsl:apply-templates select="*" />
 </xsl:template>
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1309,7 +1309,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:if test="//exercisegroup">
                 <xsl:text>%% Indented groups of exercises within an exercise section, maximum depth 4&#xa;</xsl:text>
                 <xsl:text>\usepackage{tasks}&#xa;</xsl:text>
-                <xsl:text>\NewTasks[label-format=\bfseries,item-indent=3.33em,label-offset=5pt,label-width=20pt,label-align=right,after-item-skip=\smallskipamount,after-skip=\smallskipamount]{exercisegroup}[\exercise]&#xa;</xsl:text>
+                <xsl:text>\NewTasks[label-format=\bfseries,item-indent=3.3em,label-offset=0.4em,label-width=1.7em,label-align=right,after-item-skip=\smallskipamount,after-skip=\smallskipamount]{exercisegroup}[\exercise]&#xa;</xsl:text>
             </xsl:if>
         </xsl:if>
     </xsl:if>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1310,8 +1310,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>%% Indented groups of exercises within an exercise section, maximum depth 4&#xa;</xsl:text>
                 <xsl:text>\usepackage{tasks}&#xa;</xsl:text>
                 <xsl:text>\NewTasks[label-format=\bfseries,item-indent=3.33em,label-offset=5pt,label-width=20pt,label-align=right,after-item-skip=\smallskipamount,after-skip=\smallskipamount]{exercisegroup}[\exercise]&#xa;</xsl:text>
-                <!--<xsl:text>\newlist{exercisegroup}{description}{4}&#xa;</xsl:text>-->
-                <!--<xsl:text>\setlist[exercisegroup]{leftmargin=2em,labelindent=2em,itemsep=-1.0ex,topsep=1.0ex,partopsep=0pt,parsep=0pt}&#xa;</xsl:text>-->
             </xsl:if>
         </xsl:if>
     </xsl:if>


### PR DESCRIPTION
A PR to let exercisegroups have cols. This is version 2.0 of #76 which I'll close and xref to here.

Output: compare 
http://spot.pcc.edu/~ajordan/temp/derivatives.pdf page 28 
to 
http://mathbook.pugetsound.edu/examples/sample-article/derivatives.pdf page 28

And compare
http://spot.pcc.edu/~ajordan/temp/section-11.html
to
http://mathbook.pugetsound.edu/examples/sample-article/html/section-11.html

HTML uses a div around the exercises within the exercisegroup that uses `display:flex` and has a class for the number of cols. But on a narrow screen the items will reconfigure into fewer columns. The extra CSS for this is at http://spot.pcc.edu/~ajordan/temp/sample-article.css. I suspect that the same classes `cols2`, etc. along with flex box styling could be used to improve how lists get their multiple columns. [Something is not right with that at present. When I look at http://spot.pcc.edu/~ajordan/temp/section-5.html in Firefox the ul items are not aligned with each other..]

LaTeX uses [tasks](https://www.ctan.org/tex-archive/macros/latex/contrib/tasks?lang=en) package. It has LPPL status "maintained", and is maintained by the author [Clemens Niederberger](http://www.mychemistry.eu/)  whose name is on [a lot of LaTeX contributions](https://www.ctan.org/author/niederberger). tasks was born out of a much larger package exsheets that is used for exercise sheets. tasks is just the item enumeration method, but by popular demand he split it off into its own package.

It is possible to use `\item` for the item demarker in a tasks environment. However if you do that, you cannot have regular lists inside such an item. So I have it set to `\exercise` for now. 

#76 has been there for a long time, and no rush to give feedback on this one. But I will use this for the next CLM release, and so if it sits here as a PR I will try to rebase it regularly.

