### PR TITLE
Musical Time Signatures

### DIFF
--- a/examples/humanities/music.xml
+++ b/examples/humanities/music.xml
@@ -168,36 +168,54 @@
             </ul></p>
         </example>
     </section>
-
+    <section xml:id="time-signatures">
+        <title>Time Signatures</title>
+        <p>Time signatures are created using <c>&lt;timesignature&gt;</c>, <c>&lt;meter&gt;</c>, <c>&lt;top&gt;</c>, and <c>&lt;bottom&gt;</c> tags, though not all are used in every case.</p>
+        <p>The <q>symbolic</q> time signatures<mdash/><timesignature symbol="common"/> and <timesignature symbol="cut"/><mdash/>are produced by using <c>&lt;timesignature symbol="common"/&gt;</c> and <c>&lt;timesignature symbol="cut"/&gt;</c> respectively.</p>
+        <p>We may create basic time signatures like <timesignature><top>3</top><bottom>4</bottom></timesignature> by wrapping the <q>top</q> number in a <c>&lt;top&gt;</c> tag and the <q>bottom</q> number in a <c>&lt;bottom&gt;</c> tag, all of which is wrapped in a <c>&lt;timesignature&gt;</c> tag. Within these we may also create more complicated time signatures by inserting an additive numerator (<eg/>, <c>2+3+2</c>) in the <c>&lt;top&gt;</c> tag to get a time signature like <timesignature><top>2+3+2</top><bottom>8</bottom></timesignature>.</p>
+        <p>In addition, we can create additive time signatures that use different denominators, such as <timesignature><meter><top>3</top><bottom>4</bottom></meter><meter><top>3</top><bottom>8</bottom></meter></timesignature> by wrapping each <q>sub time signature</q> (<ie/>, each portion of the time signature that could as a time signature on its own) in a <c>&lt;meter&gt;</c> tag. Thus, to get <timesignature><meter><top>3</top><bottom>4</bottom></meter><meter><top>3</top><bottom>8</bottom></meter></timesignature>, we would write:<cd>
+            <cline>&lt;timesignature&gt;</cline>
+            <cline>    &lt;meter&gt;</cline>
+            <cline>        &lt;top&gt;3&lt;/top&gt;</cline>
+            <cline>        &lt;bottom&gt;4&lt;/bottom&gt;</cline>
+            <cline>    &lt;/meter&gt;</cline>
+            <cline>    &lt;meter&gt;</cline>
+            <cline>        &lt;top&gt;3&lt;/top&gt;</cline>
+            <cline>        &lt;bottom&gt;8&lt;/bottom&gt;</cline>
+            <cline>    &lt;/meter&gt;</cline>
+            <cline>&lt;/timesignature&gt;</cline>
+        </cd></p>
+        <p>While not commonly used, time signatures such as <timesignature><meter><top>2+3</top><bottom>4</bottom></meter><meter><top>3</top><bottom>8</bottom></meter></timesignature> can be created simply by combining the previous two constructions in the natural way.</p>
+        <!-- As a note, time signatures like (2 1/2)/4 do not work in LilyGlyphs (the package used with XeLaTeX), presumably because the solidus/slash's location in the Feta font is not its canonical font location. -->
+    </section>
     <section xml:id="scores">
         <title>Scores</title>
 
         <introduction>
-            <p>A score may be represented in several formats: <init>PDF</init> output from a scorewriter (not a scan of printed sheet music), an <init>XML</init> file in the MusicXML format, online within MuseScore, or in Lilypond syntax.  We plan to support various output options and conversions, but at this writing support is rudimentary, but evolving.</p>
+            <p>A score may be represented in several formats: <init>PDF</init> output from <term>notation software</term> (not a scan of printed sheet music), an <init>XML</init> file in the MusicXML format, online within MuseScore, or in LilyPond syntax. We plan to support various output options and conversions, but at this writing support is rudimentary, but evolving.</p>
         </introduction>
 
         <subsection>
             <title><init>PDF</init> Source</title>
 
