### PR TITLE
Added some useful index entries

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -377,7 +377,7 @@ the xsltproc executable.
                 <output>12.005</output>
             </sage>
 
-            <p>Sage, and by extension, the Sage Cell Server, can interpret several languages.  The next example has code in the <c>R</c> language, a popular open source language for statistics.  As an author, you add the attribute <c>language="r"</c> to your <c>sage</c> element.  (The default language is Sage, so you do not need to indicate that repeatedly.)  Note that a language like <c>R</c> likes to use a <q>less than</q> character, the second most-dangerous special character in XML.  You need to escape it by writing <c>&amp;lt;</c> as we have done in the source for this example.  (See the discussion and summary in <xref ref="subsection-reserved-characters" autoname="yes" />.)</p>
+            <p>Sage, and by extension, the Sage Cell Server, can interpret several languages.  The next example has code in the <c>R</c> language,<index><main>R</main></index> a popular open source language for statistics.  As an author, you add the attribute <c>language="r"</c> to your <c>sage</c> element.  (The default language is Sage, so you do not need to indicate that repeatedly.)  Note that a language like <c>R</c> likes to use a <q>less than</q> character, the second most-dangerous special character in XML.  You need to escape it by writing <c>&amp;lt;</c> as we have done in the source for this example.  (See the discussion and summary in <xref ref="subsection-reserved-characters" autoname="yes" />.)</p>
 
             <p>As a reader you learn that the <q>Evaluate</q> button for a pre-loaded Sage cell will indicate the language in use.</p>
 
@@ -602,7 +602,7 @@ the xsltproc executable.
                         </solution>
                     </question>
 
-                    <p>There are many different blocks you can employ, and they mostly behave the same way.  A <c>&lt;project&gt;</c> is very similar to a <c>&lt;question&gt;</c> or <c>&lt;problem&gt;</c></p>
+                    <p>There are many different blocks you can employ, and they mostly behave the same way.  A <c>&lt;project&gt;</c><index><main>project</main></index> is very similar to a <c>&lt;question&gt;</c><index><main>question</main></index> or <c>&lt;problem&gt;</c><index><main>problem</main></index></p>
 
                     <project>
                         <title>Start Exploring MathBook XML</title>
@@ -617,9 +617,9 @@ the xsltproc executable.
                         <title>Exploring Explorations</title>
 
                         <statement>
-                            <p>This is an <c>&lt;exploration&gt;</c>.  Two similar possibilities are <c>&lt;activity&gt;</c> and <c>&lt;task&gt;</c>.</p>
+                            <p>This is an <c>&lt;exploration&gt;</c>.<index><main>exploration</main></index>  Two similar possibilities are <c>&lt;activity&gt;</c><index><main>activity</main></index> and <c>&lt;task&gt;</c>.<index><main>task</main></index></p>
 
-                            <p>Note that projects, activities, explorations, and tasks <em>share</em> the independent numbering scheme, so it is really only intended you use one of these.  If you want a variant of the name (<eg /> <q>Directed Activity</q>) you can use the <c>&lt;rename&gt;</c> facility (<xref ref="rename-facility" autoname="yes" />).</p>
+                            <p>Note that projects, activities, explorations, and tasks <em>share</em> the independent numbering scheme, so it is really only intended you use one of these.  If you want a variant of the name (<eg /> <q>Directed Activity</q>) you can use the <c>&lt;rename&gt;</c><index><main>rename an environment</main></index> facility (<xref ref="rename-facility" autoname="yes" />).</p>
                         </statement>
 
                         <solution>
@@ -668,7 +668,7 @@ the xsltproc executable.
 
             <subsection>
                 <title>Linking Sage Cells</title>
-
+                  <index><main>linking Sage cells</main></index>
                 <p>Sage cells share their results on a per-webpage basis, so if you move to a new chapter, section, or subsection that happens to be on another webpage, your Sage computations are gone and you start fresh.  But maybe you need some results from elsewhere.  As an author, you can make an exact copy of a cell in another location.  As a reader you are suggested to <q>replay</q> the cell.  You have seen the next cell before.  More typically such a cell might define a function or set some values of a variable.</p>
 
                 <sage copy="sage-numerical-integral" />
