### PR TITLE
Merge source with auxiliary WeBWorK XML

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -108,6 +108,18 @@ mini-extraction:
 	-rm $(WWOUT)/webwork-extraction.xml
 	$(MB)/script/mbx -v -c webwork -d $(WWOUT) -s $(SERVER) $(MINI)
 
+#  Make a new PTX file from the source tree, with webwork elements replaced
+#  by the webwork-reps from webwork-extraction.xml. (So run the above at
+#  least once first.) Subsequent templates are applied to the result here.
+
+sample-chapter-merge:
+	cd $(SCRATCH); \
+	xsltproc --stringparam webwork.extraction $(WWOUT)/webwork-extraction.xml $(MBXSL)/pretext-merge.xsl $(SMPCHP) > sample-chapter-merge.ptx
+
+mini-merge:
+	cd $(SCRATCH); \
+	xsltproc --stringparam webwork.extraction $(WWOUT)/webwork-extraction.xml $(MBXSL)/pretext-merge.xsl $(MINI) > mini-merge.ptx
+
 #  Write out each WW problem of the "sample-chapter" as a
 #  standalone problem in PGML ready for use on a WW server.
 #  "def" files and "header" files are produced. Directories

--- a/xsl/pretext-merge.xsl
+++ b/xsl/pretext-merge.xsl
@@ -1,0 +1,77 @@
+<?xml version='1.0'?>
+
+<!-- ********************************************************************* -->
+<!-- Copyright 2017                                                        -->
+<!-- Robert A. Beezer, Alex Jordan                                         -->
+<!--                                                                       -->
+<!-- This file is part of PreTeXt.                                         -->
+<!--                                                                       -->
+<!-- PreTeXt is free software: you can redistribute it and/or modify       -->
+<!-- it under the terms of the GNU General Public License as published by  -->
+<!-- the Free Software Foundation, either version 2 or version 3 of the    -->
+<!-- License (at your option).                                             -->
+<!--                                                                       -->
+<!-- PreTeXt is distributed in the hope that it will be useful,            -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of        -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         -->
+<!-- GNU General Public License for more details.                          -->
+<!--                                                                       -->
+<!-- You should have received a copy of the GNU General Public License     -->
+<!-- along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.      -->
+<!-- ********************************************************************* -->
+
+<!-- Identify as a stylesheet -->
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    exclude-result-prefixes="xsl"
+>
+
+<!-- Occasionally there is a need to use auxiliary XML files to process    -->
+<!-- PTX. This style sheet merges source with the auxiliary XML so that    -->
+<!-- there can be a new single XML tree for further processing by the      -->
+<!-- primary PTX style sheets.                                             -->
+
+<!-- List of auxiliary XML this sytle sheet merges:                        -->
+<!-- * WeBWorK extractions                                                 -->
+
+<xsl:import href="./mathbook-common.xsl" />
+
+<!-- We output a single, large .ptx file for further -->
+<!-- processing by other PTX style sheets            -->
+<xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+<!-- Location of webwork-extraction                  -->
+<!-- These are collected from a webwork server       -->
+<!-- by the ptx script, webwork component            -->
+<xsl:param name="webwork.extraction" select="''" />
+<xsl:variable name="b-webwork-extraction" select="not($webwork.extraction = '')" />
+
+<!-- Match root, then start copying content -->
+<xsl:template match="/">
+    <xsl:copy>
+        <xsl:apply-templates select="@* | node()" />
+    </xsl:copy>
+</xsl:template>
+
+<!-- Walk the tree, copying everything as-is, except common -->
+<!-- templates applied, and webwork elements modified below -->
+<xsl:template match="@* | node()">
+    <xsl:copy>
+        <xsl:apply-templates select="@* | node()" />
+    </xsl:copy>
+</xsl:template>
+
+<!-- Don't match on simple WeBWorK logo       -->
+<!-- Seed and possibly source attributes      -->
+<!-- Then authored?, pg?, and static children -->
+<xsl:template match="webwork[node()|@*]">
+    <xsl:if test="not($b-webwork-extraction)">
+        <xsl:message terminate="yes">PTX:ERROR   You must specify the location of the webwork extraction using the "webwork.extraction" command line stringparam.  Use the mbx script and webwork component to collect these files from a WeBWorK server. Quitting...</xsl:message>
+    </xsl:if>
+    <xsl:variable name="ww-id">
+        <xsl:apply-templates select="." mode="internal-id" />
+    </xsl:variable>
+    <xsl:copy-of select="document($webwork.extraction)/webwork-extraction/webwork-reps[@ww-id=$ww-id]" />
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
OK, next one queued up. Some of the language in `pretext-merge.xsl` is intentionally not WeBWorK specific. The need to merge XML from other places with author source might come up again (GeoGebra?) so it seems appropriate to let this be a general purpose tool.

Do: `make mini-extraction` (or `make sample-chapter-extraction`) which is from the previous PR.

Then do the new thing: `make mini-merge` (or `make sample-chapter-merge`) and you will get a single XML file with all the PTX source, but extracted WW stuff inserted where there was originally a webwork.

Not much to _do_ with that, unless you want to play more like pasting stuff into the sample article. But there is some light code review. 

Next up after this, the style sheet for making WW problem sets (the standalone PG files, set definition files, set header files) which is the last thing we can do without messing up the current WW production scheme.

PageKite up and running until bed tonight. No reply yet on my request for a free account, but I noticed my 1 day cap somehow changed to 30 days. And my 5 connections is still 5 even though I used one yesterday. Maybe they are evaluating my request and did something temporary. Anyway, that means I'll boot it up again any day you'd like to use it. 