### PR TITLE
WeBWorK version

### DIFF
--- a/doc/author-guide/webwork.xml
+++ b/doc/author-guide/webwork.xml
@@ -205,6 +205,7 @@
                 <prompt>$ </prompt>
                 <input>xsltproc --stringparam webwork.server https://webwork.myschool.edu &lt;xsl&gt; &lt;xml&gt;</input>
             </console>
+            <p>If your <c>webwork.server</c> is running version 2.11 (the first version which can be used with MBX), then you should additionally pass <c>--stringparam webwork.version 2.11</c>.<p.>
             <p>For HTML output, this is all that is needed. For <latex />, you may need to do more first. See <xref ref="subsection-webwork-latex"/>.</p>
         </subsection>
 

--- a/script/mbx
+++ b/script/mbx
@@ -308,6 +308,7 @@ def webwork_to_tex(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_
         'courseID': 'anonymous',
         'userID': 'anonymous',
         'password': 'anonymous',
+        'course_password': 'anonymous',
         'outputformat': 'simple'
     }
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -124,6 +124,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- There is no default server provided         -->
 <!-- Interactions are with an "anonymous" course -->
 <xsl:param name="webwork.server" select="''"/>
+<xsl:param name="webwork.version" select="'2.12'"/>
 <xsl:param name="webwork.course" select="'anonymous'" />
 <xsl:param name="webwork.userID" select="'anonymous'" />
 <xsl:param name="webwork.password" select="'anonymous'" />
@@ -1810,7 +1811,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:value-of select="$webwork.course"/>
                 <xsl:text>&amp;userID=</xsl:text>
                 <xsl:value-of select="$webwork.userID"/>
-                <xsl:text>&amp;password=</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="$webwork.version='2.11'">
+                        <xsl:text>&amp;password=</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>&amp;course_password=</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
                 <xsl:value-of select="$webwork.password"/>
                 <xsl:text>&amp;outputformat=</xsl:text>
                 <xsl:choose>


### PR DESCRIPTION
This is to address the issue discovered in https://groups.google.com/d/msg/mathbook-xml-support/4ThAGRu4xFI/bHY9LGNXBQAJ. 

For xsltproc, you can declare `webwork.version` to be 2.11 and you will get "password=". Otherwise, you get "course_password=". This will handle all the webwork knowls.

For the tex, that is extracted using the mbx script. My feeling was that it would be better to pass both "password=" and "course_password=" when the script makes its server call. But if you would prefer, some sort of switch could be added to the script to single out 2.11. It just seems like a really narrow thing to make a switch for.