### PR TITLE
Additional units of time for units handling

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -678,7 +678,7 @@
 
 <!ENTITY % prefix "yocto|zepto|atto|femto|pico|nano|micro|milli|centi|deci|deca|deka|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta">
 
-<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|gallon">
+<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|millennium|century|decade|year|month|week|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|gallon">
 
 <!ELEMENT quantity   (mag*, unit*, per*)>
 

--- a/xsl/mathbook-units.xsl
+++ b/xsl/mathbook-units.xsl
@@ -142,6 +142,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <base full='yard'              short='yd'       siunitx='none' />
     <base full='mile'              short='mi'       siunitx='none' />
 
+    <!-- Time                                                                       -->
+    <base full='millennium'        short='millennium' siunitx='none' />
+    <base full='century'           short='century'    siunitx='none' />
+    <base full='decade'            short='decade'     siunitx='none' />
+    <base full='year'              short='yr'         siunitx='none' />
+    <base full='month'             short='mo'         siunitx='none' />
+    <base full='week'              short='wk'         siunitx='none' />
+
     <!-- Speed                                                                      -->
     <base full='kilometerperhour'  short='kph'      siunitx='none' />
     <base full='kilometreperhour'  short='kph'      siunitx='none' />


### PR DESCRIPTION
Added "year (yr)", needed for ORCCA.

Also added:
week (wk)
month (mo)
decade (decade)
century (century)
millennium (millennium)

[Note: don't misspell "millennium" as "millenium", since "annus" and "anus" mean very different things.]