### PR TITLE
Add titles to induction examples.

### DIFF
--- a/examples/sample-book/integers.xml
+++ b/examples/sample-book/integers.xml
@@ -62,6 +62,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- wording change.  Suggested by P. Diethelm.  TWJ 22/4/2013 -->
 
         <example xml:id="example-integers-induction-greater-than">
+          <title>An inequality for powers of <m>2</m></title>
             <p>For all integers <m>n \geq 3</m>, <m>2^n \gt n + 4</m>. Since
                 <me>8 = 2^3 \gt 3 + 4 = 7,</me>
             the statement is true for <m>n_0 = 3</m>.  Assume that <m>2^k \gt k + 4</m> for <m>k \geq 3</m>.  Then <m>2^{k + 1} = 2 \cdot 2^{k} \gt 2(k + 4)</m>.  But 
@@ -71,6 +72,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 
         <example xml:id="example-integers-induction-divisible">
+          <title>Some integers divisible by <m>9</m></title>
             <p>Every integer <m>10^{n + 1} + 3 \cdot 10^n + 5</m> is divisible by 9 for <m>n \in {\mathbb N}</m>.  For <m>n = 1</m>, 
                 <me>10^{1 + 1} + 3 \cdot 10 + 5 = 135 = 9 \cdot 15</me>
             is divisible by 9.  Suppose that <m>10^{k + 1} + 3 \cdot 10^k + 5</m> is divisible by 9 for <m>k \geq 1</m>.  Then<md>
@@ -80,6 +82,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </example>
 
         <example xml:id="example-integers-binomial-theorem">
+          <title>The binomial theorem</title>
             <p>We will prove the binomial theorem using mathematical induction; that is, <me>(a + b)^n = \sum_{k = 0}^{n} \binom{n}{k} a^k b^{n - k},</me> where <m>a</m> and <m>b</m> are real numbers, <m>n \in \mathbb{N}</m>, and <me>\binom{n}{k} = \frac{n!}{k! (n - k)!}</me> is the binomial coefficient.  We first show that <me>\binom{n + 1}{k} = \binom{n}{k} + \binom{n}{k - 1}.</me> This result follows from<md>
                 <mrow>\binom{n}{k} + \binom{n}{k - 1} &amp; = \frac{n!}{k!(n - k)!} +\frac{n!}{(k-1)!(n - k + 1)!}</mrow>
                 <mrow>&amp; = \frac{(n + 1)!}{k!(n + 1 - k)!}</mrow>


### PR DESCRIPTION
The examples are immediately after Principle 2.1.1.

http://mathbook.pugetsound.edu/examples/sample-book/html/section-math-induction.html

new version looks like this:

http://sl2x.aimath.org/development/MBX/html/section-math-induction.html
