### PR TITLE
Add PGML line breaks before list and after image

### DIFF
--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -719,6 +719,8 @@
         <xsl:text>"!</xsl:text>
     </xsl:if>
     <xsl:text>)@]* </xsl:text>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <!-- We need to override the HTML template that  -->
@@ -1117,6 +1119,7 @@
 
 <!-- Implement PGML unordered lists -->
 <xsl:template match="webwork//ul|webwork//ol">
+    <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates />
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>


### PR DESCRIPTION
These are needed to fix a pressing issue with the MT Hood project. 

The main one is putting a line break at the start of a list. If there is a p with text content and then a list, it fails to build the list correctly without this line break.

The other change is putting line breaks following the image command. Without this there are instances of a sentence that should be starting on a new line starting to the right of an image. The same pair of line breaks is already there for tabular, so this also makes image parallel to tabular in this way.