@@ -695,7 +695,7 @@ the xsltproc executable.
                 <assemblage xml:id="assemblage-basics">
                     <title>Assemblages: Collections and Summaries</title>
 
-                    <p>An <c>&lt;assemblage&gt;</c> is a collection, or summary, that does not have much structure to it.  So you are limited to paragraphs (<c>p</c>), tables, figures and side-by-sides.  The intent is that these do not have captions, so are not numbered, so cannot be cross-referenced and so do not become knowls (inside of the knowled assemblage).  Note that <c>p</c> may by extension contain lists (<c>ol</c>, <c>ul</c>, <c>dl</c>).  Despite limited structure, the presentation should draw attention to it, because the contents should be seen as more important in some way.  It should be <q>highlighted</q> in some manner.  If you need to connect with material elsewhere, you can do that with the usual <c>xref/xml:id</c> mechanism.</p>
+                    <p>An <c>&lt;assemblage&gt;</c> is a collection, or summary, that does not have much structure to it.  So you are limited to paragraphs (<c>p</c>), tables, figures and side-by-sides.  The intent is that these do not have captions, so are not numbered, so cannot be cross-referenced and so do not become knowls (inside of the knowled assemblage).  Note that <c>p</c> may by extension contain lists (<c>ol</c>, <c>ul</c>, <c>dl</c>).  Despite limited structure, the presentation should draw attention to it, because the contents should be seen as more important in some way.  It should be <q>highlighted</q> in some manner.  If you need to connect with material elsewhere, you can do that with the usual <c>xref/xml:id</c> mechanism.<index><main>assemblage</main></index></p>
 
                     <p>What have we seen so far in this (disorganized) sample?<ul>
                         <li><p>Theorems, definitions and corollaries. (<xref ref="section-fundamental-theorem" autoname="yes" />)</p></li>
@@ -1020,7 +1020,7 @@ the xsltproc executable.
 
                 <p>If you would like to use macros from a <latex /> package <em>and</em> there is a MathJax extension <em>of the same name</em> which implements the same macros, then you may use these with your mathematics as we demonstrate here.</p>
 
-                <p>This example is from Jason Underdown.  The package is named <c>cancel</c> and is included in the TeXLive distribution, so is fairly standard.  The particular macro being demonstrated is <c>\cancelto{}{}</c>.  <me>\lim_{b \rightarrow \infty}\left[\cancelto{0}{-\frac{1}{s}e^{-sb}} + \frac{1}{s}\right]</me>Look at the source of this article to see the package name being supplied in a <c>latex-preamble/package</c> element within the <c>docinfo</c> section.  That is the only setup required to make the macro usable in <latex /> and <init>HTML</init> output.</p>
+                <p>This example is from Jason Underdown.<index><main>Underdown, Jason</main></index>  The package is named <c>cancel</c> and is included in the TeXLive distribution, so is fairly standard.  The particular macro being demonstrated is <c>\cancelto{}{}</c>.  <me>\lim_{b \rightarrow \infty}\left[\cancelto{0}{-\frac{1}{s}e^{-sb}} + \frac{1}{s}\right]</me>Look at the source of this article to see the package name being supplied in a <c>latex-preamble/package</c> element within the <c>docinfo</c> section.  That is the only setup required to make the macro usable in <latex /> and <init>HTML</init> output.<index><main>canceling a term</main></index><index><main><c>cancelto</c> macro</main></index></p>
 
                 <p>The packages appear before the author-supplied macros, so you can use macros from the packages as building blocks for document-specific macros.  We cannot guarantee there will be no conflicts between additional packages and those in use normally, or added in the future.  So use at your own risk.</p>
             </subsection>
@@ -1140,7 +1140,7 @@ the xsltproc executable.
             <subsection xml:id="section-urls">
                 <title>URLs</title>
 
