### PR TITLE
Webwork issues 2

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -682,7 +682,7 @@
 
 <!ENTITY % prefix "yocto|zepto|atto|femto|pico|nano|micro|milli|centi|deci|deca|deka|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta">
 
-<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|millennium|century|decade|year|month|week|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|gallon">
+<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|millennium|century|decade|year|month|week|kilometerperhour|kilometreperhour|mileperhour|gallon|milepergallon">
 
 <!ELEMENT quantity   (mag*, unit*, per*)>
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -3078,7 +3078,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Here, we just provide a light wrapper, and drop an    -->
 <!-- include, since the basename for the filenames has     -->
 <!-- been managed by the  mbx  script to be predictable.   -->
-<xsl:template match="webwork[@source]|webwork[descendant::image[@pg-name]]">
+<xsl:template match="webwork[@source]">
     <!-- directory of server LaTeX must be specified -->
     <xsl:if test="$webwork.server.latex = ''">
         <xsl:message terminate="yes">MBX:ERROR   For LaTeX versions of WeBWorK problems on a server, the mbx script will collect the LaTeX source and then this conversion must specify the location through the "webwork.server.latex" command line stringparam.  Quitting...</xsl:message>
@@ -3133,6 +3133,47 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates />
     </xsl:if>
 </xsl:template>
+
+<!-- ############################# -->
+<!-- WeBWorK Images   from Servers -->
+<!-- ############################# -->
+
+<!-- When a webwork exercise is written in MBX source, but -->
+<!-- uses an image with an @pg-name, we make the exercise  -->
+<!-- in the usual way but include an image which has been  -->
+<!-- created by the mbx script with a predictable name     -->
+<!-- For such images, width and height are pixel counts    -->
+<!-- sent to the PG image creator, intended to define the  -->
+<!-- width of HTML output. A separate tex_size is intended -->
+<!-- to define width of LaTeX output. tex_size of say 800  -->
+<!-- means 0.800\linewidth. We use 400px for the default   -->
+<!-- width in mathbook-webwork-pg. Since 600px is the      -->
+<!-- default design width in html, we use 667 as the       -->
+<!-- default for tex_size                                  -->
+
+<xsl:template match="image[@pg-name and not(ancestor::webwork[@source])]">
+    <xsl:variable name="png-filename">
+        <!-- assumes path has trailing slash -->
+        <xsl:value-of select="$webwork.server.latex" />
+        <xsl:apply-templates select="ancestor::webwork" mode="internal-id" />
+        <xsl:text>-image-</xsl:text>
+        <xsl:value-of select="count(preceding-sibling::image)+1" />
+        <xsl:text>.png</xsl:text>
+    </xsl:variable>
+    <xsl:text>\includegraphics[width=</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@tex_size">
+            <xsl:value-of select="@tex_size*0.001"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>0.667</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>\linewidth]{</xsl:text>
+    <xsl:value-of select="$png-filename" />
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
 
 <!-- Remark Like, Example Like, Project Like -->
 <!-- Simpler than theorems, definitions, etc            -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -2571,6 +2571,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="*" />
 </xsl:template>
 
+<!-- Most introductions are followed by other sectioning blocks (e.g. subsection) -->
+<!-- And then there is a resetting of the carriage. An introduction preceding a   -->
+<!-- webwork needs an additional \par at the end (if there even was an intro)     -->
+<xsl:template match="introduction[following-sibling::webwork]">
+    <xsl:apply-templates select="." mode="console-typeout" />
+    <xsl:apply-templates select="*" />
+    <xsl:text>\par\medskip&#xa;</xsl:text>
+</xsl:template>
+
 <xsl:template match="exercisegroup/introduction">
     <xsl:text>\par\noindent </xsl:text>
     <xsl:apply-templates select="*" />
@@ -2584,6 +2593,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="console-typeout" />
     <xsl:text>\bigbreak&#xa;</xsl:text>
     <xsl:apply-templates select="*" />
+</xsl:template>
+
+<!-- webwork conclusions forego the \bigbreak  -->
+<!-- To stand apart, a medskip and noindent    -->
+<xsl:template match="conclusion[preceding-sibling::webwork]">
+    <xsl:apply-templates select="." mode="console-typeout" />
+    <xsl:text>\medskip\noindent </xsl:text>
+    <xsl:apply-templates select="*" />
+    <xsl:text>\par&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="exercisegroup/conclusion">
@@ -2909,7 +2927,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Top-down structure -->
 <!-- Basic outline of a simple problem -->
 <xsl:template match="webwork[child::statement]">
-    <xsl:text>\par&#xa;</xsl:text>
     <xsl:apply-templates select="statement" />
     <xsl:apply-templates select="hint" />
     <xsl:apply-templates select="solution" />
@@ -2940,10 +2957,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="webwork//statement">
     <xsl:text>\noindent%&#xa;</xsl:text>
     <xsl:choose>
-        <xsl:when test="parent::webwork">
-            <xsl:text>\textbf{Problem.}\quad </xsl:text>
+        <xsl:when test="parent::stage and count(parent::stage/preceding-sibling::stage)=0">
+            <xsl:text>\par\noindent%&#xa;</xsl:text>
+            <xsl:text>\textbf{Part </xsl:text>
+            <xsl:number count="stage" from="webwork" />
+            <xsl:text>.}\quad </xsl:text>
         </xsl:when>
         <xsl:when test="parent::stage">
+            <xsl:text>\medskip\noindent%&#xa;</xsl:text>
             <xsl:text>\textbf{Part </xsl:text>
             <xsl:number count="stage" from="webwork" />
             <xsl:text>.}\quad </xsl:text>
@@ -2955,7 +2976,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- default template, for solution -->
 <xsl:template match="webwork//solution">
-    <xsl:text>\noindent%&#xa;</xsl:text>
+    <xsl:text>\medskip\noindent%&#xa;</xsl:text>
     <xsl:text>\textbf{Solution.}\quad </xsl:text>
     <xsl:apply-templates />
     <xsl:text>\par&#xa;</xsl:text>
@@ -2963,7 +2984,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- default template, for hint -->
 <xsl:template match="webwork//hint">
-    <xsl:text>\noindent%&#xa;</xsl:text>
+    <xsl:text>\medskip\noindent%&#xa;</xsl:text>
     <xsl:text>\textbf{Hint.}\quad </xsl:text>
     <xsl:apply-templates />
     <xsl:text>\par&#xa;</xsl:text>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -3067,7 +3067,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- ############################# -->
-<!-- WeBWork Problems from Servers -->
+<!-- WeBWorK Problems from Servers -->
 <!-- ############################# -->
 
 <!-- @source, in an otherwise empty "webwork" element,     -->
@@ -3101,9 +3101,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$server-tex/statement|$server-tex/solution|$server-tex/hint" />
     <xsl:text>}</xsl:text>
     <xsl:text>\par\vspace*{2ex}%&#xa;</xsl:text>
