### PR TITLE
Rearrange order of units in DTD; replace those that disappeared

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -682,7 +682,7 @@
 
 <!ENTITY % prefix "yocto|zepto|atto|femto|pico|nano|micro|milli|centi|deci|deca|deka|hecto|kilo|mega|giga|tera|peta|exa|zetta|yotta">
 
-<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|millennium|century|decade|year|month|week|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|mileperhour|gallon">
+<!ENTITY % base "ampere|candela|kelvin|gram|meter|metre|mole|second|becquerel|gray|sievert|degreeCelsius|celsius|coulomb|henry|ohm|siemens|tesla|volt|weber|hertz|katal|joule|newton|pascal|watt|lumen|lux|radian|steradian|degree|arcminute|arcsecond|day|hour|minute|hectare|liter|litre|percent|degreeFahrenheit|fahrenheit|pound|foot|inch|yard|mile|millennium|century|decade|year|month|week|kilometerperhour|kilometreperhour|mileperhour|gallon|milepergallon">
 
 <!ELEMENT quantity   (mag*, unit*, per*)>
 


### PR DESCRIPTION
Two things: add back three units to the DTD that were accidentally cut. And put all units in the DTD in the same order as they appear in mathbook-units.xsl.