### PR TITLE
Update the `video` Tag

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -4448,17 +4448,50 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 
 <!-- Video -->
-<!-- Embed FlowPlayer to play mp4 format                                    -->
-<!-- 2014/03/07:  http://flowplayer.org/docs/setup.html                     -->
-<!-- TODO: use for-each and extension matching to preferentially use WebM format -->
-<!-- <source type="video/mp4" src="http://mydomain.com/path/to/intro.webm">     -->
-<!-- TODO: respect @width attribute on ext rewrite, see YouTube -->
 <xsl:template match="video">
-    <div class="flowplayer" style="width:200px">
-        <xsl:text disable-output-escaping='yes'>&lt;video controls>&#xa;</xsl:text>
-        <source type="video/webm" src="{@source}" />
-        <xsl:text disable-output-escaping='yes'>&lt;/video>&#xa;</xsl:text>
-    </div>
+    <xsl:element name="video">
+        <xsl:attribute name="id">
+            <xsl:apply-templates select="." mode="internal-id"/>
+        </xsl:attribute>
+        <xsl:attribute name="width">
+            <xsl:choose>
+                <xsl:when test="@width">
+                    <xsl:value-of select="@width"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>100%</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+        <xsl:element name="source">
+            <xsl:attribute name="src">
+                <xsl:value-of select="@source"/>
+                <xsl:text>.mp4</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="type">
+                <xsl:text>video/mp4</xsl:text>
+            </xsl:attribute>
+        </xsl:element>
+        <xsl:element name="source">
+            <xsl:attribute name="src">
+                <xsl:value-of select="@source"/>
+                <xsl:text>.ogg</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="type">
+                <xsl:text>video/ogg</xsl:text>
+            </xsl:attribute>
+        </xsl:element>
+        <xsl:element name="source">
+            <xsl:attribute name="src">
+                <xsl:value-of select="@source"/>
+                <xsl:text>.webm</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="type">
+                <xsl:text>video/webm</xsl:text>
+            </xsl:attribute>
+        </xsl:element>
+        <xsl:text>Your browser does not support the video tag.</xsl:text>
+    </xsl:element>
 </xsl:template>
 
 <!-- You Tube -->
@@ -6219,9 +6252,6 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
             <xsl:call-template name="hypothesis-annotation" />
             <xsl:call-template name="jsxgraph" />
             <xsl:call-template name="css" />
-            <xsl:if test="//video">
-                <xsl:call-template name="video" />
-            </xsl:if>
         </head>
         <xsl:element name="body">
             <!-- the first class controls the default icon -->
@@ -7523,18 +7553,6 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
             </xsl:element>
         </xsl:otherwise>
     </xsl:choose>
-</xsl:template>
-
-<!-- Video header                    -->
-<!-- Flowplayer setup                -->
-<!-- assumes JQuery loaded elsewhere -->
-<!-- 2014/03/07: http://flowplayer.org/docs/setup.html#global-configuration -->
-<xsl:template name="video">
-    <link rel="stylesheet" href="//releases.flowplayer.org/5.4.6/skin/minimalist.css" />
-    <script src="https://releases.flowplayer.org/5.4.6/flowplayer.min.js"></script>
-    <script>flowplayer.conf = {
-    };</script>
-
 </xsl:template>
 
 <!-- ############## -->


### PR DESCRIPTION
This will make the `video` tag (when not using YouTube) use the HTML5 `video` tag instead of `flowplayer`.

This will allow videos other than `webm` files and should be more cross-platform compatible.