-    <xsl:text>{\tiny\ttfamily\noindent&#xa;</xsl:text>
+    <xsl:text>{\tiny\ttfamily\noindent\url{</xsl:text>
     <xsl:value-of select="@source" />
-    <xsl:text>\\</xsl:text>
+    <xsl:text>}\\</xsl:text>
     <!-- seed will round-trip through mbx script, default -->
     <!-- is hard-coded there.  It comes back as an        -->
     <!-- attribute of the overall "webwork-tex" element   -->

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -22,6 +22,8 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="str"
 >
 
 <!-- This file is a library of routines to convert parts of      -->
@@ -1645,6 +1647,105 @@
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
+
+<!-- Numbers, units, quantities                     -->
+<!-- quantity                                       -->
+<xsl:template match="quantity">
+    <!-- warning if there is no content -->
+    <xsl:if test="not(descendant::unit) and not(descendant::per) and not(descendant::mag)">
+        <xsl:message terminate="no">
+        <xsl:text>MBX:WARNING: magnitude or units needed</xsl:text>
+        </xsl:message>
+    </xsl:if>
+    <!-- print magnitude if there is one -->
+    <xsl:if test="descendant::mag">
+        <xsl:apply-templates select="mag"/>
+        <!-- if the units that follow are fractional, space -->
+        <xsl:if test="descendant::per">
+            <xsl:text> </xsl:text>
+        </xsl:if>
+    </xsl:if>
+    <!-- if there are non-fracitonal units, print them -->
+    <xsl:if test="descendant::unit and not(descendant::per)">
+        <xsl:apply-templates select="unit" />
+    </xsl:if>
+    <!-- if there are fracitonal units with a numerator part, print them -->
+    <xsl:if test="descendant::unit and descendant::per">
+        <sup> <xsl:apply-templates select="unit" /> </sup>
+        <xsl:text>/</xsl:text>
+        <sub> <xsl:apply-templates select="per" /> </sub>
+    </xsl:if>
+    <!-- if there are fracitonal units without a numerator part, print them -->
+    <xsl:if test="not(descendant::unit) and descendant::per">
+        <sup> <xsl:text>1</xsl:text></sup>
+        <xsl:text>/</xsl:text>
+        <sub> <xsl:apply-templates select="per" /> </sub>
+    </xsl:if>
+</xsl:template>
+
+<!-- Magnitude                                      -->
+<xsl:template match="mag">
+    <xsl:variable name="mag">
+        <xsl:apply-templates />
+    </xsl:variable>
+    <xsl:value-of select="str:replace($mag,'\pi','\(\pi\)')"/>
+</xsl:template>
+
+<!-- unit and per children of a quantity element    -->
+<!-- have a mandatory base attribute                -->
+<!-- may have prefix and exp attributes             -->
+<!-- base and prefix are not abbreviations          -->
+
+<xsl:key name="prefix-key" match="prefix" use="concat(../@name, @full)"/>
+<xsl:key name="base-key" match="base" use="concat(../@name, @full)"/>
+
+<xsl:template match="unit|per">
+    <xsl:if test="not(parent::quantity)">
+        <xsl:message>MBX:WARNING: unit or per element should have parent quantity element</xsl:message>
+    </xsl:if>
+    <!-- if the unit is 1st and no mag, no need for space. Otherwise, give space -->
+    <xsl:if test="position() != 1 or (local-name(.)='unit' and (preceding-sibling::mag or following-sibling::mag) and not(preceding-sibling::per or following-sibling::per))">
+        <xsl:text> </xsl:text>
+    </xsl:if>
+    <!-- prefix is optional -->
+    <xsl:if test="@prefix">
+        <xsl:variable name="prefix">
+            <xsl:value-of select="@prefix" />
+        </xsl:variable>
+        <xsl:variable name="short">
+            <xsl:for-each select="document('mathbook-units.xsl')">
+                <xsl:value-of select="key('prefix-key',concat('prefixes',$prefix))/@short"/>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:value-of select="$short" />
+    </xsl:if>
+    <!-- base unit is *mandatory* so check to see if it has been provided -->
+    <xsl:choose>
+        <xsl:when test="@base">
+            <xsl:variable name="base">
+                <xsl:value-of select="@base" />
+            </xsl:variable>
+            <xsl:variable name="short">
+                <xsl:for-each select="document('mathbook-units.xsl')">
+                    <xsl:value-of select="key('base-key',concat('bases',$base))/@short"/>
+                </xsl:for-each>
+            </xsl:variable>
+            <xsl:value-of select="$short" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message terminate="no">
+                <xsl:text>MBX:WARNING: base unit needed</xsl:text>
+            </xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+    <!-- exponent is optional -->
+    <xsl:if test="@exp">
+        <sup><xsl:value-of select="@exp"/></sup>
+    </xsl:if>
+</xsl:template>
+
+
+
 
 <!-- ################# -->
 <!-- Utility Templates -->


### PR DESCRIPTION
New attempt at #440.

Latest commit addresses two non-WeBWorK issues, but they were too trivial and I was too lazy to make a new branch. One issue is that the unit list in the DTD wasn't in the same order as mathbook-units.xsl. My fault from when I added those extra time units about a month ago. The other issue was that kilometerperhour, kilometreperhour, and milepergallon had been removed from the DTD accidentally (I think) on the same day they had been added. See 9c1148c189bfed9de8541b5573622130a199c8ef and d0517a3f5a1b577a83ac1ac405287b66b886fc44.