### PR TITLE
Allow activity, exploration, and exercises inclusions in DTD

### DIFF
--- a/schema/dtd/mathbook.dtd
+++ b/schema/dtd/mathbook.dtd
@@ -253,8 +253,12 @@
     <!ATTLIST project xml:id ID #IMPLIED>
 <!ELEMENT activity (title?, index*, ((%para;)*|(statement, hint*, answer*, solution*)))>
     <!ATTLIST activity xml:id ID #IMPLIED>
+    <!ATTLIST activity xml:base CDATA    #IMPLIED>
+    <!ATTLIST activity xmlns:xi CDATA #FIXED "http://www.w3.org/2001/XInclude">
 <!ELEMENT exploration (title?, index*, ((%para;)*|(statement, hint*, answer*, solution*)))>
     <!ATTLIST exploration xml:id ID #IMPLIED>
+    <!ATTLIST exploration xml:base CDATA    #IMPLIED>
+    <!ATTLIST exploration xmlns:xi CDATA #FIXED "http://www.w3.org/2001/XInclude">
 <!ELEMENT task (title?, index*, ((%para;)*|(statement, hint*, answer*, solution*)))>
     <!ATTLIST task xml:id ID #IMPLIED>
 <!ELEMENT investigation (title?, index*, ((%para;)*|(statement, hint*, answer*, solution*)))>
@@ -603,6 +607,7 @@
 <!ELEMENT exercises (title?, index*, introduction?, (exercise|exercisegroup|todo)*, conclusion?)>
     <!ATTLIST exercises xml:id   ID       #IMPLIED>
     <!ATTLIST exercises xml:base CDATA    #IMPLIED>
+    <!ATTLIST exercises xmlns:xi CDATA #FIXED "http://www.w3.org/2001/XInclude">
 
 <!ELEMENT exercisegroup (introduction?, exercise+, conclusion?)>
     <!ATTLIST exercisegroup xml:id ID             #IMPLIED>


### PR DESCRIPTION
This PR is because Active Calculus has separated each `exercises`, `activity`, and `exploration` into its own file, which is then included via `xi:include`. These edits to the DTD make that DTD-compliant.

I could see not approving this for a number of reasons. But maybe it's OK because the DTD is not being maintained anyway. I just want to cut down DTD violations as I try to get Active ready to print, and at the same time I want to cut down on the current level of branching that I have going on.