### PR TITLE
Make WeBWorK image widths be percentages

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -939,7 +939,7 @@
                             $gr = init_graph(-1,-1,4,4,
                             axes=>[0,0],
                             grid=>[5,5],
-                            size=>[400,400]
+                            size=>[300,300]
                             );
                             add_functions($gr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
                             $second_x = Real($answer*2**(1/3));
@@ -947,7 +947,7 @@
                             $solgr = init_graph(-1,-1,4,4,
                             axes=>[0,0],
                             grid=>[5,5],
-                            size=>[400,400]
+                            size=>[300,300]
                             );
                             add_functions($solgr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
                             $solgr->moveTo(0,1);
@@ -960,7 +960,7 @@
                     <statement>
                         <p>The graph below is a graph of <m>y=f(x)</m>. Use the graph to solve the equation <m>f(x)=1</m>.</p>
 
-                        <sidebyside>
+                        <sidebyside widths="50%">
                             <image pg-name="$gr">
                                 <description>a plot of a curve on a cartesian set of axes; the x axis ranges from -1 to 4, and the y-axis ranges from -1 to 4; the curve enters from the left, below the x-axis, and curves upward and to the right until it reaches the point (0,0); from here it continues predominantly rightward for a bit, bending slightly upward more and more as it progresses; it passes through the points (<var name="$answer"/>,1) and (<var name="$second_x"/>,2) before leaving the graph moving more and more upward and to the right.</description>
                             </image>
@@ -973,7 +973,7 @@
 
                         <p>The graph reveals that the only solution to <m>f(x)=1</m> is <m>x=<var name="$answer"/></m>.</p>
 
-                        <sidebyside>
+                        <sidebyside widths="50%">
                             <image pg-name="$solgr">
                                 <description>a plot of a curve on a cartesian set of axes; the x axis ranges from -1 to 4, and the y-axis ranges from -1 to 4; the curve enters from the left, below the x-axis, and curves upward and to the right until it reaches the point (0,0); from here it continues predominantly rightward for a bit, bending slightly upward more and more as it progresses; it passes through the points ($answer,1) and ($second_x,2) before leaving the graph moving more and more upward and to the right; a horizontal line segment moves rightward from y=1 on the y-axis until it reaches a point on the curve; a vertical line segment moves down from this point to x=$answer on the x-axis.</description>
                             </image>
@@ -1265,41 +1265,41 @@
                     </setup>
                     <stage>
                         <statement>
-                            <sidebyside>
-                                <image pg-name="$gr[0]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[0]" />
                             </sidebyside>
-                            <sidebyside>
-                                <image pg-name="$gr[1]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[1]" />
                             </sidebyside>
                         </statement>
                         <solution>
-                            <sidebyside>
-                                <image pg-name="$gr[2]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[2]" />
                             </sidebyside>
                         </solution>
                     </stage>
                     <stage>
                         <statement>
-                            <sidebyside>
-                                <image pg-name="$gr[3]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[3]" />
                             </sidebyside>
-                            <sidebyside>
-                                <image pg-name="$gr[4]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[4]" />
                             </sidebyside>
-                            <sidebyside>
-                                <image pg-name="$gr[5]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[5]" />
                             </sidebyside>
                         </statement>
                         <!-- No hints for now because with displayMode=tex, the anonymous problem rendering is not -->
                         <!--generating a hints section at all. Will have to work with Mike to investigate this.    -->
                         <!--<hint>
-                            <sidebyside>
-                                <image pg-name="$gr[6]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[6]" />
                             </sidebyside>
                         </hint>-->
                         <solution>
-                            <sidebyside>
-                                <image pg-name="$gr[7]" width="150" height="150" tex-size="150"/>
+                            <sidebyside widths="25%">
+                                <image pg-name="$gr[7]" />
                             </sidebyside>
                         </solution>
                   </stage>
@@ -1582,20 +1582,20 @@
                         <p><ol>
                             <li>
                                 <p>Structured item</p>
-                                <sidebyside>
-                                    <image pg-name="$g" width="100" height="100"/>
+                                <sidebyside widths="17%">
+                                    <image pg-name="$g" />
                                 </sidebyside>
                             </li>
                             <li>
-                                <sidebyside>
-                                    <image pg-name="$g" width="100" height="100"/>
+                                <sidebyside widths="17%">
+                                    <image pg-name="$g" />
                                 </sidebyside>
                                 <p>Structured item</p>
                             </li>
                             <li>
                                 <p>Structured item</p>
-                                <sidebyside>
-                                    <image pg-name="$g" width="100" height="100"/>
+                                <sidebyside widths="17%">
+                                    <image pg-name="$g" />
                                 </sidebyside>
                                 <p>Second paragraph</p>
                             </li>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -2380,7 +2380,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Widths from sidebyside layouts have been error-checked as input    -->
 
 <!-- occurs in a figure, not contained in a sidebyside -->
-<xsl:template match="video[ancestor::sidebyside]|jsxgraph[ancestor::sidebyside]" mode="get-width-percentage">
+<xsl:template match="image[ancestor::sidebyside]|video[ancestor::sidebyside]|jsxgraph[ancestor::sidebyside]" mode="get-width-percentage">
     <!-- in a side-by-side, get layout, locate in layout -->
     <!-- and get width.  The layout-parameters template  -->
     <!-- will analyze an enclosing sbsgroup              -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -3316,7 +3316,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
     <xsl:text>\noindent%&#xa;</xsl:text>
     <xsl:text>\textbf{Part </xsl:text>
-    <xsl:apply-templates select="." mode="serial-number" />
+    <xsl:apply-templates select="parent::stage" mode="serial-number" />
     <xsl:text>.}\quad </xsl:text>
     <xsl:apply-templates />
     <xsl:text>\par&#xa;</xsl:text>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -3521,22 +3521,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- default for tex-size                                  -->
 
 <xsl:template match="webwork//image[@pg-name]">
+    <xsl:variable name="width">
+        <xsl:apply-templates select="." mode="get-width-percentage" />
+    </xsl:variable>
     <xsl:text>\includegraphics[width=</xsl:text>
-    <xsl:choose>
-        <xsl:when test="@tex-size">
-            <xsl:value-of select="@tex-size*0.001"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text>0.667</xsl:text>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>\linewidth]{</xsl:text>
-        <!-- assumes path has trailing slash -->
-        <xsl:value-of select="$webwork.server.latex" />
-        <xsl:apply-templates select="ancestor::webwork" mode="internal-id" />
-        <xsl:text>-image-</xsl:text>
-        <xsl:number count="image[@pg-name]" from="webwork" level="any" />
-        <xsl:text>.png</xsl:text>
+    <xsl:value-of select="substring-before($width,'%') div 100" />
+    <xsl:text>\linewidth]</xsl:text>
+    <xsl:text>{</xsl:text>
+    <!-- assumes path has trailing slash -->
+    <xsl:value-of select="$webwork.server.latex" />
+    <xsl:apply-templates select="ancestor::webwork" mode="internal-id" />
+    <xsl:text>-image-</xsl:text>
+    <xsl:number count="image[@pg-name]" from="webwork" level="any" />
+    <xsl:text>.png</xsl:text>
     <xsl:text>}&#xa;</xsl:text>
 </xsl:template>
 
@@ -6055,36 +6052,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>]}</xsl:text>
 </xsl:template>
 
