### PR TITLE
Enable full screen on videos

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -5415,6 +5415,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             width="{$width}"
             height="{$height}"
             frameborder="0"
+            allowfullscreen=""
             src="{$source-url}" />
 </xsl:template>
 


### PR DESCRIPTION
Prior to this commit, if I play the YouTube videos at 
http://mathbook.pugetsound.edu/examples/sample-article/html/section-video.html

there is a YouTube-provided icon at the lower right, but clicking it says full screen is not enabled. With this small change, I can make the videos full screen.

All examples that I find leave out the `=""`. But `xsltproc` is not OK with that when processing this, since the `iframe` is built directly. The `=""` seems to work for me at least.

This W3C report claims it is implemented across browsers:
http://w3c.github.io/test-results/html51/implementation-report.html