### PR TITLE
Pgml indentation

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -248,11 +248,11 @@
 
                 <introduction>
                     <p>One of the strengths of <webwork /> is its ability to give intelligent feedback for incorrect answers.</p>
-                    <ul>
+                    <p><ul>
                         <li><p>There is general feedback for when the student's answer is in an entirely different ballpark from the correct answer. Try entering something like <q>y</q>.</p></li>
                         <li><p>There is general feedback for when the student's answer is not in the right form. Try entering <q>x<circumflex />2*x<circumflex />3</q>, which, right or wrong, is unsimplified.</p></li>
                         <li><p>And problems can be written to detect and respond to common mistakes. Try entering an answer where you multiply the two exponents (instead of adding them, which would be correct.)</p></li>
-                    </ul>
+                    </ul></p>
                 </introduction>
 
                 <webwork>
@@ -1011,24 +1011,24 @@
                     </setup>
 
                     <statement>
-                        <ol label="a.">
+                        <p><ol label="a.">
                             <li>
                                 <p>Suppose the correct answer is <m><var name="$answer1"/></m>.</p>
-                                <ul label="square">
+                                <p><ul label="square">
                                     <li>
                                         <p><var name="$answer1" width="15"/></p>
                                     </li>
-                                </ul>
+                                </ul></p>
                             </li>
                             <li>
                                 <p>Suppose the correct answer is <m>\displaystyle <var name="$answer2"/></m>.</p>
-                                <ul label="square">
+                                <p><ul label="square">
                                     <li>
                                         <p><var name="$answer2" width="15"/></p>
                                     </li>
-                                </ul>
+                                </ul></p>
                             </li>
-                        </ol>
+                        </ol></p>
 
                     </statement>
 
@@ -1062,24 +1062,24 @@
                     </setup>
 
                     <statement>
-                        <ol label="a.">
+                        <p><ol label="a.">
                             <li>
                                 <p>Suppose the correct answer is <m>\displaystyle <var name="$answer1"/></m>.</p>
-                                <ul label="square">
+                                <p><ul label="square">
                                     <li>
                                         <p><var name="$answer1" width="15"/></p>
                                     </li>
-                                </ul>
+                                </ul></p>
                             </li>
                             <li>
                                 <p>Suppose the correct answer is <m>\displaystyle <var name="$answer2"/></m>.</p>
-                                <ul label="square">
+                                <p><ul label="square">
                                     <li>
                                         <p><var name="$answer2" width="15" evaluator="$answer2evaluator"/></p>
                                     </li>
-                                </ul>
+                                </ul></p>
                             </li>
-                        </ol>
+                        </ol></p>
 
                     </statement>
 
@@ -1320,10 +1320,10 @@
                 </webwork>
             </exercise>
             <exercise>
+                <title>Has a Title</title>
                 <introduction>
                     <p>Has an introduction.</p>
                 </introduction>
-                <title>Has a Title</title>
                 <webwork>
                     <statement>
                         <p><m>1+1=2</m></p>
@@ -1365,10 +1365,10 @@
                 </conclusion>
             </exercise>
             <exercise>
+                <title>Has a Title</title>
                 <introduction>
                     <p>Has an introduction.</p>
                 </introduction>
-                <title>Has a Title</title>
                 <webwork>
                     <statement>
                         <p><m>1+1=2</m></p>
@@ -1405,10 +1405,10 @@
                     </webwork>
                 </exercise>
                 <exercise>
+                    <title>Has a Title</title>
                     <introduction>
                         <p>Has an introduction.</p>
                     </introduction>
-                    <title>Has a Title</title>
                     <webwork>
                         <statement>
                             <p><m>1+1=2</m></p>
@@ -1450,10 +1450,10 @@
                     </conclusion>
                 </exercise>
                 <exercise>
+                    <title>Has a Title</title>
                     <introduction>
                         <p>Has an introduction.</p>
                     </introduction>
-                    <title>Has a Title</title>
                     <webwork>
                         <statement>
                             <p><m>1+1=2</m></p>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1288,6 +1288,358 @@
                   </stage>
                 </webwork>
             </exercise>
