### PR TITLE
GeoGebra

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -915,7 +915,7 @@
         </section>
 
         <section>
-            <title>Graphics in Exercises</title>
+            <title>Graphics and Interactives in Exercises</title>
             <p>It is natural to want to write exercises that rely on graphics. For example, an exericse might produce a chart of some kind, and ask the reader to extract some information from that chart.</p>
             <p>At present, this can be done using the same mechanism one would use to insert a graphic into a <webwork /> problem when writing regular <webwork /> problems. (And this is what is done below.) In the future, there will be a nicer option that will be able to make use of MBX's <c>latex-image-code</c>. This requires some <webwork /> development first, which is underway.</p>
 
@@ -979,6 +979,20 @@
 
                     </solution>
 
+                </webwork>
+            </exercise>
+
+            <p>Material from GeoGebra-Materials can also be embedded in a <webwork /> problem.</p>
+
+            <exercise>
+                <webwork>
+                    <statement>
+                        <p>Find <m>f(g(2))</m>.</p>
+                        <sidebyside>
+                            <geogebra materials="vZUDWFjJ" width="425" height="420"/>
+                        </sidebyside>
+                        <p><var name="'30'" width="10"/></p>
+                    </statement>
                 </webwork>
             </exercise>
 

--- a/script/mbx
+++ b/script/mbx
@@ -476,18 +476,244 @@ def webwork_to_tex(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_
             raise ValueError(msg.format(include_file_name) + root_cause)
 
 
+###########################################
+#
+#  WeBWorK to Static MBX source on a Server
+#
+###########################################
+
+def webwork_to_mbx(origin, xslt_exec, mbx_xsl_dir, xml_source, server_url, dest_dir):
+    import subprocess, os.path, requests
+    import re     # regular expressions for parsing
+    from xml.sax.saxutils import escape    # sanitize string
+
+
+    # execute XSL extraction for source problems
+    # origin is a flag for where the problem is born
+    #   'server' : lives on the server, only a URL is in MBX document
+    #   'mbx'    : authored in MBX document (and has PG code for images)
+    if origin == 'server':
+        xsl_transform = 'extract-ww-tex-server.xsl'
+        msg = 'analyzing source document for URLs of WeBWorK problems, to send to server for static MBX version'
+    elif origin == 'mbx':
+        xsl_transform = 'extract-ww-tex-mbx.xsl'
+        msg = 'analyzing source document for WeBWorK problems with PG images, to send to server for static MBX version'
+    else:
+        raise ValueError("flag sent to webwork_to_mbx() should be 'server' or 'mbx', not '{}'".format(origin))
+    extraction_xslt = os.path.join(mbx_xsl_dir, xsl_transform)
+    cmd = [xslt_exec, '--xinclude', extraction_xslt, xml_source]
+    _verbose(msg)
+    try:
+        problem_list = subprocess.check_output(cmd)
+    except subprocess.CalledProcessError as e:
+        root_cause = str(e)
+        msg = 'xsltproc command failed, tried: "{}"\n'.format(' '.join(cmd))
+        raise ValueError(msg + root_cause)
+    # "run" an assignment for the list of triples of strings
+    problems = eval(problem_list.decode('ascii'))
+
+    # verify destination exists
+    sanitize_directory(dest_dir)
+    if plat == "Windows":
+        dest_dir = break_windows_path(dest_dir)
+
+    # verify, construct problem format requestor
+    server_url = sanitize_url(server_url)
+    wwurl = server_url + "webwork2/html2xml"
+
+    # using a "Session()" will pool connection information
+    # since we always hit the same server, this should increase performance
+    session = requests.Session()
+
+    # dictionary of values for URL request, these are fixed for each problem
+    # sourceFilePath and problemSeed are set below, on per-problem basis
+    server_params = {
+        'answersSubmitted': '0',
+        'displayMode': 'MBX',
+        'courseID': 'anonymous',
+        'userID': 'anonymous',
+        'password': 'anonymous',
+        'course_password': 'anonymous',
+        'outputformat': 'mbx'
+    }
+
+    # XML content comes back
+    # these delimit what we want
+    start_marker = re.compile('<!--BEGIN PROBLEM-->')
+    end_marker = re.compile('<!--END PROBLEM-->')
+
+    # WW server can react to a
+    #   URL stored there already
+    #   a base64 encoding of the problem
+    if origin == 'server':
+        ww_server_option = 'sourceFilePath'
+    elif origin == 'mbx':
+        ww_server_option = 'problemSource'
+
+    # each problem is a triple created by the XSL transform
+    # 0. "source", URL or base64 string (not URL encoded!)
+    # 1. seed for randomness control
+    # 2. the internal id string for coherence
+    for problem in problems:
+        source, seed, internal_id = problem
+        server_params['problemSeed'] = seed
+        server_params[ww_server_option] = source
+
+        msg = "sending {} to server to save in {}: origin is '{}'"
+        _verbose(msg.format(internal_id, dest_dir, origin))
+        _debug('server-to-latex: {} {} {} {}'.format(source, wwurl, dest_dir, internal_id))
+
+        # Ready, go out on the wire
+        try:
+            response = session.get(wwurl, params=server_params, verify=False)
+        except requests.exceptions.RequestException as e:
+            root_cause = str(e)
+            msg = "There was a problem collecting a problem,\n Server: {}\nRequest Parameters: {}\n"
+            raise ValueError(msg.format(wwurl, server_params) + root_cause)
+        # Obtained, this is it
+        # Could mine the title and other things
+        content = response.text
+        # strip out actual TeX code between markers
+        start = start_marker.split(content, maxsplit=1)
+        content = start[1]
+        end = end_marker.split(content, maxsplit=1)
+        content = end[0]
+        #tex_only = end[0]
+
+        # need to loop through content looking for images with pattern:
+        #
+        #   <image source="relative-path-to-temporary-image-on-server"
+        #
+        graphics_pattern = re.compile(r'<image.*?source="([^\.]*)\.([^"]*)"')
+
+        # replace filenames, download images with new filenames
+        count = 0
+        for match in re.finditer(graphics_pattern, content):
+            count += 1
+            ww_basename = match.group(1)
+            file_extension = '.' + match.group(2)
+            ww_filename = ww_basename + file_extension
+            # rename, eg, webwork-tex/webwork-5-image-3.png
+            mbx_basename =  internal_id + '-image-' + str(count)
+            mbx_filename = mbx_basename + file_extension
+            # URL of image on server starts two steps down
+            image_url = server_url + ww_filename
+            # modify MBX problem source to include local versions
+            content = content.replace(ww_filename, 'images/' + mbx_filename)
+            # download actual image files
+            # http://stackoverflow.com/questions/13137817/how-to-download-image-using-requests
+            try:
+                response = session.get(image_url, verify=False)
+            except requests.exceptions.RequestException as e:
+                root_cause = str(e)
+                msg = "There was a problem downloading an image file,\n URL: {}\n"
+                raise ValueError(msg.format(image_url) + root_cause)
+            # and save the image itself
+            try:
+                image_file = open(os.path.join(dest_dir, mbx_filename), 'wb')
+                image_file.write(response.content)
+                image_file.close()
+            except Exception as e:
+                root_cause = str(e)
+                msg = "There was a problem saving an image file,\n Filename: {}\n"
+                raise ValueError(os.path.join(dest_dir, mbx_filename) + root_cause)
+
+        # various strings and patterns for XML-ification
+        # we pass the seed along for reliability/accuracy
+        #problem_start = r'<webwork-tex seed="{}">'.format(seed)
+        #problem_end = r'</webwork-tex>'
+
+        #preamble_begin_pattern = re.compile(r'%%% BEGIN PROBLEM PREAMBLE')
+        #preamble_end_pattern = re.compile(r'%%% END PROBLEM PREAMBLE')
+        #preamble_start = r'<preamble>'
+        #preamble_end = r'</preamble>'
+
+        #statement_start = r'<statement>'
+        #statement_end = r'</statement>'
+
+        #solution_begin_pattern = re.compile(r'%%% BEGIN SOLUTION')
+        #solution_end_pattern = re.compile(r'%%% END SOLUTION')
+        #solution_start = r'<solution>'
+        #solution_end = r'</solution>'
+
+        #hint_begin_pattern = re.compile(r'%%% BEGIN HINT')
+        #hint_end_pattern = re.compile(r'%%% END HINT')
+        #hint_start = r'<hint>'
+        #hint_end = r'</hint>'
+
+        #start_pattern = re.compile(r'<preamble>|<solution>|<hint>')
+        #end_pattern = re.compile(r'<\/preamble>|<\/solution>|<\/hint>')
+
+        # the right time to escape problematic XML characters, <, >, &
+        # https://wiki.python.org/moin/EscapingXml
+        #tex_only = escape(tex_only)
+
+        # is end of preamble marked?
+        # should only happen once
+        #match = preamble_end_pattern.search(tex_only)
+        #if match:
+        #    tex_only = preamble_start + '\n' + tex_only
+        #    tex_only = preamble_end_pattern.sub(preamble_end, tex_only, count=1)
+        # straightup replacements for solutions, hints
+        #tex_only = solution_begin_pattern.sub(solution_start, tex_only)
+        #tex_only = solution_end_pattern.sub(solution_end, tex_only)
+        #tex_only = hint_begin_pattern.sub(hint_start, tex_only)
+        #tex_only = hint_end_pattern.sub(hint_end, tex_only)
+
+        # problem statements appear as "text()"
+        # boolean "balanced" means previous line ends an XML element
+        #xml_lines = [problem_start]
+        #balanced = True
+        #for line in iter(tex_only.splitlines()):
+        #    # throw out blank lines between XML elements
+        #    if balanced and line == '':
+        #        pass
+        #    # if a group does not start, then begin problem statement
+        #    elif balanced:
+        #        if not(start_pattern.search(line)):
+        #            xml_lines.append(statement_start)
+        #            balanced = False
+        #        else:
+        #            balanced = False
+        #        xml_lines.append(line)
+        #    # if we encounter a start while unbalanced, close statement
+        #    # if we hit the end of an element, we flip to balanced
+        #    elif not(balanced):
+        #        if start_pattern.search(line):
+        #            xml_lines.append(statement_end)
+        #            balanced = False  # matching start line is reproduced
+        #        elif end_pattern.search(line):
+        #            balanced = True
+        #        xml_lines.append(line)
+        # if we made it to the end unbalanced, need to close statement
+        #if not(balanced):
+        #    xml_lines.append(statement_end)
+        #xml_lines.append(problem_end)
+
+        # place content in a file in destination directory
+        include_file_name = os.path.join(dest_dir, internal_id + ".xml")
+        try:
+            include_file = open(include_file_name, 'w')
+            include_file.write(content)
+            include_file.close()
+        except Exception as e:
+            root_cause = str(e)
+            msg = "There was a problem writing a problem to the file: {}\n"
+            raise ValueError(msg.format(include_file_name) + root_cause)
+
+
 ##############################
 #
-#  You Tube thumbnail scraping
+#  Thumbnail scraping
 #
 ##############################
 
-def youtube_thumbnail(xml_source, xmlid_root, dest_dir):
+def thumbnail(xml_source, xmlid_root, dest_dir):
     global config
     import tempfile, os, os.path, subprocess, shutil
     import requests
 
-    _verbose('downloading YouTube thumbnails from {} for placement in {}'.format(xml_source, dest_dir))
+    _verbose('downloading thumbnails from {} for placement in {}'.format(xml_source, dest_dir))
     dest_dir = sanitize_directory(dest_dir)
     plat = get_platform()
     if plat == "Windows":
@@ -495,9 +721,9 @@ def youtube_thumbnail(xml_source, xmlid_root, dest_dir):
     xslt_executable = get_executable(config,  'xslt')
     _debug("xslt executable: {}".format(xslt_executable))
     if plat == "Windows":
-        extraction_xslt = '/'.join(mbx_xsl_dir, 'extract-youtube.xsl')
+        extraction_xslt = '/'.join(mbx_xsl_dir, 'extract-thumbnail.xsl')
     else:
-        extraction_xslt = os.path.join(mbx_xsl_dir, 'extract-youtube.xsl')
+        extraction_xslt = os.path.join(mbx_xsl_dir, 'extract-thumbnail.xsl')
     cmd = [xslt_executable,
             '--xinclude',
             '--stringparam',
@@ -514,13 +740,24 @@ def youtube_thumbnail(xml_source, xmlid_root, dest_dir):
     # "run" an assignment for the list of triples of strings
     thumbs = eval(thumb_list.decode('ascii'))
 
+    # thumbnail url patterns
     yt_url = 'http://i.ytimg.com/vi/{}/default.jpg'
-    image_path = dest_dir + '/{}.jpg'
+    ggm_url = 'https://www.geogebra.org/files/material-{}-thumb.png'
+
+    # thumbnail destination files
+    yt_image_path = dest_dir + '/{}.jpg'
+    ggm_image_path = dest_dir + '/{}.png'
+
     session = requests.Session()
     for thumb in thumbs:
-        url = yt_url.format(thumb[0])
-        path = image_path.format(thumb[1])
-        _verbose('downloading {} as {}...'.format(url, path))
+        if thumb[0] == "youtube":
+            url = yt_url.format(thumb[1])
+            path = yt_image_path.format(thumb[2])
+            _verbose('downloading {} as {}...'.format(url, path))
+        elif thumb[0] == "geogebra-materials":
+            url = ggm_url.format(thumb[1])
+            path = ggm_image_path.format(thumb[2])
+            _verbose('downloading {} as {}...'.format(url, path))
         # http://stackoverflow.com/questions/13137817/how-to-download-image-using-requests/13137873
         # removed some settings wrapper from around the URL, otherwise verbatim
         r = requests.get(url, stream=True)
@@ -531,7 +768,7 @@ def youtube_thumbnail(xml_source, xmlid_root, dest_dir):
         else:
             msg = 'Download returned a bad status code ({}), perhaps try {} manually?'
             raise OSError(msg.format(r.status_code, url))
-    _verbose('YouTube thumbnail download complete')
+    _verbose('Thumbnail download complete')
 
 
 #######################################
@@ -853,7 +1090,7 @@ def get_cli_arguments():
         ('sageplot', 'Sage graphics'),
         ('latex-image', 'LaTeX pictures'),
         ('webwork-tex', 'WeBWorK server problems as LaTeX'),
-        ('youtube', 'Thumbnails for YouTube videos (JPEG only)'),
+        ('thumbnail', 'Thumbnails for YouTube (.jpg), GeoGebraTube (.png)'),
         ('all', 'Complete document (only SageNB format)'),
         ('tikz', 'tikz pictures (obsolete)'),
     ]
@@ -1048,7 +1285,9 @@ elif args.component == 'webwork-tex':
     webwork_to_tex('server', xslt_executable, mbx_xsl_dir, args.xml_file, args.server, output_dir)
     webwork_to_tex('mbx',    xslt_executable, mbx_xsl_dir, args.xml_file, args.server, output_dir)
 elif args.component == 'youtube':
-    youtube_thumbnail(args.xml_file, args.xmlid, output_dir)
+    raise ValueError('the "{}" component is now "thumbnail"'.format(args.component))
+elif args.component == 'thumbnail':
+    thumbnail(args.xml_file, args.xmlid, output_dir)
 elif args.component == 'all':
     if args.format == 'sagenb':
         # initialize  the converter

--- a/xsl/extract-thumbnail.xsl
+++ b/xsl/extract-thumbnail.xsl
@@ -19,10 +19,12 @@ You should have received a copy of the GNU General Public License
 along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
-<!-- This stylesheet locates <latex-image-code> elements   -->
-<!-- and wraps them for LaTeX processing                   -->
-<!-- This includes the LaTeX macros present in docinfo     -->
-<!-- and the document's docinfo/latex-image-preamble       -->
+
+<!-- Extraction template for thumbnail images        -->
+<!-- Outputs an array with three elements:           -->
+<!-- (thumbnail-for-what, external id,  internal id) -->
+<!-- Example: (youtube, abcdEFGH, youtube-1)         -->
+<!-- Example: (geogebra-materials, abcdEFGH, geogebra-1)   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -50,10 +52,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>]</xsl:text>
 </xsl:template>
 
