### PR TITLE
Document perl-free WeBWorK problems

### DIFF
--- a/doc/author-guide/webwork.xml
+++ b/doc/author-guide/webwork.xml
@@ -95,10 +95,51 @@
 
         <subsection>
             <title>Perl-free Problems</title>
-            <p>Planned.</p>
+            <p>If you'd just like to rattle off a quick question with no randomization, you can do as in this example:</p>
+            <pre>
+            <![CDATA[
+            <exercise>
+                <webwork>
+                    <statement>
+                        <p><m>1+2=</m><var name="3" width="5" /></p>
+                    </statement>
+                </webwork>
+            </exercise>
+            ]]>
+            </pre>
+
+            <p>The above example could be given an optional title, introduction, conclusion, hint, and solution. These are discussed in <xref ref="subsection-pg-code">Subsection</xref>.</p>
+
+            <p>In the above example, <c>"3"</c> is the <attribute>name</attribute> attribute to a <tag>var</tag> element. This is how to create an answer blank that is expecting <m>3</m> as the answer. What you give as a <attribute>name</attribute> attribute will be passed as a string to PG's <c>Compute()</c> command, so it needs to be valid input for <c>Compute()</c>. It should <em>not</em> begin with a <c>$</c>.</p>
+
+            <p>The default context is <c>Numeric</c>, which understands numerical expressions and formulaic expressions in the variable <m>x</m>. You can activate some other context as in this example:</p>
+            <pre>
+            <![CDATA[
+            <exercise>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                            Context("ImplicitPlane");
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p>The answer is <m>x+y=1</m>.</p>
+                        <p><var name="x+y=1" width="8" /></p>
+                    </statement>
+                </webwork>
+            </exercise>
+            ]]>
+            </pre>
+
+            <p>Many special contexts are automatically detected by MBX, and it loads the appropriate macro file into the PG problem. However you may need to explicitly load a macro file as described in <xref ref="subsection-pg-code">Subsection</xref>.</p>
+
+            <p>You should only use this (nearly) perl-free shortcut if the <attribute>name</attribute> attribute could be put in math mode and simultaneously serve as a printed answer in something like a solutions manual. In the above two examples, this is the case. But in a question with, say, <attribute>name="cos(x)/2"</attribute>, if you'd like the solutions manual to print using <c>\frac{\cos(x)}{2}</c>, then you should write the problem as described in <xref ref="subsection-pg-code">Subsection</xref>.</p>
+
+            <p>Additionally, in shortcutting around the structure described in <xref ref="subsection-pg-code">Subsection</xref>, you will not have access to certain other features, such as answer format help links.</p>
+
         </subsection>
 
-        <subsection>
+        <subsection xml:id="subsection-pg-code">
             <title>PG code in Problems</title>
             <p>To have randomization in problems or otherwise take advantage of the algorithmic programming capabilities of Perl and <webwork />'s PG language requires using a <tag>setup</tag> tag. Having at least a little familiarity with coding problems in <webwork /> is necessary, although for simpler problems you could get away with mimicking the sample article in <c>mathbook/examples/webwork/</c>. A <tag>statement</tag>, (optional) <tag>hint</tag>, and (optional) <tag>solution</tag> follow. The whole thing can have an optional <tag>title</tag>.</p> 
             <pre>
@@ -124,7 +165,7 @@
             ]]>
             </pre>
 
-            <p>The <tag>setup</tag> contains a section of <tag>var</tag> tags followed by a <tag>pg-code</tag>. If you are familiar with code for <webwork /> PG problems, the <tag>pg-code</tag> contains lines of PG code that would appear in the <q>setup</q> portion of the problem. Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>. If your code needs any special <webwork /> macro libraries, you may load them in a <tag>pg-macros</tag> tag prior to <tag>setup</tag>, with each such <c>.pl</c> file's name inside a <tag>macro-file</tag>. However many of the most common macro libraries will be loaded automatically based on the content and attributes you use in the rest of your problem.</p>
+            <p>The <tag>setup</tag> contains a section of <tag>var</tag> tags followed by a <tag>pg-code</tag>. If you are familiar with code for <webwork /> PG problems, the <tag>pg-code</tag> contains lines of PG code that would appear in the <q>setup</q> portion of the problem. Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>. If your code needs any special <webwork /> macro libraries, you may load them in a <tag>pg-macros</tag> tag prior to <tag>setup</tag>, with each such <c>.pl</c> file's name inside a <tag>macro-file</tag> tag. However many of the most common macro libraries will be loaded automatically based on the content and attributes you use in the rest of your problem.</p>
 
             <p>For each perl variable (scalar, array, or hash) that is used in the <tag>pg-code</tag> and which will <em>also</em> be used in the <tag>statement</tag>, <tag>solution</tag>, or as an answer to an answer blank, there should be a <tag>var</tag>. These <tag>var</tag> tags are primarily to help MBX handle static output, but they also allow for some optimal leveraging of <webwork /> features.</p>
 

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -474,7 +474,7 @@
 <xsl:template match="webwork//var" mode="static-warning">
     <xsl:variable name="varname" select="@name" />
     <xsl:variable name="problem" select="ancestor::webwork" />
-    <xsl:if test="not($problem/setup/var[@name=$varname]/static) and not($problem/setup/var[@name=$varname]/set/member) and not(@form='essay')">
+    <xsl:if test="substring($varname,1,1)='$' and not($problem/setup/var[@name=$varname]/static) and not($problem/setup/var[@name=$varname]/set/member) and not(@form='essay')">
         <xsl:message>
             <xsl:text>MBX:WARNING: A WeBWorK exercise uses a var (name="</xsl:text>
             <xsl:value-of select="$varname"/>


### PR DESCRIPTION
It's always been possible to take a shortcut and not use any perl in a pg-code section with a WW problem. This makes it official by describing how to do that, and giving the right warnings about doing things that way.