-                <p>An internet <init>URL</init> can very well contain some of the characters that <latex /> needs to escape.  But the packages we use for embedded links should be smart about this.  So we include a long <init>URL</init> for testing <latex /> output, with one reserved character, though maybe someday it will become stale and we need to change it out:  <url href="http://www.pcc.edu/enroll/registration/dropping.html#withdraw">www.pcc.edu/enroll/registration/dropping.html<hash />withdraw</url>.  Notice in the source that you <em>cannot</em> put a tag inside the <c>href</c> attribute, and do need to use an element within the content (unless you like to wrap the content in a <c>c</c> element).  Here is a totally bogus <init>URL</init>, which contains every possible legal character, so if this fails to convert there is some problematic character.  Four combinations: with the content as normal text versus with the characters as verbatim text, and as a <init>URL</init> versus not.</p>
+                <p>An internet <init>URL</init><index><main>URLs</main></index> can very well contain some of the characters that <latex /> needs to escape.  But the packages we use for embedded links should be smart about this.  So we include a long <init>URL</init> for testing <latex /> output, with one reserved character, though maybe someday it will become stale and we need to change it out:  <url href="http://www.pcc.edu/enroll/registration/dropping.html#withdraw">www.pcc.edu/enroll/registration/dropping.html<hash />withdraw</url>.  Notice in the source that you <em>cannot</em> put a tag inside the <c>href</c> attribute, and do need to use an element within the content (unless you like to wrap the content in a <c>c</c> element).  Here is a totally bogus <init>URL</init>, which contains every possible legal character, so if this fails to convert there is some problematic character.  Four combinations: with the content as normal text versus with the characters as verbatim text, and as a <init>URL</init> versus not.</p>
 
                 <blockquote>
 
@@ -1171,7 +1171,7 @@ the xsltproc executable.
             <subsection>
                 <title>Quotations</title>
 
-                <p>The <c>q</c> tag will provide beginning and ending double quotations, while the <c>sq</c> tag will behave similarly but provide single quotes.</p>
+                <p>The <c>q</c><index><main>quotations</main></index> tag will provide beginning and ending double quotations, while the <c>sq</c> tag will behave similarly but provide single quotes.</p>
 
                 <p><q>The roots of education are bitter, but the fruit is sweet.</q> (Aristotle)</p>
 
@@ -1498,7 +1498,7 @@ the xsltproc executable.
             <subsection>
                 <title>Asymptote</title>
 
-                <p>The Asymptote graphics language may be placed in your source to draw graphs, diagrams or pictures.  Rules for formatting code are identical to those for Sage code.  For more on Asymptote see <url href="http://asymptote.sourceforge.net/" />.</p>
+                <p>The Asymptote<index><main>asymptote graphics language</main></index> graphics language may be placed in your source to draw graphs, diagrams or pictures.  Rules for formatting code are identical to those for Sage code.  For more on Asymptote see <url href="http://asymptote.sourceforge.net/" />.</p>
 
                 <!--
                 See a different (more traditional) variant of URL usage
@@ -1641,7 +1641,7 @@ the xsltproc executable.
 
             <subsection>
                 <title>Sage Plots</title>
-
+                  <index><main>Sage plots</main></index>
                 <p>Any of the numerous capabilities of Sage may be used to produce any graphics object, be it the simple graph of a single-variable function or some realization of a more complicated object.  All of the usual rules about formatting Sage code (esp. indentation) apply, along with one more caveat.  The last line of your Sage code <alert>must</alert> return a Sage <c>Graphics</c> object (or 3D plot).  The <c>mbx</c> script will isolate this last line, use it as the RHS of an assignment statement, and the Sage <c>.save()</c> method will be called to generate the image, which is either a Portable Document Format (PDF) file amenable to <latex /> output, or a Scalable Vector Graphics (SVG) file amenable to HTML output.  For visualizations of 3D plots, Sage will only produce Portable Network Graphics (PNG) files, which can be included in HTML pages or <latex /> output.</p>
 
                 <figure xml:id="figure-sage-parabola">
@@ -1826,7 +1826,7 @@ the xsltproc executable.
 
             <references>
                 <title>References</title>
-
+                  <item><main>references</main><sub>within a section</sub></index>
                 <introduction>
                     <p>These items are here to test basic formatting of references.</p>
                 </introduction>
@@ -1887,7 +1887,7 @@ the xsltproc executable.
 
                 <exercise>
                     <statement>