-<!-- YouTube ID, and internal id as a Python pair -->
+<!-- Type of thumbnail, external ID, and internal ID as a Python triple -->
 <xsl:template match="video[@youtube]">
     <xsl:text>('</xsl:text>
+    <xsl:text>youtube</xsl:text>
+    <xsl:text>', '</xsl:text>
     <xsl:value-of select="@youtube" />
+    <xsl:text>', '</xsl:text>
+    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:text>'), </xsl:text>
+</xsl:template>
+
+<xsl:template match="geogebra[@materials]">
+    <xsl:text>('</xsl:text>
+    <xsl:text>geogebra-materials</xsl:text>
+    <xsl:text>', '</xsl:text>
+    <xsl:value-of select="@materials" />
     <xsl:text>', '</xsl:text>
     <xsl:apply-templates select="." mode="internal-id" />
     <xsl:text>'), </xsl:text>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -5183,10 +5183,11 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     </xsl:for-each>
 </xsl:template>
 
-<!-- We warn about WeBWorK table details that ultimately may not be respected -->
-<!-- if a problem is archived to .pg, and then that file is used on a WeBWorK -->
-<!-- server, and then WeBWorK's print copy mechanism is used to make a pdf    -->
+<!-- Some things in a webwork do not behave as they do elsewhere in PTX -->
 <xsl:template match="mathbook" mode="webwork-warnings">
+    <!-- We warn about WeBWorK table details that ultimately may not be respected -->
+    <!-- if a problem is archived to .pg, and then that file is used on a WeBWorK -->
+    <!-- server, and then WeBWorK's print copy mechanism is used to make a pdf    -->
     <xsl:variable name="coltop" select="//webwork//tabular/col/@top" />
     <xsl:variable name="cellbottom" select="//webwork//tabular/cell/@bottom" />
     <xsl:variable name="medium-major" select="//webwork//tabular//*[@top='medium' or @top='major' or @bottom='medium' or @bottom='major' or @left='medium' or @left='major' or @right='medium' or @right='major']" />
@@ -5221,6 +5222,20 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
             <xsl:value-of select="count($medium-major)" />
             <xsl:text> time</xsl:text>
             <xsl:if test="count($medium-major) > 1">
+                <xsl:text>s</xsl:text>
+            </xsl:if>
+            <xsl:text>)</xsl:text>
+        </xsl:message>
+    </xsl:if>
+    <!-- We warn about WeBWorK not actually being able to handle multiple objects in a sidebyside -->
+    <xsl:variable name="multiple-sidebyside" select="//webwork//sidebyside[count(child::*[not(self::caption)]) > 1]" />
+    <xsl:if test="$multiple-sidebyside">
+        <xsl:message>
+            <xsl:text>MBX:WARNING:   </xsl:text>
+            <xsl:text>a sidebyside inside a webwork with more than one object will not layout the objects side by side (</xsl:text>
+            <xsl:value-of select="count($multiple-sidebyside)" />
+            <xsl:text> time</xsl:text>
+            <xsl:if test="count($multiple-sidebyside) > 1">
                 <xsl:text>s</xsl:text>
             </xsl:if>
             <xsl:text>)</xsl:text>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -5119,6 +5119,34 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- GeoGebra from GeoGebra Materials                  -->
+<!-- Assuming thumbnails have been scraped with the    -->
+<!-- mbx script, we make a short static display, using -->
+<!-- a title of an enclosing figure, if available      -->
+<xsl:template match="geogebra[@materials]">
+    <xsl:variable name="geogebra-materials-url">
+        <xsl:text>https://www.geogebra.org/m/</xsl:text>
+        <xsl:value-of select="@materials" />
+    </xsl:variable>
+    <xsl:text>\begin{tabular}{p{.3\linewidth}p{.7\linewidth}}&#xa;</xsl:text>
+    <xsl:text>\raisebox{\dimexpr-\height+\baselineskip}{\includegraphics[width=\linewidth]{</xsl:text>
+    <xsl:value-of select="$directory.images" />
+    <xsl:text>/</xsl:text>
+    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:text>.png}}&amp;%&#xa;</xsl:text>
+    <xsl:if test="parent::*[title]">
+        <xsl:apply-templates select="parent::*" mode="title-full" />
+        <xsl:text>\newline%&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:text>GeoGebra applet at:\newline</xsl:text>
+    <xsl:text>\href{</xsl:text>
+    <xsl:value-of select="$geogebra-materials-url" />
+    <xsl:text>}{\texttt{\nolinkurl{</xsl:text>
+    <xsl:value-of select="$geogebra-materials-url" />
+    <xsl:text>}}}&#xa;</xsl:text>
+    <xsl:text>\end{tabular}&#xa;</xsl:text>
+</xsl:template>
+
 <!-- JSXGraph -->
 <xsl:template match="jsxgraph">
     <xsl:text>\par\smallskip\centerline{A JSXGraph interactive demonstration goes here in interactive output.}\smallskip&#xa;</xsl:text>
@@ -5469,7 +5497,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- behaves in minipages.                                      -->
 <!-- Called in -setup and saved results recycled in -panel      -->
 
-<xsl:template match="p|paragraphs|tabular|ol|ul|dl|list|poem" mode="panel-latex-box">
+<xsl:template match="p|paragraphs|tabular|ol|ul|dl|list|poem|geogebra" mode="panel-latex-box">
     <xsl:param name="width" />
     <xsl:variable name="percent" select="substring-before($width,'%') div 100" />
     <xsl:if test="$sbsdebug">
@@ -5506,6 +5534,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="stanza"/>
             <xsl:apply-templates select="author" />
             <xsl:text>\end{poem}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="self::geogebra">
+            <xsl:text>\centering</xsl:text>
+            <xsl:apply-templates select="."/>
         </xsl:when>
     </xsl:choose>
     <xsl:text>}}</xsl:text>

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -732,7 +732,296 @@
     <xsl:apply-templates />
 </xsl:template>
 