+
+            <exercise>
+                <title>Checking Proper Indentation In Lists</title>
+                <webwork>
+                    <statement>
+                        <p><ol>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                        </ol></p>
+
+                        <p><ol>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                        </ol></p>
+
+                        <p>Text before.<ol>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                            <li>Simple item</li>
+                        </ol>And after.</p>
+
+                        <p><ol>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol></p>
+
+                        <p>Text before.<ol>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol>And after.</p>
+
+                        <p><ol>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p><ol label="a">
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                </ol></p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol></p>
+
+                        <p>Text before.<ol>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Text before.<ol label="a">
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                    </li>
+                                </ol>And after.</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol>And after.</p>
+
+                        <p>Note: some lists follow with second paragraphs in list items. While the PGML output by MBX appears to be in order, PGML does not process second paragraphs as intended when they are in a nest deeper than the outermost list. List numbering is interfered with. Either this is a bug with PGML, or PGML never intended to support second paragraphs in inner lists.</p>
+
+                        <p><ol>
+                            <li>
+                                <p>Structured item</p>
+                                <p>Second paragraph</p>
+                            </li>
+                            <li>
+                                <p><ol label="a">
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                </ol></p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                                <p>Second paragraph</p>
+                            </li>
+                        </ol></p>
+
+                        <p>Text before.<ol>
+                            <li>
+                                <p>Structured item</p>
+                                <p>Second paragraph</p>
+                            </li>
+                            <li>
+                                <p>Text before.<ol label="a">
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item</p>
+                                        <p>Second paragraph</p>
+                                    </li>
+                                </ol>And after.</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                                <p>Second paragraph</p>
+                            </li>
+                        </ol>And after.</p>
+
+                        <p><ol>
+                            <li>
+                                <p><me>1+1=2</me>Structured item</p>
+                                <p>Second<me>1+1=2</me> paragraph</p>
+                            </li>
+                            <li>
+                                <p><ol label="a">
+                                    <li>
+                                        <p>Sublist<me>1+1=2</me> Item</p>
+                                        <p>Second paragraph<me>1+1=2</me></p>
+                                    </li>
+                                    <li>
+                                        <p><me>1+1=2</me>Sublist Item</p>
+                                        <p>Second<me>1+1=2</me> paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item<me>1+1=2</me></p>
+                                        <p><me>1+1=2</me>Second paragraph</p>
+                                    </li>
+                                </ol></p>
+                            </li>
+                            <li>
+                                <p>Structured<me>1+1=2</me> item</p>
+                                <p>Second paragraph<me>1+1=2</me></p>
+                            </li>
+                        </ol></p>
+
+                        <p>Text before.<ol>
+                            <li>
+                                <p>Structured<me>1+1=2</me> item</p>
+                                <p>Second paragraph<me>1+1=2</me></p>
+                            </li>
+                            <li>
+                                <p><me>1+1=2</me>Text before.<ol label="a">
+                                    <li>
+                                        <p>Sublist<me>1+1=2</me> Item</p>
+                                        <p>Second paragraph<me>1+1=2</me></p>
+                                    </li>
+                                    <li>
+                                        <p><me>1+1=2</me>Sublist Item</p>
+                                        <p>Second<me>1+1=2</me> paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item<me>1+1=2</me></p>
+                                        <p><me>1+1=2</me>Second paragraph</p>
+                                    </li>
+                                </ol>And<me>1+1=2</me> after.</p>
+                            </li>
+                            <li>
+                                <p>Structured item<me>1+1=2</me></p>
+                                <p><me>1+1=2</me>Second paragraph</p>
+                            </li>
+                        </ol>And after.</p>
+
+                        <p>Text before.<ol>
+                            <li>
+                                <p>Structured<md>
+                                    <mrow>1+1\amp=2</mrow>
+                                    <mrow>2\amp=2</mrow>
+                                </md> item</p>
+                                <p>Second paragraph<md>
+                                    <mrow>1+1\amp=2</mrow>
+                                    <mrow>2\amp=2</mrow>
+                                </md></p>
+                            </li>
+                            <li>
+                                <p><md>
+                                    <mrow>1+1\amp=2</mrow>
+                                    <mrow>2\amp=2</mrow>
+                                </md>Text before.<ol label="a">
+                                    <li>
+                                        <p>Sublist<md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md> Item</p>
+                                        <p>Second paragraph<md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md></p>
+                                    </li>
+                                    <li>
+                                        <p><md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md>Sublist Item</p>
+                                        <p>Second<md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md> paragraph</p>
+                                    </li>
+                                    <li>
+                                        <p>Sublist Item<md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md></p>
+                                        <p><md>
+                                            <mrow>1+1\amp=2</mrow>
+                                            <mrow>2\amp=2</mrow>
+                                        </md>Second paragraph</p>
+                                    </li>
+                                </ol>And<md>
+                                <mrow>1+1\amp=2</mrow>
+                                <mrow>2\amp=2</mrow>
+                            </md> after.</p>
+                            </li>
+                            <li>
+                                <p>Structured item<md>
+                                    <mrow>1+1\amp=2</mrow>
+                                    <mrow>2\amp=2</mrow>
+                                </md></p>
+                                <p><md>
+                                    <mrow>1+1\amp=2</mrow>
+                                    <mrow>2\amp=2</mrow>
+                                </md>Second paragraph</p>
+                            </li>
+                        </ol>And after.</p>
+                    </statement>
+                </webwork>
+            </exercise>
+
+            <exercise>
+                <title>Checking Proper Indentation In Lists with Images and Tables</title>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                            $g=init_graph(0,0,1,1);
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p><ol>
+                            <li>
+                                <p>Structured item</p>
+                                <image pg-name="$g" width="100" height="100"/>
+                            </li>
+                            <li>
+                                <image pg-name="$g" width="100" height="100"/>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                                <image pg-name="$g" width="100" height="100"/>
+                                <p>Second paragraph</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol></p>
+
+                        <p><ol>
+                            <li>
+                                <p>Structured item</p>
+                                <tabular>
+                                    <row>
+                                        <cell>a</cell>
+                                        <cell>b</cell>
+                                    </row>
+                                    <row>
+                                        <cell>c</cell>
+                                        <cell>d</cell>
+                                    </row>
+                                </tabular>
+                            </li>
+                            <li>
+                                <tabular top="major" left="major" bottom="major" right="minor" halign="center">
+                                    <col halign="right" top="minor"/>
+                                    <col right="medium"/>
+                                    <col halign="left"/>
+                                    <row bottom="none" left="none">
+                                    <cell right="minor">1</cell>
+                                        <cell>two</cell>
+                                        <cell><m>\lfloor\pi\rfloor</m></cell>
+                                    </row>
+                                    <row valign="bottom">
+                                        <cell bottom="minor"><line><m>\text{I}+\text{I}</m></line><line><m>{}+\text{I}+\text{I}</m></line></cell>
+                                        <cell><m>5</m></cell>
+                                        <cell>six</cell>
+                                    </row>
+                                    <row halign="right">
+                                        <cell><m>2^3-1</m></cell>
+                                        <cell colspan="2" halign="center">VIII</cell>
+                                    </row>
+                                </tabular>
+                                <p>Structured item</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                                <tabular>
+                                    <row>
+                                        <cell>a</cell>
+                                        <cell>b</cell>
+                                    </row>
+                                    <row>
+                                        <cell>c</cell>
+                                        <cell>d</cell>
+                                    </row>
+                                </tabular>
+                                <p>Second paragraph</p>
+                            </li>
+                            <li>
+                                <p>Structured item</p>
+                            </li>
+                        </ol></p>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1640,6 +1640,54 @@
                     </statement>
                 </webwork>
             </exercise>
