### PR TITLE
Restore Normal Emphasis Behavior

### DIFF
--- a/contrib/ups-writers/ups-writers-latex.xsl
+++ b/contrib/ups-writers/ups-writers-latex.xsl
@@ -16,6 +16,7 @@
 <!-- presumably not a problem to attempt second load -->
 <xsl:param name="latex.preamble.late">
     <xsl:text>\usepackage{ulem}&#xa;</xsl:text>
+    <xsl:text>\normalem&#xa;</xsl:text>
 </xsl:param>
 
 <!-- General commands from the "ulem" package -->


### PR DESCRIPTION
To add the custom underline abilities of *Sound Writing*, we loaded `ulem`, but `ulem` makes `\emph` underline text instead of italicizing it. Adding `\normalem` returns `\emph` to italics, and this helps keep the LaTeX and HTML output visually similar.