+<!-- ####################### -->
+<!-- PGML GeoGebra Materials -->
+<!-- ####################### -->
 
+<xsl:template match="webwork//geogebra[@materials]">
+    <xsl:variable name="geogebra-materials-embed-url">
+        <xsl:text>https://www.geogebra.org/material/iframe/id/</xsl:text>
+        <xsl:value-of select="@materials" />
+    </xsl:variable>
+    <xsl:variable name="geogebra-materials-url">
+        <xsl:text>https://www.geogebra.org/m/</xsl:text>
+        <xsl:value-of select="@materials" />
+    </xsl:variable>
+    <xsl:if test="preceding-sibling::p|preceding-sibling::image|preceding-sibling::tabular">
+        <xsl:call-template name="potential-list-indent" />
+    </xsl:if>
+    <xsl:text>[@MODES(</xsl:text>
+    <!-- HTML Mode -->
+    <xsl:text>HTML=&gt;'&lt;iframe </xsl:text>
+    <xsl:if test="title">
+        <xsl:text>title="</xsl:text>
+        <xsl:value-of select="title"/>
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:text>width="</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@width">
+            <xsl:value-of select="@width"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>400</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>" </xsl:text>
+    <xsl:text>height="</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@height">
+            <xsl:value-of select="@height"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>400</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>" </xsl:text>
+    <xsl:text>scrolling="</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@scrolling">
+            <xsl:value-of select="@scrolling"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>no</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>" </xsl:text>
+    <xsl:text>src="</xsl:text>
+    <xsl:value-of select="$geogebra-materials-embed-url" />
+    <xsl:text>/width/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@width">
+            <xsl:value-of select="@width"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>400</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/height/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@height">
+            <xsl:value-of select="@height"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>400</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/border/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@border-color">
+            <xsl:value-of select="@border-color"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>888888</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/smb/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@menu = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@menu = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/stb/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@toolbar = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@toolbar = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/stbh/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@toolbar = 'yes' and @toolbar-help = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@toolbar-help = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/ai/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@input-bar = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@input-bar = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/asb/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@style-bar = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@style-bar = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/sri/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@allow-reset = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@allow-reset = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>true</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/rc/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@right-click-and-keyboard-editing = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@right-click-and-keyboard-editing = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/ld/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@label-dragging = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@label-dragging = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/sdz/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@pan-and-zoom = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@pan-and-zoom = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/ctl/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@click-to-load = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:when test="@click-to-load = 'no'">
+            <xsl:text>false</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>" </xsl:text>
+    <xsl:text>style="border:0px;" </xsl:text>
+    <xsl:text>&gt;&lt;/iframe&gt;', </xsl:text>
+    <!-- TeX Mode -->
+    <xsl:text>TeX =&gt;'A GeoGebra applet at \path|</xsl:text>
+    <xsl:value-of select="$geogebra-materials-embed-url" />
+    <xsl:text>|.', </xsl:text>
+    <!-- PTX Mode -->
+    <xsl:text>PTX =&gt;'&lt;geogebra </xsl:text>
+    <xsl:text>materials="</xsl:text>
+    <xsl:value-of select="@materials" />
+    <xsl:text>" </xsl:text>
+    <xsl:if test="@width">
+        <xsl:text>width="</xsl:text>
+        <xsl:value-of select="@width" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@height">
+        <xsl:text>height="</xsl:text>
+        <xsl:value-of select="@height" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@scrolling">
+        <xsl:text>scrolling="</xsl:text>
+        <xsl:value-of select="@scrolling" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@border-color">
+        <xsl:text>border-color="</xsl:text>
+        <xsl:value-of select="@border-color" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@menu">
+        <xsl:text>menu="</xsl:text>
+        <xsl:value-of select="@menu" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@toolbar">
+        <xsl:text>toolbar="</xsl:text>
+        <xsl:value-of select="@toolbar" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@toolbar-help">
+        <xsl:text>toolbar-help="</xsl:text>
+        <xsl:value-of select="@toolbar-help" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@input-bar">
+        <xsl:text>input-bar="</xsl:text>
+        <xsl:value-of select="@input-bar" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@style-bar">
+        <xsl:text>style-bar="</xsl:text>
+        <xsl:value-of select="@style-bar" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@allow-reset">
+        <xsl:text>allow-reset="</xsl:text>
+        <xsl:value-of select="@allow-reset" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@right-click-and-keyboard-editing">
+        <xsl:text>right-click-and-keyboard-editing="</xsl:text>
+        <xsl:value-of select="@right-click-and-keyboard-editing" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@label-dragging">
+        <xsl:text>label-dragging="</xsl:text>
+        <xsl:value-of select="@label-dragging" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@pan-and-zoom">
+        <xsl:text>pan-and-zoom="</xsl:text>
+        <xsl:value-of select="@pan-and-zoom" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:if test="@click-to-load">
+        <xsl:text>click-to-load="</xsl:text>
+        <xsl:value-of select="@click-to-load" />
+        <xsl:text>" </xsl:text>
+    </xsl:if>
+    <xsl:text>/&gt;', </xsl:text>
+    <xsl:text>);@]*</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
 
 <!-- ############################# -->
 <!-- ############################# -->