+
+            <exercise>
+                <title>Deep-nested lists</title>
+                <introduction>
+                    <p>Nesting lists deeper than a second level is known to result in enumeration issues, seen here. This is a PGML issue, not an MBX issue. Perhaps in the future PGML will be able to handle deep nested lists. However, this does demonstrate that (arabic, latin, roman, Latin) is the enumeration scheme, matching HTML and LaTeX.</p>
+                    <p>With unordered lists, there is also a PGML issue at depth 4 and deeper. The bullet cycle for HTML and LaTeX is (disc, circle, square, disc) but despite proper PGML output from MBX, the fourth level currently comes out as circle.</p>
+                </introduction>
+                <webwork>
+                    <statement>
+                        <p>Ordered list.</p>
+                        <p><ol>
+                            <li><p>Level 1, first.</p></li>
+                            <li><p>Level 1, second.<ol>
+                                <li><p>Level 2, first.</p></li>
+                                <li><p>Level 2, second.<ol>
+                                    <li><p>Level 3, first.</p></li>
+                                    <li><p>Level 3, second.<ol>
+                                        <li><p>Level 4, first.</p></li>
+                                        <li><p>Level 4, second.</p></li>
+                                        <li><p>Level 4, third.</p></li>
+                                    </ol></p></li>
+                                    <li><p>Level 3, third.</p></li>
+                                </ol></p></li>
+                                <li><p>Level 2, third.</p></li>
+                            </ol></p></li>
+                            <li><p>Level 1, third.</p></li>
+                        </ol></p>
+                        <p>Unordered list.</p>
+                        <p><ul>
+                            <li><p>Level 1, first.</p></li>
+                            <li><p>Level 1, second.<ul>
+                                <li><p>Level 2, first.</p></li>
+                                <li><p>Level 2, second.<ul>
+                                    <li><p>Level 3, first.</p></li>
+                                    <li><p>Level 3, second.<ul>
+                                        <li><p>Level 4, first.</p></li>
+                                        <li><p>Level 4, second.</p></li>
+                                        <li><p>Level 4, third.</p></li>
+                                    </ul></p></li>
+                                    <li><p>Level 3, third.</p></li>
+                                </ul></p></li>
+                                <li><p>Level 2, third.</p></li>
+                            </ul></p></li>
+                            <li><p>Level 1, third.</p></li>
+                        </ul></p>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -1161,7 +1161,13 @@
                 <xsl:when test="../@label='disc'">*</xsl:when>
                 <xsl:when test="../@label='circle'">o</xsl:when>
                 <xsl:when test="../@label='square'">+</xsl:when>
