### PR TITLE
New scheme for WeBWorK in print

### DIFF
--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -56,6 +56,11 @@
 <!-- to provide AnswerFormatHelp link.                            -->
 <xsl:param name="pg.answer.form.help" select="'yes'" />
 
+
+<!-- If the extraction style sheet is calling this style sheet, $static -->
+<!-- will be 'yes', and that influences certain templates here          -->
+<xsl:param name="static" />
+
 <!-- ################# -->
 <!-- File Organization -->
 <!-- ################# -->
@@ -802,7 +807,12 @@
 
 <xsl:template match= "webwork//m">
     <xsl:text>[`</xsl:text>
-    <xsl:call-template name="select-latex-macros"/>
+    <xsl:choose>
+        <xsl:when test="$static = 'yes'" />
+        <xsl:otherwise>
+            <xsl:call-template name="select-latex-macros"/>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates select="text()|var" />
     <!-- look ahead to absorb immediate clause-ending punctuation -->
     <xsl:apply-templates select="." mode="get-clause-punctuation" />
@@ -815,7 +825,12 @@
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:text>&gt;&gt; [``</xsl:text>
-    <xsl:call-template name="select-latex-macros"/>
+    <xsl:choose>
+        <xsl:when test="$static = 'yes'" />
+        <xsl:otherwise>
+            <xsl:call-template name="select-latex-macros"/>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates select="text()|var" />
     <!-- look ahead to absorb immediate clause-ending punctuation -->
     <xsl:apply-templates select="." mode="get-clause-punctuation" />
@@ -834,14 +849,24 @@
     <xsl:choose>
         <xsl:when test="contains(., '&amp;') or contains(., '\amp')">
             <xsl:text>[``</xsl:text>
-            <xsl:call-template name="select-latex-macros"/>
+            <xsl:choose>
+                <xsl:when test="$static = 'yes'" />
+                <xsl:otherwise>
+                    <xsl:call-template name="select-latex-macros"/>
+                </xsl:otherwise>
+            </xsl:choose>
             <xsl:text>\begin{aligned}&#xa;</xsl:text>
             <xsl:apply-templates select="mrow" />
             <xsl:text>\end{aligned}``]</xsl:text>
         </xsl:when>
         <xsl:otherwise>
             <xsl:text>[``</xsl:text>
-            <xsl:call-template name="select-latex-macros"/>
+            <xsl:choose>
+                <xsl:when test="$static = 'yes'" />
+                <xsl:otherwise>
+                    <xsl:call-template name="select-latex-macros"/>
+                </xsl:otherwise>
+            </xsl:choose>
             <xsl:text>\begin{gathered}&#xa;</xsl:text>
             <xsl:apply-templates select="mrow" />
             <xsl:text>\end{gathered}``]</xsl:text>


### PR DESCRIPTION
I'll be pushing commits here for the new scheme for handling WeBWorK in print over the next few weeks. There are some moving parts, because for this to work it depends on the version of the WeBWorK server. WW 2.14 will come late summer, and that is where I will have everything ready to go. 

But there are a few things that are independent of such core changes to WW, and I'd like to start pushing those. If you like, don't merge and just let it all accumulate here. I would still appreciate any observations you might make about these commits as they come in though.

This first commit is about a book's custom LaTeX macros. Right now, they are inserted into every little bit of math in a problem. Not an issue for MathJax, which can handle repeat \newcommand's. But this will be an issue for the new print scheme. So this commit allows `mathbook-webwork-pg.xsl` to see "know" it is being called from (the new, uncommitted) extraction template. If so, it omits the macro definitions.