### PR TITLE
Define sidebyside template for within a webwork

### DIFF
--- a/xsl/mathbook-webwork-pg.xsl
+++ b/xsl/mathbook-webwork-pg.xsl
@@ -689,6 +689,16 @@
     </xsl:choose>
 </xsl:template>
 
+<!-- ############################################## -->
+<!-- Sidebyside in a WeBWorK expects only one child -->
+<!-- It should be in the captionless family         -->
+<!-- Just applies its tempaltes                     -->
+<!-- ############################################## -->
+
+<xsl:template match="webwork//sidebyside">
+    <xsl:apply-templates />
+</xsl:template>
+
 <!-- ####################### -->
 <!-- PGML Image Construction -->
 <!-- ####################### -->


### PR DESCRIPTION
Recently, the WW sample chapter has not been grabbing images off the server to insert into the PDF. This was because these images were put inside a sidebyside with the recent sbs and schema work, and sidebyside was not defined within mathbook-webwork-pg.xsl. The PG output had nothing where the image should go, except its description. So when the base64 was sent to the server, there was no image to grab. The mbx script would have no way to know this. So the error only became visible when the pdf compilation was attempted.

I'm unsure if this is how you'd like to handle this. Perhaps you have something more specific in mind for sidebyside template here. I do too, even allowing more than one panel. But for now this makes the sample chapter compile again.

I'm also unsure if the schema is ready to distinguish between "sbs lite" with only one, captionless child. Can I leave it to you to do the right thing for the schema?