-                        <p>One of the few things you can place inside of mathematics is a <q>fill-in</q> blank.  We demonstrate a few scenarios here.  See details on syntax in <xref ref="subsection-paragraph-markup" autoname="yes" /><ndash />the use is identical within mathematics.<ul>
+                        <p>One of the few things you can place inside of mathematics is a <q>fill-in</q> blank.<index><main>fill-in the blank</main></index>  We demonstrate a few scenarios here.  See details on syntax in <xref ref="subsection-paragraph-markup" autoname="yes" /><ndash />the use is identical within mathematics.<ul>
                             <li><p>Inside inline math (short, 4 characters): <m>\sin(<fillin characters="4" />)</m></p></li>
 
                             <li><p>Inside inline math (default, 10 characters): <m>\sin(<fillin characters="10" />)</m></p></li>
@@ -1965,7 +1965,7 @@ the xsltproc executable.
 
             <subsection>
                 <title>Lists, Generally</title>
-
+                  <index><main>ordered list</main></index><index><main>list</main><sub>ordered</sub></index><index><main>unordered list</main></index><index><main>list</main><sub>unordered</sub></index>
                 <p>This section contains nested lists, to demonstrate how they get assigned labels (numbering, symbols).  But we begin with two simple lists, demonstrating an ordered list and an unordered list.  See the end of section for an example of a description list.  Since Jupyter notebooks use markdown syntax, their lists are less flexible.  So some assertions here may be wrong when viewed as a Jupyter notebook.</p>
 
                 <p><ol>
@@ -2162,7 +2162,7 @@ the xsltproc executable.
             <subsection>
                 <title>Description Lists</title>
 
-                <p>A <q>description</q> list has a short term or phrase that is prominent, followed by a short description.  It is modeled on the lists of similar structure in both <latex /> and HTML.  It makes for a nice medium-weight way to define terms, somewhere in-between the <c>term</c> tag which just makes a term prominent in a sentence, and a <c>definition</c>, which is set off, has a heading, a number, and a title.  This example is from Bob Plantz.<dl>
+                <p>A <q>description</q><index><main>description list</main></index><index><main>list</main><sub>description</sub></index> list has a short term or phrase that is prominent, followed by a short description.  It is modeled on the lists of similar structure in both <latex /> and HTML.  It makes for a nice medium-weight way to define terms, somewhere in-between the <c>term</c> tag which just makes a term prominent in a sentence, and a <c>definition</c>, which is set off, has a heading, a number, and a title.  This example is from Bob Plantz.<dl>
                     <li>
                         <title>Central Processing Unit (CPU)</title>
                         <p>Controls most of the activities of the computer, performs the arithmetic and logical operations, and contains a small amount of very fast memory.</p>
@@ -2958,7 +2958,7 @@ the xsltproc executable.
 
             <subsection>
                 <title>GeoGebra</title>
-
+                  <index><main>GeoGebra</main></index>
                 <p>This first example of a  GeoGebra demonstration has just the controls for moving the three vertices on the circumfrence of the circle.  This is courtesy of Danny Parsons at the African Institute of Mathematical Sciences.  This demo requires Java, which could be problematic.</p>
 
                 <p>GeoGebra will create screenshots of demonstrations in TikZ/<latex /> code.  For a static version, we use this as a figure.</p>
@@ -3028,7 +3028,7 @@ the xsltproc executable.
                 <video source="images/ups-visitor-guide-360.mp4" />
             </figure>
 
-            <p>YouTube videos may be embedded with only knowledge of the <q>ID</q>.  This a string of eleven seemingly random characters that show up in the URL when you watch a video.  For the Led Zeppelin performance below, the ID is <c>hAzdgU_kpGo</c>, which you might normally watch directly from the URL <url href="https://www.youtube.com/watch?v=hAzdgU_kpGo" />.  Screen real estate is determined by specifying an optional <c>@width</c> attribute as a percentage, and aspect ratio is preserved on the assumption of HD video (16:9).</p>
+            <p>YouTube<index><main>YouTube videos</main></index><index><main>videos</main><sub>YouTube</sub></index> videos may be embedded with only knowledge of the <q>ID</q>.  This a string of eleven seemingly random characters that show up in the URL when you watch a video.  For the Led Zeppelin performance below, the ID is <c>hAzdgU_kpGo</c>, which you might normally watch directly from the URL <url href="https://www.youtube.com/watch?v=hAzdgU_kpGo" />.  Screen real estate is determined by specifying an optional <c>@width</c> attribute as a percentage, and aspect ratio is preserved on the assumption of HD video (16:9).</p>
 
             <p>Enhancements could include other aspect ratios, and attributes for a start and stop time.</p>
 