-                <xsl:otherwise>-</xsl:otherwise>
+                <xsl:otherwise>
+                    <xsl:choose>
+                        <xsl:when test="count(ancestor::ul) mod 3 = 1">*</xsl:when>
+                        <xsl:when test="count(ancestor::ul) mod 3 = 2">o</xsl:when>
+                        <xsl:when test="count(ancestor::ul) mod 3 = 0">+</xsl:when>
+                    </xsl:choose>
+                </xsl:otherwise>
             </xsl:choose>
             <xsl:text> </xsl:text>
         </xsl:when>
@@ -1172,7 +1178,14 @@
                 <xsl:when test="contains(../@label,'A')">A</xsl:when>
                 <xsl:when test="contains(../@label,'i')">i</xsl:when>
                 <xsl:when test="contains(../@label,'I')">I</xsl:when>
-                <xsl:otherwise>1</xsl:otherwise>
+                <xsl:otherwise>
+                    <xsl:choose>
+                        <xsl:when test="count(ancestor::ol) mod 4 = 1">1</xsl:when>
+                        <xsl:when test="count(ancestor::ol) mod 4 = 2">a</xsl:when>
+                        <xsl:when test="count(ancestor::ol) mod 4 = 3">i</xsl:when>
+                        <xsl:when test="count(ancestor::ol) mod 4 = 0">A</xsl:when>
+                    </xsl:choose>
+                </xsl:otherwise>
             </xsl:choose>
             <xsl:text>.  </xsl:text>
         </xsl:when>

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -684,6 +684,9 @@
 <!-- ####################### -->
 
 <xsl:template match="webwork//image[@pg-name]">