-            <p>Starting with a <init>PDF</init> that is <q>born digital</q> such as output from a <term>scorewriter</term> like Finale, it is possible to treat the score simply as we would any other image.  The <init>PDF</init> version will be incorporated into the <init>PDF</init> output when the <latex /> output is compiled, presuming the file is placed in the right location relative to the main <tex /> file.  For <init>HTML</init> output the utilities <c>pdfcrop</c> and <c>pdf2svg</c> will produce an <init>SVG</init> image that will work well.</p>
+            <p>Starting with a <init>PDF</init> that is <q>born digital</q>, such as output from <term>notation software</term> (<eg/>, Finale), it is possible to treat the score simply as we would any other image. The <init>PDF</init> version will be incorporated into the <init>PDF</init> output when the <latex/> output is compiled, presuming the file is placed in the right location relative to the main <tex/> file. For <init>HTML</init> output the utilities <c>pdfcrop</c> and <c>pdf2svg</c> will produce an <init>SVG</init> image that will work well.</p>
 
-            <p>This procedure will work best for very short scores, since it is treated as an indivisible image.  For <latex /> output, a longer score can lead to very poor page breaks, and large vertical gaps, especially in a preceding page.  Or worse, the score might be longer than a single page, for which there is no solution. The piece below is inadvisably long and will likely demonstrate this behavior, though it is shorter than a page.  Using scores authored, or converted to, Lilypond syntax should allow for better behavior of longer scores within a <latex /> document.</p>
+            <p>This procedure will work best for very short scores, since it is treated as an indivisible image. For <latex/> output, a longer score can lead to very poor page breaks, and large vertical gaps, especially in a preceding page. Or worse, the score might be longer than a single page, for which there is no (current) solution. The piece below is inadvisedly long and will likely demonstrate this behavior, though it is shorter than a page. Using scores authored, or converted to, LilyPond syntax should allow for better behavior of longer scores within a <latex/> document.</p>
 
             <figure>
                 <caption>Allegretto in F, Rob Hutchinson</caption>
-                <image source="images/allegretto-in-F-hutchinson" />
+                <image source="images/allegretto-in-F-hutchinson"/>
             </figure>
         </subsection>
 
         <subsection>
             <title>Embedded Interactive Musical Scores</title>
 
-            <p>A score hosted on <url href="http://musescore.com">MuseScore</url> is easy to specify with two ID numbers: the user number and the score number (examine the source for details).  Then an embedded interactive player is nearly trivial to embed into <init>HTML</init> output.  Work continues on a process to realize the score within <latex /> output.</p>
+            <p>A score hosted on <url href="http://musescore.com">MuseScore</url> is easy to specify with two ID numbers: the user number and the score number (examine the source for details). Then an embedded interactive player is nearly trivial to embed into <init>HTML</init> output. Work continues on a process to realize the score within <latex/> output.</p>
 
             <figure>
                 <caption><url href="https://musescore.com/user/141988/scores/3113841">String Quartet 1</url> by <url href="https://musescore.com/user/141988">Lily He</url></caption>
-
-                <score musescoreuser="141988" musescore="3113841" />
+                <score musescoreuser="141988" musescore="3113841"/>
             </figure>
         </subsection>
     </section>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -6737,6 +6737,63 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#x00F8;</xsl:text>
 </xsl:template>
 