@@ -3036,7 +3036,7 @@ the xsltproc executable.
 
             <figure>
                 <title>Kashmir (Live), Led Zeppelin</title>
-                <caption>Kashmir (Live), Led Zeppelin. O2 Arena, London. December 10, 2007. (8:55)</caption>
+                <caption>Kashmir (Live), Led Zeppelin.<index><main>Led Zeppelin video</main></index> O2 Arena, London. December 10, 2007. (8:55)</caption>
                 <video youtube="hAzdgU_kpGo" width="70%" xml:id="led-zeppelin-kashmir" />
             </figure>
 
@@ -3131,7 +3131,7 @@ the xsltproc executable.
         <section xml:id="section-cross-referencing">
             <title>Cross-Referencing</title>
 
-            <p>Cross-references are easy, since that is a key reason for having a highly structured document.  Here is a useful feature if you elect to use it.  Any <c>&lt;xref&gt;</c> will <q>know</q> what it points to, so you can let it provide the <q>naming</q> part of the cross-reference text.  You can turn this on globally with the command-line parameter <c>autoname</c> set to <c>'yes'</c>.  If you do that, you will see most of the names in this document doubled, since the names are written into the source already in most places outside of this section.  Try it and see: use <c>--stringparam autoname 'yes'</c> as an argument to <c>xsltproc</c>.</p>
+            <p>Cross-references are easy, since that is a key reason for having a highly structured document.  Here is a useful feature if you elect to use it.  Any <c>&lt;xref&gt;</c> will <q>know</q> what it points to, so you can let it provide the <q>naming</q> part of the cross-reference text.  You can turn this on globally with the command-line parameter <c>autoname</c><index><main>autoname</main></index> set to <c>'yes'</c>.  If you do that, you will see most of the names in this document doubled, since the names are written into the source already in most places outside of this section.  Try it and see: use <c>--stringparam autoname 'yes'</c> as an argument to <c>xsltproc</c>.</p>
 
             <p>Moreover, the names themselves will change with the use of the one language dependent file.  And another bonus is that with an autoname, you automatically get a <em>non-breaking</em> space between the name and the reference.  The autoname switch makes no sense for <q>provisional</q> cross-references, since there is no information about what they point to.</p>
 
@@ -3514,7 +3514,7 @@ the xsltproc executable.
 
             <p>Sage cells can be used for Python examples, but Sage uses a mild amount of pre-parsing, so that might not be a wise decision, especially in instructional settings.  We might implement Skulpt or Brython (in-browser Python) or the Python language argument to the Sage Cell Server.  To see examples of authoring Sage cells, have a look at Section<nbsp /><xref ref="section-sage-cells" />.</p>
 
-            <p>In the meantime, program listings, especially with syntax highlighting, is useful all by itself.  The <q>R</q> language might not be a bad stand-in for pseudo-code, as it supports assignment with a left arrow and has fairly generic procedural syntax for control structures and data structures.  Or maybe Pascal would be a good choice?  Here is an example of R.  Note in the source that the entire block of code is wrapped in a CDATA section due to the four left angle brackets.</p>
+            <p>In the meantime, program listings,<index><main>listing</main></index><index><main>program listing</main></index> especially with syntax highlighting, is useful all by itself.  The <q>R</q> language might not be a bad stand-in for pseudo-code, as it supports assignment with a left arrow and has fairly generic procedural syntax for control structures and data structures.  Or maybe Pascal would be a good choice?  Here is an example of R.  Note in the source that the entire block of code is wrapped in a CDATA section due to the four left angle brackets.</p>
 
             <!-- Output in knowls?? -->
 