--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -1234,13 +1234,29 @@
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- ###### -->
-<!-- Tables -->
-<!-- ###### -->
+<!-- ############################ -->
+<!-- Tables, Figures, Sidebysides -->
+<!-- ############################ -->
+
+<!-- These outer wrappers for tabular, image, and similar things are allowed inside a webwork problem, -->
+<!-- but captions and numbering are ignored. Presently no effort is made to handle the sidebysides as  -->
+<!-- true sidebysides. -->
+
+<xsl:template match="webwork//figure">
+    <xsl:apply-templates select="*[not(self::caption)]" />
+</xsl:template>
 
 <xsl:template match="webwork//table">
     <xsl:apply-templates select="*[not(self::caption)]" />
 </xsl:template>
+
+<xsl:template match="webwork//sidebyside">
+    <xsl:apply-templates select="*[not(self::caption)]" />
+</xsl:template>
+
+<!-- ####### -->
+<!-- Tabular -->
+<!-- ####### -->
 
 <xsl:template match="webwork//tabular">
     <xsl:if test="preceding-sibling::p|preceding-sibling::image|preceding-sibling::tabular">


### PR DESCRIPTION
These commits are all GeoGebra Materials-related. The first commit additionally combines YouTube thumbnail scraping with GGM thumbnail scraping.

The rest give an example of a `<geogebra materials='...' />` in the WeBWorK sample chapter. You can test how it behaves in the HTML output. Or you can archive to PG, upload to WeBWorK and see behavior there (including through WeBWorK's hardcopy output mode).

The last commit lets `<geogebra materials='...' />` behave in LaTeX output. You can test what the WeBWorK sample chapter looks like in LaTeX, but I did not provide a WeBWorK-independent test example because that is a job for #587. Also there is the enhancement of `sidebyside` so that it can support a `geogebra` child, because at Tacoma, Rob outlined a future where a one-panel sidebyside would be the equivalent of a captionless figure, which is how WeBWorK needs to handle `geogebra`.

This replaces #586, which I will now close.