+    <xsl:if test="preceding-sibling::p|preceding-sibling::image|preceding-sibling::tabular">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
     <xsl:text>[@ image(insertGraph(</xsl:text>
     <xsl:value-of select="@pg-name"/>
     <xsl:text>), width=&gt;</xsl:text>
@@ -747,28 +750,19 @@
 <!-- issue a blank line to signify the break        -->
 <!-- If p is inside a list, special handling        -->
 <xsl:template match="webwork//p">
-    <xsl:if test="preceding-sibling::p">
-        <xsl:call-template name="duplicate-string">
-            <xsl:with-param name="count" select="4 * (count(ancestor::ul) + count(ancestor::ol))" />
-            <xsl:with-param name="text"  select="' '" />
-        </xsl:call-template>
+    <xsl:if test="preceding-sibling::p|preceding-sibling::image|preceding-sibling::tabular and not(child::*[1][self::ol] or child::*[1][self::ul])">
+        <xsl:call-template name="list-indent" />
     </xsl:if>
     <xsl:apply-templates />
-    <xsl:if test="parent::li and not(../following-sibling::li) and not(../following::*[1][self::li])">
+    <!-- If p is last thing in entire (maybe nested) list, explicitly terminate list with three spaces at end of line. -->
+    <xsl:if test="parent::li and not(following-sibling::*) and not(../following::*[1][self::li])">
         <xsl:text>   </xsl:text>
     </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
-</xsl:template>
-
-<!-- This construction in not valid MBX, can we do better? -->
-<!-- TODO: add an error message?, terminate?               -->
-<xsl:template match="webwork//p[@halign='center']">
-    <xsl:text>&gt;&gt; </xsl:text>
-    <xsl:apply-templates />
-    <xsl:text>&lt;&lt;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
+    <!-- Blank line required or PGML will treat two adjacent p as one -->
+    <xsl:if test="not(parent::li) or following-sibling::* or parent::li/following-sibling::*">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- ######### -->
@@ -803,14 +797,25 @@
 </xsl:template>
 
 <xsl:template match="webwork//me">
-    <xsl:text>&#xa;&#xa;>> [``</xsl:text>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:if test="ancestor::ul|ancestor::ol">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
+    <xsl:text>&gt;&gt; [``</xsl:text>
     <xsl:call-template name="select-latex-macros"/>
     <xsl:apply-templates select="text()|var" />
     <xsl:text>``] &lt;&lt;&#xa;&#xa;</xsl:text>
+    <xsl:if test="following-sibling::text()[normalize-space()] or following-sibling::*">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="webwork//md">
-    <xsl:text>&#xa;&#xa;&gt;&gt; </xsl:text>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+        <xsl:if test="ancestor::ul|ancestor::ol">
+            <xsl:call-template name="list-indent" />
+        </xsl:if>
+    <xsl:text>&gt;&gt; </xsl:text>
     <xsl:choose>
         <xsl:when test="contains(., '&amp;') or contains(., '\amp')">
             <xsl:text>[``</xsl:text>
@@ -828,9 +833,15 @@
         </xsl:otherwise>
     </xsl:choose>
     <xsl:text> &lt;&lt;&#xa;&#xa;</xsl:text>
+    <xsl:if test="following-sibling::text()[normalize-space()] or following-sibling::*">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="webwork//md/mrow">
+    <xsl:if test="ancestor::ul|ancestor::ol">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
     <xsl:apply-templates select="text()|var" />
     <xsl:if test="position()!=last()">
        <xsl:text>\\</xsl:text>
@@ -897,6 +908,8 @@
 
 <!-- two spaces at line-end makes a newline in PGML-->
 <xsl:template match="webwork//cell/line">
+    <!-- This leads to lines of PG code that would ideally be indented for human readability,        -->
+    <!-- but it cannot be avoided because the cell is fed to PF(), and would act on the indentation. -->
     <xsl:apply-templates />
     <xsl:text>  &#xa;</xsl:text>
 </xsl:template>
@@ -1119,46 +1132,68 @@
 
 <!-- Implement PGML unordered lists -->
 <xsl:template match="webwork//ul|webwork//ol">
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:apply-templates />
-    <xsl:text>&#xa;</xsl:text>
-</xsl:template>
-
-<xsl:template match="webwork//ul/li">
-    <xsl:call-template name="duplicate-string">
-        <xsl:with-param name="count" select="4 * (count(ancestor::ul) + count(ancestor::ol) - 1)" />
-        <xsl:with-param name="text"  select="' '" />
-    </xsl:call-template>
-    <xsl:choose>
-        <xsl:when test="../@label='disc'">*</xsl:when>
-        <xsl:when test="../@label='circle'">o</xsl:when>
-        <xsl:when test="../@label='square'">+</xsl:when>
-        <xsl:otherwise>-</xsl:otherwise>
-    </xsl:choose>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates />
-    <xsl:if test="not(child::p) and not(following-sibling::li) and not(following::*[1][self::li])">
-        <xsl:text>   </xsl:text>
+    <!-- Lists are always inside a p.                                         -->
+    <!-- If some text content or other elements precede the list within the p -->
+    <!-- then line break to get a clean start. Otherwise do nothing; assume   -->
+    <!-- whatever preceded the list gave adequate line breaks.                -->
+    <xsl:if test="preceding-sibling::text()[normalize-space()] or preceding-sibling::*">
+        <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates />
+    <!-- When a list ends, there may be more content before the p ends. This  -->
+    <!-- content needs to be indented the proper amount when the list was a   -->
+    <!-- nested list.                                                         -->
+    <xsl:if test="following-sibling::text()[normalize-space()] or following-sibling::*">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
 </xsl:template>
 
-<xsl:template match="webwork//ol/li">
+<xsl:template match="webwork//li">
+    <!-- Indent according to list depth; note this differs from list-indent template. -->
     <xsl:call-template name="duplicate-string">
         <xsl:with-param name="count" select="4 * (count(ancestor::ul) + count(ancestor::ol) - 1)" />
         <xsl:with-param name="text"  select="' '" />
     </xsl:call-template>
     <xsl:choose>
-        <xsl:when test="contains(../@label,'1')">1</xsl:when>
-        <xsl:when test="contains(../@label,'a')">a</xsl:when>
-        <xsl:when test="contains(../@label,'A')">A</xsl:when>
-        <xsl:when test="contains(../@label,'i')">i</xsl:when>
-        <xsl:when test="contains(../@label,'I')">I</xsl:when>
-        <xsl:otherwise>1</xsl:otherwise>
+        <xsl:when test="parent::ul">
+            <xsl:choose>
+                <xsl:when test="../@label='disc'">*</xsl:when>
+                <xsl:when test="../@label='circle'">o</xsl:when>
+                <xsl:when test="../@label='square'">+</xsl:when>
+                <xsl:otherwise>-</xsl:otherwise>
+            </xsl:choose>
+            <xsl:text> </xsl:text>
+        </xsl:when>
+        <xsl:when test="parent::ol">
+            <xsl:choose>
+                <xsl:when test="contains(../@label,'1')">1</xsl:when>
+                <xsl:when test="contains(../@label,'a')">a</xsl:when>
+                <xsl:when test="contains(../@label,'A')">A</xsl:when>
+                <xsl:when test="contains(../@label,'i')">i</xsl:when>
+                <xsl:when test="contains(../@label,'I')">I</xsl:when>
+                <xsl:otherwise>1</xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>.  </xsl:text>
+        </xsl:when>
     </xsl:choose>
-    <xsl:text>.  </xsl:text>
+    <!-- If the very first thing inside the li is a list or display math, we must line break before it -->
+    <!-- starts. However the line with the li needs *some* non-space characater or it will be ignored  -->
+    <!-- so we give it a NBSP.                                                                         -->
+    <xsl:if test="(child::*|child::text())[normalize-space()][1][self::p] and
+                  (
+                    (child::p[1]/child::*|child::p[1]/child::text())[normalize-space()][1][self::ol] or
+                    (child::p[1]/child::*|child::p[1]/child::text())[normalize-space()][1][self::ul] or
+                    (child::p[1]/child::*|child::p[1]/child::text())[normalize-space()][1][self::me] or
+                    (child::p[1]/child::*|child::p[1]/child::text())[normalize-space()][1][self::md]
+                  )">
+        <xsl:text>[$NBSP]*&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates />
-    <xsl:if test="not(child::p) and not(following-sibling::li) and not(following::*[1][self::li])">
+    <!-- Explicitly end lists with three trailing spaces when at the absolute end of all nested list  -->
+    <!-- in document order. For structured list items  with p, image, tabular children, this trailing -->
+    <!-- whitespace must be added in respective templates prior to their trailing line breaks.        -->
+    <xsl:if test="(child::*|child::text())[normalize-space()][position()=last()][self::text()] and not(following::*[1][self::li])">
         <xsl:text>   </xsl:text>
     </xsl:if>
     <xsl:text>&#xa;</xsl:text>
@@ -1173,12 +1208,19 @@
 </xsl:template>
 
 <xsl:template match="webwork//tabular">
+    <xsl:if test="preceding-sibling::p|preceding-sibling::image|preceding-sibling::tabular">
+        <xsl:call-template name="list-indent" />
+    </xsl:if>
     <!-- MBX tabular attributes top, bottom, left, right, halign are essentially passed -->
     <!-- down to cells, rather than used at the tabular level.                          -->
-    <xsl:text>[@DataTable(&#xa;  [&#xa;</xsl:text>
+    <xsl:text>[@DataTable(&#xa;</xsl:text>
+    <xsl:call-template name="list-indent" />
+    <xsl:text>  [&#xa;</xsl:text>
     <xsl:apply-templates select="row"/>
+    <xsl:call-template name="list-indent" />
     <xsl:text>  ],&#xa;</xsl:text>
     <xsl:if test="ancestor::table/caption">
+        <xsl:call-template name="list-indent" />
         <xsl:text>  caption => '</xsl:text>
             <xsl:apply-templates select="parent::*" mode="type-name"/>
             <xsl:text> </xsl:text>
@@ -1220,6 +1262,7 @@
     <!-- Build latex column specification                         -->
     <!--   vertical borders (left side, right side, three widths) -->
     <!--   horizontal alignment (left, center, right)             -->
+    <xsl:call-template name="list-indent" />
     <xsl:text>  align => '</xsl:text>
         <!-- start with left vertical border -->
         <xsl:call-template name="pg-vrule-specification">
@@ -1285,6 +1328,7 @@
     <!-- kill all of niceTable's column left/right border thickness in colgroup/col css; just let cellcss control border thickness -->
     <xsl:variable name="columns-css">
         <xsl:if test="col[@right] or @left">
+            <xsl:call-template name="list-indent" />
             <xsl:text>    [</xsl:text>
                 <xsl:for-each select="col">
                     <xsl:text>'</xsl:text>
@@ -1306,6 +1350,7 @@
                     <xsl:choose>
                         <xsl:when test="following-sibling::col">
                             <xsl:text>&#xa;     </xsl:text>
+                            <xsl:call-template name="list-indent" />
                         </xsl:when>
                     </xsl:choose>
                 </xsl:for-each>
@@ -1313,25 +1358,35 @@
         </xsl:if>
     </xsl:variable>
     <xsl:if test="not($columns-css='')">
+        <xsl:call-template name="list-indent" />
         <xsl:text>  columnscss =>&#xa;</xsl:text>
+        <xsl:call-template name="list-indent" />
         <xsl:value-of select="$columns-css"/>
         <xsl:text>,&#xa;</xsl:text>
     </xsl:if>
     <!-- column specification done -->
+    <xsl:if test="not(parent::table)">
+        <xsl:call-template name="list-indent" />
+        <xsl:text>  center => 0,&#xa;</xsl:text>
+    </xsl:if>
     <!-- remains to apply tabular/@top and tabular/@bottom -->
     <!-- will handle these at cell level -->
+    <xsl:call-template name="list-indent" />
     <xsl:text>);@]*&#xa;&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="webwork//tabular/row">
+    <xsl:call-template name="list-indent" />
     <xsl:text>    [</xsl:text>
     <xsl:apply-templates />
+    <xsl:call-template name="list-indent" />
     <xsl:text>    ],&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="webwork//tabular/row/cell">
     <xsl:variable name="this-cells-left-column" select="count(preceding-sibling::cell) + 1 + sum(preceding-sibling::cell[@colspan]/@colspan) - count(preceding-sibling::cell[@colspan])"/>
     <xsl:variable name="this-cells-right-column" select="$this-cells-left-column + sum(self::cell[@colspan]/@colspan) - count(self::cell[@colspan]/@colspan)"/>
+
     <!-- $halign below is a full LaTeX tabular argument for one cell, with perhaps more info than just alignment -->
     <xsl:variable name="halign">
         <xsl:if test="@colspan or @halign or @right or parent::row/@halign or (parent::row/@left and (count(preceding-sibling::cell)=0))">
@@ -1557,19 +1612,25 @@
                 <xsl:value-of select="$cell-bottom-css"/>
             </xsl:if>
             <xsl:if test="not($cell-bottom-css='') and (not($cell-top-css='') or not($cell-left-css='') or not($cell-right-css=''))">
-                <xsl:text>&#xa;                  </xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-top-css='')">
                 <xsl:value-of select="$cell-top-css"/>
             </xsl:if>
             <xsl:if test="not($cell-top-css='') and (not($cell-left-css='') or not($cell-right-css=''))">
-                <xsl:text>&#xa;                  </xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-left-css='')">
                 <xsl:value-of select="$cell-left-css"/>
             </xsl:if>
             <xsl:if test="not($cell-left-css='') and not($cell-right-css='')">
-                <xsl:text>&#xa;                  </xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>                  </xsl:text>
             </xsl:if>
             <xsl:if test="not($cell-right-css='')">
                 <xsl:value-of select="$cell-right-css"/>
@@ -1582,6 +1643,7 @@
             <xsl:text></xsl:text>
         </xsl:when>
         <xsl:otherwise>
+            <xsl:call-template name="list-indent" />
             <xsl:text>     </xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -1597,27 +1659,37 @@
             <xsl:apply-templates/>
             <xsl:text>'),</xsl:text>
             <xsl:if test="@colspan">
-                <xsl:text>&#xa;      colspan => '</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>      colspan => '</xsl:text>
                 <xsl:value-of select="@colspan"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($halign='')">
-                <xsl:text>&#xa;      halign  => '</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>      halign  => '</xsl:text>
                 <xsl:value-of select="$halign"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="$midrule='1' and not(preceding-sibling::cell)">
-                <xsl:text>&#xa;      midrule => '</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>      midrule => '</xsl:text>
                 <xsl:value-of select="$midrule"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($rowcss='')">
-                <xsl:text>&#xa;      rowcss  => '</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>      rowcss  => '</xsl:text>
                 <xsl:value-of select="$rowcss"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
             <xsl:if test="not($cellcss='')">
-                <xsl:text>&#xa;      cellcss => '</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:call-template name="list-indent" />
+                <xsl:text>      cellcss => '</xsl:text>
                 <xsl:value-of select="$cellcss"/>
                 <xsl:text>',</xsl:text>
             </xsl:if>
@@ -1682,6 +1754,14 @@
             <xsl:with-param name="text" select="substring-after($text, '&#xA;')"/>
         </xsl:call-template>
     </xsl:if>
+</xsl:template>
+
+<!-- Base indentation for lines of code in the middle of a list -->
+<xsl:template name="list-indent">
+    <xsl:call-template name="duplicate-string">
+        <xsl:with-param name="count" select="4 * (count(ancestor::ul) + count(ancestor::ol))" />
+        <xsl:with-param name="text"  select="' '" />
+    </xsl:call-template>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Two commits here. First one only corrects DTD violations I found in the WW sample chapter.

Next one is all for the sake of list items. Prior to this, there are issues with list enumeration when the list items have too much going on inside. It all comes down to how you basically have to maintain the same level of indentation to persist with a list at a certain depth.

ol/li and ul/li got merged into one template, so that might make for an ugly section of the diff. 

Added lots of lists in the stress test section. Some of them are still broken! But I am convinced it is not our fault, after examining the PG output. As noted in the section, there may be a PGML bug (or we are trying to use PGML for something it was not intended to do.)

One other thing that this commit does is cut down on over liberal line breaks in the PG output. Too many line breaks made the PG code hard to read with human eyes, with long voids of vertical white space. Much better now, and everything in the sample chapter still works as before.
