### PR TITLE
Fix typos in author guide

### DIFF
--- a/doc/author-guide/add-ons.xml
+++ b/doc/author-guide/add-ons.xml
@@ -22,7 +22,7 @@
     <section xml:id="add-on-search">
         <title>Search</title>
 
-        <p>Search facilities are enabled through <url ref="https://cse.google.com/cse">Google Custom Search Engine</url>.  Please, please report any discrepancies in the following instructions as the setup interface at Google changes out from underneath us.  These instructions are accurate as of 2016-12-12.</p>
+        <p>Search facilities are enabled through <url href="https://cse.google.com/cse">Google Custom Search Engine</url>.  Please, please report any discrepancies in the following instructions as the setup interface at Google changes out from underneath us.  These instructions are accurate as of 2016-12-12.</p>
 
         <p>Besides being useful for search facilities, setting up a search engine might be a good way to alert Google of something newly available, and initiate your book's rise up the search results rankings.</p>
 
@@ -32,7 +32,7 @@
             <ol>
                 <li><p>Create an account with Google (GMail, YouTube, <etc />) and make sure you are signed in.</p></li>
 
-                <li><p>Visit <url ref="https://cse.google.com/cse">GCSE</url> and <c>Add</c> a new search engine of follow <c>New Search Engine</c>.</p></li>
+                <li><p>Visit <url href="https://cse.google.com/cse">GCSE</url> and <c>Add</c> a new search engine of follow <c>New Search Engine</c>.</p></li>
 
                 <li><p>Provide a <init>URL</init> for the top-level domain name/directory for your book/document.  Everything below this will be indexed.  We have taken some care to mark knowl content in a way compatible with the search facility, but there is more work to do here.</p></li>
 


### PR DESCRIPTION
Links in posted HTML author guide were not working. Tracked it to these typos.