@@ -3782,7 +3782,7 @@ the xsltproc executable.
         <section>
             <title>Units of Measure</title>
 
-            <p>Units of measure can be given xml treatment too with the <c>quantity</c> element. In <latex />, the <c>siunitx</c> package is loaded to achive unit handling. Since that package only offers SI units, some other common units will be added by MBX in the preamble. In HTML, the capabilities of <c>siunitx</c> are simulated, weakly. Note that at present, you should not attempt to use the <c>quantity</c> element within a math environment.</p>
+            <p>Units of measure can be given xml treatment too with the <c>quantity</c> element. In <latex />, the <c>siunitx</c><index><main>siunitx package</main></index><index><main>package</main><sub>siunitx</sub></index><index><main>units</main></index> package is loaded to achive unit handling. Since that package only offers SI units, some other common units will be added by MBX in the preamble. In HTML, the capabilities of <c>siunitx</c> are simulated, weakly. Note that at present, you should not attempt to use the <c>quantity</c> element within a math environment.</p>
             <p>The value of gravitational constant <m>g</m> is <quantity><mag>9.8</mag><unit base="meter"/><per base="second" exp="2"/></quantity>. Force is measured in <quantity><unit prefix="kilo" base="gram"/><unit base="meter"/><per base="second" exp="2"/></quantity>, also known as one <quantity><unit base="newton"/></quantity>. A quantity with rather ridiculous units is <quantity><mag>23</mag><unit prefix='micro' base='hectare' exp='23'/><per base='degreeCelsius'/><per base='second' exp='2'/></quantity>. One <quantity><unit base="hertz"/></quantity> is the same as <quantity><per base='second'/></quantity>. You can have a unitless quantity, like <quantity><mag>42</mag></quantity>, which may help with consistency between such numbers and units in the <latex /> output. Some non-SI units are available, such as the absurd <quantity><unit base="degreeFahrenheit"/><unit base="foot"/><unit base="pound"/><per base="gallon"/></quantity>.  The <latex /> command <c>\pi</c> is recognized within <c>mag</c> in conversions to HTML, which is consistent with the behavior with a conversion to <latex />, for example there are <quantity><mag>2\pi</mag><unit base="radian"/></quantity> in a full circle.</p>
 
             <p>For a full list of the allowed units and prefixes, see <c>mathbook-units.xsl</c>. If you have a need for more units, they need to be added to <c>mathbook-units.xsl</c> in the section that deals with units which are not part of <c>siunitx</c> by default.  Note that the <c>mag</c> element should come first, followed by the <c>unit</c> element, followed by the <c>per</c> element.</p>
@@ -4904,7 +4904,7 @@ the xsltproc executable.
 
                 <p><q>Names</q> for various parts of a document are determined exactly once for each language, ensuring consistency and saving you the bother of always typing them in.</p>
 
-                <p>However, you may want to have <q>Conundrum</q>s in your document and you have no use for any <q>Proposition</q>s.  So you can repurpose the <c>proposition</c> tag to render a different name.  Or you might have a Lab Manual and want to rename <c>subsection</c> as <q>Activity</q>.  See the <c>docinfo</c> portion of this sample article to see how this is done, in concert with the example below.</p>
+                <p>However, you may want to have <q>Conundrum</q>s<index><main>conundrum</main><sub>repurposed from proposition</sub></index> in your document and you have no use for any <q>Proposition</q>s.  So you can repurpose the <c>proposition</c> tag to render a different name.  Or you might have a Lab Manual and want to rename <c>subsection</c> as <q>Activity</q>.  See the <c>docinfo</c> portion of this sample article to see how this is done, in concert with the example below.</p>
 
                 <proposition xml:id="proposition-as-conundrum">
                     <statement>


### PR DESCRIPTION
Added some index entries for terms I repeatedly need to look up,
and also a few others that I saw.

After committing I saw that there were already some index entries.
It would be good to compile the index as part of the sample article.

I didn't know the standard for adding index entries: end of a paragraph,
immediately after the term first appears, or between the section title
and the first paragraph.  So I did examples of all three possibilities.