-
-<!-- ############################# -->
-<!-- Widths of Images, Videos, Etc -->
-<!-- ############################# -->
-
-<!-- For LaTeX, we need a fixed fraction of the linewidth,             -->
-<!-- so we need to get the right entry from the sidebyside layout.     -->
-<!-- This is complicated slightly by two possibilities for the element -->
-<!-- of the sidebyside, a naked image, or a figure holding an image    -->
-<!-- See xsl/mathbook-common.xsl for more information                  -->
-<xsl:template match="image[ancestor::sidebyside]" mode="get-width-percentage">
-    <!-- in a side-by-side, get layout, locate in layout -->
-    <!-- and get width.  The layout-parameters template  -->
-    <!-- will analyze an enclosing sbsgroup              -->
-    <xsl:variable name="enclosing-sbs" select="ancestor::sidebyside" />
-    <xsl:variable name="rtf-layout">
-        <xsl:apply-templates select="$enclosing-sbs" mode="layout-parameters" />
-    </xsl:variable>
-    <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
-    <xsl:choose>
-        <xsl:when test="parent::figure">
-            <xsl:variable name="panel-number" select="count(parent::figure/preceding-sibling::*) + 1" />
-            <xsl:value-of select="$layout/width[$panel-number]" />
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:variable name="panel-number" select="count(preceding-sibling::*) + 1" />
-            <xsl:value-of select="$layout/width[$panel-number]" />
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
 
 <!-- ###### -->
 <!-- Images -->


### PR DESCRIPTION
This will need a deprecation warning/alert. And it's not backward compatible: WW image widths need to be percentages now like everywhere else. Also, this should allow you to tidy up the schema some.

After this, I can PR the new extraction style sheets and the new webwork component for the mbx script.