### PR TITLE
Webwork212 2

### DIFF
--- a/doc/author-guide/webwork.xml
+++ b/doc/author-guide/webwork.xml
@@ -12,12 +12,12 @@
     <author>Alex Jordan</author>
 
     <introduction>
-        <p>With a <webwork /> server (version 2.11 or higher) and a little setup work, you can embed <webwork /> exercises in your MBX project. HTML output will have interactive problem cells. PDF output will contain static versions of exercises. And all such exercises can be archived by the <c>mbx</c> script into a file tree to be uploaded onto the <webwork /> server for use in the <q>traditional</q> way.</p>
+        <p>With a <webwork /> server (version 2.12 or higher, limited support with 2.11) and a little setup work, you can embed <webwork /> exercises in your MBX project. HTML output will have interactive problem cells. PDF output will contain static versions of exercises. And all such exercises can be archived by the <c>mbx</c> script into a file tree to be uploaded onto the <webwork /> server for use in the <q>traditional</q> way.</p>
     </introduction>
 
     <section>
         <title>Configuring a <webwork /> Course for MBX</title>
-        <p>We assume a mild familiarity with administrating a <webwork /> server. The version of <webwork /> needs to be 2.11 or later for use with MBX. Using the <c>admin</c> course, create a course named <c>anonymous</c>. In the course's Course Configuration menu, set all permissions to <c>admin</c> (or perhaps set some to the even more restrictive <c>nobody</c>). Except set <q>Allowed to login to the course</q> to <c>login_proctor</c>.</p>
+        <p>We assume a mild familiarity with administrating a <webwork /> server. The version of <webwork /> needs to be 2.12 or later for use with MBX, although with version 2.11 all features should function except for latex output with server-based problems (see <xref ref="subsection-webwork-latex">Subsection</xref>. Using the <c>admin</c> course, create a course named <c>anonymous</c>. In the course's Course Configuration menu, set all permissions to <c>admin</c> (or perhaps set some to the even more restrictive <c>nobody</c>). Except set <q>Allowed to login to the course</q> to <c>login_proctor</c>.</p>
         <p>In the Classlist Editor, add a user named <c>anonymous</c>, and set that user's permission level to <c>login_proctor</c>, the permission level one higher than <c>student</c>. Set that user's password to <c>anonymous</c>. Note that because this is public information, anyone will be able to log into this course as user <c>anonymous</c>. This is why setting the permissions earlier is very important. (Especially preventing this user from changing its own password.)</p>
         <p>Add the following lines to the <c>course.conf</c> file (which lives in the parent folder of the <c>templates/</c> folder.)</p>
         <pre>
@@ -28,12 +28,6 @@
         <p>In the <c>templates/macros/</c> folder, edit <c>PGcourse.pl</c> (or create it if need be) and add the lines:</p>
         <pre>
         <![CDATA[
-        #### Suppress beginproblem from giving problem number, etc.
-        sub beginproblem {
-            my $out = MODES(%{main::PG_restricted_eval(q!$main::problemPreamble!)});
-            $out;
-        };
-
         #### Replace essay boxes with a message
         sub essay_box {
             my $out = MODES(
@@ -51,7 +45,9 @@
         sub essay_help {};
 
         #### How many attempts until hint is available
-        $showHint = 0;
+        $showHint = -1;
+        # May be a bug that WeBWorK requires -1 instead of 0
+        # for immediate access to hints
 
         1;
         ]]>
@@ -211,7 +207,7 @@
 
         <subsection xml:id="subsection-webwork-latex">
             <title><latex /> output</title>
-            <p>If your project uses PG files that live on the <webwork /> server, or if you have <tag>webwork</tag> tags that have image creation code in their <tag>pg-code</tag> tag, then you will need to retrieve <latex /> chunks from the server before you use <c>xsltproc</c>. The <c>mbx</c> script handles this:</p>
+            <p>If your project uses PG files that live on the <webwork /> server, or if you have <tag>webwork</tag> tags that have image creation code in their <tag>pg-code</tag> tag, then you will need to retrieve <latex /> chunks from the server before you use <c>xsltproc</c>. The <c>mbx</c> script handles this, but only for <webwork /> 2.12 and later:</p>
             <console>
                 <prompt>$ </prompt>
                 <input>mbx -c webwork-tex -s https://webwork.myschool.edu -d &lt;storage location&gt; &lt;xml&gt;</input> 

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -949,7 +949,7 @@
                             </image>
                         </figure>
 
-                        <p><m>x=</m> <var name="$answer"/></p>
+                        <p><m>x=</m> <var name="$answer" width="5"/></p>
                     </statement>
 
                     <solution>
@@ -1226,6 +1226,53 @@
 
             </exercise>
 
+        </section>
+
+        <section>
+            <title>Stress Tests</title>
+
+            <exercise>
+                <title>MBX problem source with server-generated images</title>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                            for my $i(0..7){$gr[$i] = init_graph(-1,-1,4,4,axes=>[0,0],grid=>[5,5],size=>[150,150]);};
+                            add_functions($gr[0], "1 for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[1], "x for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[2], "x^2 for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[3], "x^3 for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[4], "e^x for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[5], "sin(x) for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[6], "cos(x) for x in &lt;-1,4> using color:blue and weight:2");
+                            add_functions($gr[7], "exp(-x^2) for x in &lt;-1,4> using color:blue and weight:2");
+                        </pg-code>
+                    </setup>
+                    <stage>
+                        <statement>
+                            <figure><image pg-name="$gr[0]" width="150" height="150" tex_size="150"/></figure>
+                            <figure><image pg-name="$gr[1]" width="150" height="150" tex_size="150"/></figure>
+                        </statement>
+                        <solution>
+                            <figure><image pg-name="$gr[2]" width="150" height="150" tex_size="150"/></figure>
+                        </solution>
+                    </stage>
+                    <stage>
+                        <statement>
+                            <figure><image pg-name="$gr[3]" width="150" height="150" tex_size="150"/></figure>
+                            <figure><image pg-name="$gr[4]" width="150" height="150" tex_size="150"/></figure>
+                            <figure><image pg-name="$gr[5]" width="150" height="150" tex_size="150"/></figure>
+                        </statement>
+                        <!-- No hints for now because with displayMode=tex, the anonymous problem rendering is not -->
+                        <!--generating a hints section at all. Will have to work with Mike to investigate this.    -->
+                        <!--<hint>
+                            <figure><image pg-name="$gr[6]" width="150" height="150" tex_size="150"/></figure>
+                        </hint>-->
+                        <solution>
+                            <figure><image pg-name="$gr[7]" width="150" height="150" tex_size="150"/></figure>
+                        </solution>
+                  </stage>
+                </webwork>
+            </exercise>
         </section>
 
     </article>

--- a/script/mbx
+++ b/script/mbx
@@ -354,22 +354,6 @@ def webwork_to_tex(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_
         end = end_marker.split(content, maxsplit=1)
         tex_only = end[0]
 
-        # There is a problem header we'd prefer not to see
-        # When enmeshed in some TeX macros, we need remove it
-        # Pattern is based on:
-        #
-        # {\bf 13. {\footnotesize (1 point) \path|Library/....pg|}}\newline
-        #
-        header_pattern = re.compile(r'{\\bf.*\\path\|.*\|}}\\newline')
-        head_match = header_pattern.search(tex_only)
-        if head_match:
-            tex_only = tex_only.replace(head_match.group(), '%mbx script removed problem header\n')
-
-        # Some tex that causes compilation errors
-        # Ends with comment, so no extra newline inserted
-        tex_only = tex_only.replace('\\vadjust{\kern3pt}%',
-                                    '\\leavevmode\\vadjust{\kern3pt}% mbx script adjusted')
-
         # need to loop through content looking for images with pattern:
         #
         #   \includegraphics[<width-spec>]{(base-graphic-filename).(file-extension)}
@@ -413,7 +397,8 @@ def webwork_to_tex(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_
         problem_start = r'<webwork-tex seed="{}">'.format(seed)
         problem_end = r'</webwork-tex>'
 
-        preamble_end_pattern = re.compile(r'%%% END beginproblem\(\)')
+        preamble_begin_pattern = re.compile(r'%%% BEGIN PROBLEM PREAMBLE')
+        preamble_end_pattern = re.compile(r'%%% END PROBLEM PREAMBLE')
         preamble_start = r'<preamble>'
         preamble_end = r'</preamble>'
 
@@ -474,6 +459,9 @@ def webwork_to_tex(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_
                 elif end_pattern.search(line):
                     balanced = True
                 xml_lines.append(line)
+        # if we made it to the end unbalanced, need to close statement
+        if not(balanced):
+            xml_lines.append(statement_end)
         xml_lines.append(problem_end)
 
         # place modified LaTeX as XML in a file in destination directory

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1538,6 +1538,104 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\setlength{\fboxsep}{-1pt}&#xa;</xsl:text>
     </xsl:if>
 
+    <!-- PGML definitions. What follows is the PGML problem preamble in its entirety, taken from  -->
+    <!-- https://github.com/openwebwork/pg/blob/master/macros/PGML.pl. However some lines are     -->
+    <!-- commented out, as they clash with MBX LaTeX.                                             -->
+    <xsl:if test="//webwork[@source]">
+        <xsl:text>%% PGML macros&#xa;</xsl:text>
+        <xsl:text>%% formatted to exactly match output from PGML.pl as of 11/22/2016&#xa;</xsl:text>
+        <xsl:text>%% but with some lines commented out&#xa;</xsl:text>
+        <xsl:text>%\ifx\pgmlMarker\undefined&#xa;</xsl:text>
+        <xsl:text>%  \newdimen\pgmlMarker \pgmlMarker=0.00314159pt  % hack to tell if \newline was used&#xa;</xsl:text>
+        <xsl:text>%\fi&#xa;</xsl:text>
+        <xsl:text>%\ifx\oldnewline\undefined \let\oldnewline=\newline \fi&#xa;</xsl:text>
+        <xsl:text>%\def\newline{\oldnewline\hskip-\pgmlMarker\hskip\pgmlMarker\relax}%&#xa;</xsl:text>
+        <xsl:text>%\parindent=0pt&#xa;</xsl:text>
+        <xsl:text>%\catcode`\^^M=\active&#xa;</xsl:text>
+        <xsl:text>%\def^^M{\ifmmode\else\fi\ignorespaces}%  skip paragraph breaks in the preamble&#xa;</xsl:text>
+        <xsl:text>%\def\par{\ifmmode\else\endgraf\fi\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>%\ifdim\lastskip=\pgmlMarker&#xa;</xsl:text>
+        <xsl:text>%  \let\pgmlPar=\relax&#xa;</xsl:text>
+        <xsl:text>% \else&#xa;</xsl:text>
+        <xsl:text>  \let\pgmlPar=\par&#xa;</xsl:text>
+        <xsl:text>%  \vadjust{\kern3pt}%&#xa;</xsl:text>
+        <xsl:text>%\fi&#xa;</xsl:text>
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%&#xa;</xsl:text>
+        <xsl:text>%%&#xa;</xsl:text>
+        <xsl:text>%%    definitions for PGML&#xa;</xsl:text>
+        <xsl:text>%%&#xa;</xsl:text>
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>%\ifx\pgmlCount\undefined  % do not redefine if multiple files load PGML.pl&#xa;</xsl:text>
+        <xsl:text>  \newcount\pgmlCount&#xa;</xsl:text>
+        <xsl:text>  \newdimen\pgmlPercent&#xa;</xsl:text>
+        <xsl:text>  \newdimen\pgmlPixels  \pgmlPixels=.5pt&#xa;</xsl:text>
+        <xsl:text>%\fi&#xa;</xsl:text>
+        <xsl:text>%\pgmlPercent=.01\hsize&#xa;</xsl:text>
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlSetup{%&#xa;</xsl:text>
+        <xsl:text>  \parskip=0pt \parindent=0pt&#xa;</xsl:text>
+        <xsl:text>%  \ifdim\lastskip=\pgmlMarker\else\par\fi&#xa;</xsl:text>
+        <xsl:text>  \pgmlPar&#xa;</xsl:text>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlIndent{\par\advance\leftskip by 2em \advance\pgmlPercent by .02em \pgmlCount=0}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlbulletItem{\par\indent\llap{$\bullet$ }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlcircleItem{\par\indent\llap{$\circ$ }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlsquareItem{\par\indent\llap{\vrule height 1ex width .75ex depth -.25ex\ }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlnumericItem{\par\indent\advance\pgmlCount by 1 \llap{\the\pgmlCount. }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlalphaItem{\par\indent{\advance\pgmlCount by `\a \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlAlphaItem{\par\indent{\advance\pgmlCount by `\A \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlromanItem{\par\indent\advance\pgmlCount by 1 \llap{\romannumeral\pgmlCount. }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlRomanItem{\par\indent\advance\pgmlCount by 1 \llap{\uppercase\expandafter{\romannumeral\pgmlCount}. }\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlCenter{%&#xa;</xsl:text>
+        <xsl:text>  \par \parfillskip=0pt&#xa;</xsl:text>
+        <xsl:text>  \advance\leftskip by 0pt plus .5\hsize&#xa;</xsl:text>
+        <xsl:text>  \advance\rightskip by 0pt plus .5\hsize&#xa;</xsl:text>
+        <xsl:text>  \def\pgmlBreak{\break}%&#xa;</xsl:text>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlRight{%&#xa;</xsl:text>
+        <xsl:text>  \par \parfillskip=0pt&#xa;</xsl:text>
+        <xsl:text>  \advance\leftskip by 0pt plus \hsize&#xa;</xsl:text>
+        <xsl:text>  \def\pgmlBreak{\break}%&#xa;</xsl:text>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlBreak{\\}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlHeading#1{%&#xa;</xsl:text>
+        <xsl:text>  \par\bfseries&#xa;</xsl:text>
+        <xsl:text>  \ifcase#1 \or\huge \or\LARGE \or\large \or\normalsize \or\footnotesize \or\scriptsize \fi&#xa;</xsl:text>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlRule#1#2{%&#xa;</xsl:text>
+        <xsl:text>  \par\noindent&#xa;</xsl:text>
+        <xsl:text>  \hbox{%&#xa;</xsl:text>
+        <xsl:text>    \strut%&#xa;</xsl:text>
+        <xsl:text>    \dimen1=\ht\strutbox%&#xa;</xsl:text>
+        <xsl:text>    \advance\dimen1 by -#2%&#xa;</xsl:text>
+        <xsl:text>    \divide\dimen1 by 2%&#xa;</xsl:text>
+        <xsl:text>    \advance\dimen2 by -\dp\strutbox%&#xa;</xsl:text>
+        <xsl:text>    \raise\dimen1\hbox{\vrule width #1 height #2 depth 0pt}%&#xa;</xsl:text>
+        <xsl:text>  }%&#xa;</xsl:text>
+        <xsl:text>  \par&#xa;</xsl:text>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>\def\pgmlIC#1{\futurelet\pgmlNext\pgmlCheckIC}%&#xa;</xsl:text>
+        <xsl:text>\def\pgmlCheckIC{\ifx\pgmlNext\pgmlSpace \/\fi}%&#xa;</xsl:text>
+        <xsl:text>{\def\getSpace#1{\global\let\pgmlSpace= }\getSpace{} }%&#xa;</xsl:text>
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>%{\catcode`\ =12\global\let\pgmlSpaceChar= }%&#xa;</xsl:text>
+        <xsl:text>%{\obeylines\gdef\pgmlPreformatted{\par\small\ttfamily\hsize=10\hsize\obeyspaces\obeylines\let^^M=\pgmlNL\pgmlNL}}%&#xa;</xsl:text>
+        <xsl:text>%\def\pgmlNL{\par\bgroup\catcode`\ =12\pgmlTestSpace}%&#xa;</xsl:text>
+        <xsl:text>%\def\pgmlTestSpace{\futurelet\next\pgmlTestChar}%&#xa;</xsl:text>
+        <xsl:text>%\def\pgmlTestChar{\ifx\next\pgmlSpaceChar\ \pgmlTestNext\fi\egroup}%&#xa;</xsl:text>
+        <xsl:text>%\def\pgmlTestNext\fi\egroup#1{\fi\pgmlTestSpace}%&#xa;</xsl:text>
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>%\def^^M{\ifmmode\else\space\fi\ignorespaces}%&#xa;</xsl:text>
+        <xsl:text>%% END PGML macros&#xa;</xsl:text>
+    </xsl:if>
+
 </xsl:template>
 
 <!-- Tack in a graphic with initials                   -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -3126,7 +3126,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Here, we just provide a light wrapper, and drop an    -->
 <!-- include, since the basename for the filenames has     -->
 <!-- been managed by the  mbx  script to be predictable.   -->
-<xsl:template match="webwork[@source]|webwork[descendant::image[@pg-name]]">
+<xsl:template match="webwork[@source]">
     <!-- directory of server LaTeX must be specified -->
     <xsl:if test="$webwork.server.latex = ''">
         <xsl:message terminate="yes">MBX:ERROR   For LaTeX versions of WeBWorK problems on a server, the mbx script will collect the LaTeX source and then this conversion must specify the location through the "webwork.server.latex" command line stringparam.  Quitting...</xsl:message>
@@ -3144,7 +3144,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="introduction" /> <!-- before boxed problem -->
     <xsl:text>\begin{mdframed}&#xa;</xsl:text>
     <xsl:text>{</xsl:text> <!-- prophylactic wrapper -->
-    <xsl:value-of select="$server-tex/preamble" />
+    <!-- mbx script collects problem preamble, but we do not use it here -->
     <!-- process in the order server produces them, may be several -->
     <xsl:apply-templates select="$server-tex/statement|$server-tex/solution|$server-tex/hint" />
     <xsl:text>}</xsl:text>
@@ -3181,6 +3181,44 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates />
     </xsl:if>
 </xsl:template>
+
+<!-- ############################# -->
+<!-- WeBWorK Images   from Servers -->
+<!-- ############################# -->
+
+<!-- When a webwork exercise is written in MBX source, but -->
+<!-- uses an image with an @pg-name, we make the exercise  -->
+<!-- in the usual way but include an image which has been  -->
+<!-- created by the mbx script with a predictable name     -->
+<!-- For such images, width and height are pixel counts    -->
+<!-- sent to the PG image creator, intended to define the  -->
+<!-- width of HTML output. A separate tex_size is intended -->
+<!-- to define width of LaTeX output. tex_size of say 800  -->
+<!-- means 0.800\linewidth. We use 400px for the default   -->
+<!-- width in mathbook-webwork-pg. Since 600px is the      -->
+<!-- default design width in html, we use 667 as the       -->
+<!-- default for tex_size                                  -->
+
+<xsl:template match="webwork//image[@pg-name]">
+    <xsl:text>\includegraphics[width=</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@tex_size">
+            <xsl:value-of select="@tex_size*0.001"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>0.667</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>\linewidth]{</xsl:text>
+        <!-- assumes path has trailing slash -->
+        <xsl:value-of select="$webwork.server.latex" />
+        <xsl:apply-templates select="ancestor::webwork" mode="internal-id" />
+        <xsl:text>-image-</xsl:text>
+        <xsl:number count="webwork//image[@pg-name]" from="webwork" level="any" />
+        <xsl:text>.png</xsl:text>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
 
 <!-- Remark Like, Example Like, Project Like -->
 <!-- Simpler than theorems, definitions, etc            -->

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -317,7 +317,7 @@
             <xsl:text>  "PGessaymacros.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- when there is a PGgraphmacros graph -->
-        <xsl:if test="./statement//image[@pg-name]|./solution//image[@pg-name]">
+        <xsl:if test=".//image[@pg-name]">
             <xsl:text>  "PGgraphmacros.pl",&#xa;</xsl:text>
         </xsl:if>
         <!-- ################### -->
@@ -438,7 +438,7 @@
     <xsl:value-of select="$course-macro" />
     <xsl:text>);&#xa;</xsl:text>
     <!-- if images are used, explicitly refresh or stale images will be used in HTML -->
-    <xsl:if test="./statement//image[@pg-name]|./solution//image[@pg-name]">
+    <xsl:if test=".//image[@pg-name]">
         <xsl:text>$refreshCachedImages= 1;</xsl:text>
     </xsl:if>
     <!-- shorten name of PGML::Format to save characters for base64 url -->


### PR DESCRIPTION
Now with `xsl:number`.

One thing that might raise an eyebrow is removing lines 357--372 of the mbx script. These two things are not necessary with 2.12 and above, and we now indicate in the author guide that with 2.11, server tex problems were never truly an option (since I never made the appropriate PR to WeBWorK.)

One of these things comes from the PGML preamble, and is commented out in the new block pf PGML preamble code. The other thing comes from a WeBWorK subroutine which now (appropriately) does nothing when the problem is called via the anonymous route.

Some things were formerly not accounting for stages, hence certain changes in `mathbook-webwork-pg.xsl`.

Thanks for your patience and careful reviewing.