+<!--                 -->
+<!-- Time Signatures -->
+<!--                 -->
+
+<!-- Common Time -->
+<xsl:template name="common-time">
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12px" height="18px">
+        <title>4/4</title>
+        <desc>The symbolic time signature equivalent to 4/4.</desc>
+        <path unicode="&#x1D134;" transform="translate(0,9) scale(0.025,0.025)" d="M359 27c-49 0 -75 42 -75 75c0 38 27 77 72 77c4 0 9 0 14 -1c-28 37 -72 59 -120 59c-106 0 -113 -73 -113 -186v-51v-51c0 -113 7 -187 113 -187c80 0 139 70 158 151c2 7 7 10 12 10c6 0 13 -4 13 -12c0 -94 -105 -174 -183 -174c-68 0 -137 21 -184 70 c-49 51 -66 122 -66 193s17 142 66 193c47 49 116 69 184 69c87 0 160 -64 175 -150c1 -5 1 -9 1 -13c0 -40 -30 -72 -67 -72z"></path>
+    </svg>
+</xsl:template>
+
+<!-- Cut Time -->
+<xsl:template name="cut-time">
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12px" height="18px">
+        <title>2/2</title>
+        <desc>The symbolic time signature equivalent to 2/2.</desc>
+        <path unicode="&#x1D135;" transform="translate(0,9) scale(0.025,0.025)" d="M359 27c-49 0 -75 42 -75 75c0 38 27 77 72 77c4 0 9 0 14 -1c-28 37 -72 59 -120 59h-13v-474c4 0 9 -1 13 -1c80 0 139 70 158 151c2 7 7 10 12 10c6 0 13 -4 13 -12c0 -94 -105 -174 -183 -174c-4 0 -9 1 -13 1v-78c0 -6 -4 -10 -10 -10h-17c-6 0 -10 4 -10 10v81 c-51 8 -99 29 -134 66c-49 51 -66 122 -66 193s17 142 66 193c35 37 83 58 134 66v81c0 6 4 10 10 10h17c6 0 10 -4 10 -10v-78h13c87 0 160 -64 175 -150c1 -5 1 -9 1 -13c0 -40 -30 -72 -67 -72zM200 -230v460c-58 -22 -63 -87 -63 -179v-51v-51c0 -92 5 -157 63 -179z"></path>
+    </svg>
+</xsl:template>
+
+<!-- Numeric Time Signatures -->
+<!-- Note: As of now, the numeric time signatures produced by pdfLaTeX are rather ugly -->
+<!-- If using timesignatures, it is HIGHLY recommended to use XeLaTeX for PDF creation -->
+<xsl:template match="timesignature">
+    <xsl:choose>
+        <xsl:when test="@symbol = 'common'">
+            <xsl:call-template name="common-time"/>
+        </xsl:when>
+        <xsl:when test="@symbol = 'cut'">
+            <xsl:call-template name="cut-time"/>
+        </xsl:when>
+        <xsl:when test="not(meter)">
+            <xsl:call-template name="single-meter"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="meter">
+    <xsl:text>(</xsl:text>
+    <xsl:call-template name="single-meter"/>
+    <xsl:text>)</xsl:text>
+    <xsl:if test="following-sibling::meter">
+        <xsl:text>+</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="single-meter">
+    <xsl:value-of select="top"/>
+    <xsl:text>/</xsl:text>
+    <xsl:value-of select="bottom"/>
+</xsl:template>
+
 <!-- Raw Bibliographic Entry Formatting              -->
 <!-- Markup really, not full-blown data preservation -->
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1224,7 +1224,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newcommand{\poemlineright}[1]{{\raggedleft{#1}\par}\vspace{-\parskip}}&#xa;</xsl:text>
     </xsl:if>
     <!-- Music -->
-    <xsl:if test="//n or //scaledeg or //chord">
+    <xsl:if test="//n or //scaledeg or //chord or //timesignature">
         <xsl:text>%% Musical Symbol Support&#xa;</xsl:text>
         <xsl:text>\ifthenelse{\boolean{xetex}}{&#xa;</xsl:text>
         <xsl:text>%% begin: xelatex-specific configuration&#xa;</xsl:text>
@@ -1232,6 +1232,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\lilyGlobalOptions{scale=0.8}&#xa;</xsl:text>
         <!-- Create alias to lilyglyphs command with common name -->
         <xsl:text>\newcommand*{\doubleflat}{\flatflat}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\meterC}{\lilyTimeC{}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\meterCHalf}{\lilyTimeCHalf{}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignature}[2]{\lilyTimeSignature[scale=1.25]{#1}{#2}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignatureGroup}[1]{#1}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignaturePlus}{\lilyText[scale=1.875,raise=-0.25]{+}}&#xa;</xsl:text>
         <xsl:text>%% end: xelatex-specific configuration&#xa;</xsl:text>
         <xsl:text>}{&#xa;</xsl:text>
         <xsl:text>%% begin: pdflatex-specific configuration&#xa;</xsl:text>
@@ -1251,6 +1256,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\renewcommand*\sharp{\raisebox{0.5ex}{\usefont{U}{musix}{m}{n}\selectfont{4}}}&#xa;</xsl:text>
         <xsl:text>\newcommand*\doublesharp{\raisebox{0.5ex}{\usefont{U}{musix}{m}{n}\selectfont{5}}}&#xa;</xsl:text>
         <xsl:text>\renewcommand*\natural{\raisebox{0.5ex}{\usefont{U}{musix}{m}{n}\selectfont{6}}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*\meterC{\raisebox{0.65ex}{\usefont{U}{musix}{m}{n}\selectfont{S}}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*\meterCHalf{\meterC{\kern-0.45ex}\rule[-0.3ex]{0.1ex}{1.9ex}{\kern0.5ex}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignature}[2]{\ensuremath{\genfrac{}{}{0pt}{1}{#1}{#2}}}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignatureGroup}[1]{\(#1\)}&#xa;</xsl:text>
+        <xsl:text>\newcommand*{\timeSignaturePlus}{+}&#xa;</xsl:text>
         <xsl:text>%% end: pdflatex-specific configuration&#xa;</xsl:text>
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
@@ -7365,6 +7375,55 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Double Flat -->
 <xsl:template name="doubleflat">
     <xsl:text>{\doubleflat}</xsl:text>
+</xsl:template>
+
+<!-- Time Signatures -->
+
+<!-- Common Time -->
+<xsl:template name="common-time">
+    <xsl:text>{\meterC}</xsl:text>
+</xsl:template>
+
+<!-- Cut Time -->
+<xsl:template name="cut-time">
+    <xsl:text>{\meterCHalf}</xsl:text>
+</xsl:template>
+
+<!-- Numeric Time Signatures -->
+<!-- Note: As of now, the numeric time signatures produced by pdfLaTeX are rather ugly -->
+<!-- If using timesignatures, it is HIGHLY recommended to use XeLaTeX for PDF creation -->
+<xsl:template match="timesignature">
+    <xsl:choose>
+        <xsl:when test="@symbol = 'common'">
+            <xsl:call-template name="common-time"/>
+        </xsl:when>
+        <xsl:when test="@symbol = 'cut'">
+            <xsl:call-template name="cut-time"/>
+        </xsl:when>
+        <xsl:when test="not(meter)">
+            <xsl:call-template name="single-meter"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>\timeSignatureGroup{</xsl:text>
+            <xsl:apply-templates/>
+            <xsl:text>}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="meter">
+    <xsl:call-template name="single-meter"/>
+    <xsl:if test="following-sibling::meter">
+        <xsl:text>{\timeSignaturePlus}</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="single-meter">
+    <xsl:text>\timeSignature{</xsl:text>
+    <xsl:value-of select="top"/>
+    <xsl:text>}{</xsl:text>
+    <xsl:value-of select="bottom"/>
+    <xsl:text>}</xsl:text>
 </xsl:template>
 
 <!-- Footnotes               -->


### PR DESCRIPTION
Currently time signature support is very good for LaTeX. XeLaTeX provides the best output but pdfLaTeX is also acceptable (if visually less pleasing).

On the other hand, HTLM output is typographically lacking, however it is of comparable quality with what I could find online already. The issues arise from two technical difficulties:
- First, the lack of support for unicode music symbols which is why symbolic time signatures are inserted as inline SVGs which reference the unicode glyph that *should* be there. In addition, they are supplied with a title and description for accessibility.
- Second, typographically correct time signatures are normally set in a music specific font and stacked (as can be seen in the XeLaTeX output), however as Google Fonts does not provide a music enabled font (and as most browsers enforce a same-origin policy) it would be difficult to achieve the characteristic look of typographically correct time signatures. However, it has become standard practice when writing about time signatures online to use a simple inline layout (e.g., 3/8, 2/4, etc.) and this presentation is sufficient (for now) for Dr. Robert Hutchinson who is (to my knowledge) the only author currently using the music capabilities of PTX.

It is possible that we can improve the HTML output in the future, but the current implementation should be sufficient for now.