### PR TITLE
WeBWorK problem sets

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -120,6 +120,23 @@ mini-merge:
 	cd $(SCRATCH); \
 	xsltproc --stringparam webwork.extraction $(WWOUT)/webwork-extraction.xml $(MBXSL)/pretext-merge.xsl $(MINI) > mini-merge.ptx
 
+#  Make an archive of webwork problem sets for each "section" (as specified
+#  by chunk level) with set definition files, set  header files, and problem
+#  files in a file tree. Separate problem sets for inline and sectional
+#  problems. Requires the merged PTX file from above.
+
+sample-chapter-problem-sets:
+	install -d $(PGOUT)
+	cd $(PGOUT); \
+	rm -r Integrating_WeBWorK_into_Textbooks; \
+	xsltproc --stringparam chunk.level 1 $(MBXSL)/pretext-ww-problem-sets.xsl $(SCRATCH)/sample-chapter-merge.ptx
+
+mini-problem-sets:
+	install -d $(PGOUT)
+	cd $(PGOUT); \
+	rm -r WeBWorK_Minimal_Example; \
+	xsltproc --stringparam chunk.level 1 $(MBXSL)/pretext-ww-problem-sets.xsl $(SCRATCH)/mini-merge.ptx
+
 #  Write out each WW problem of the "sample-chapter" as a
 #  standalone problem in PGML ready for use on a WW server.
 #  "def" files and "header" files are produced. Directories

--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- ********************************************************************* -->
+<!-- Copyright 2015-7                                                      -->
+<!-- Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             -->
+<!--                                                                       -->
+<!-- This file is part of PreTeXt.                                         -->
+<!--                                                                       -->
+<!-- PreTeXt is free software: you can redistribute it and/or modify       -->
+<!-- it under the terms of the GNU General Public License as published by  -->
+<!-- the Free Software Foundation, either version 2 or version 3 of the    -->
+<!-- License (at your option).                                             -->
+<!--                                                                       -->
+<!-- PreTeXt is distributed in the hope that it will be useful,            -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of        -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         -->
+<!-- GNU General Public License for more details.                          -->
+<!--                                                                       -->
+<!-- You should have received a copy of the GNU General Public License     -->
+<!-- along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.      -->
+<!-- ********************************************************************* -->
+
+<!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "entities.ent">
+    %entities;
+]>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:date="http://exslt.org/dates-and-times"
+    extension-element-prefixes="exsl date"
+>
+
+<!-- Apply this style sheet to merged XML (see pretext-merge.xsl and       -->
+<!-- webwork-extraction.xsl) to produce a folder tree of .pg problem files -->
+<!-- with set defintion and set header files. Compress into a .tgz and     -->
+<!-- upload into a WeBWorK course (perhaps in the templates/local folder); -->
+<!-- or into a server's libraries folder and set up site-wide access.      -->
+
+<xsl:import href="./mathbook-common.xsl" />
+
+<!-- Intend output to be a PG/PGML problem -->
+<xsl:output method="text" />
+
+<!-- ######### -->
+<!-- Variables -->
+<!-- ######### -->
+
+<!-- Variables that affect PG archive creation -->
+<!-- More in the common file                  -->
+
+<!-- We default to one massive def file -->
+<xsl:variable name="chunk-level">
+    <xsl:choose>
+        <xsl:when test="$chunk.level != ''">
+            <xsl:value-of select="$chunk.level" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>0</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+<!-- ############## -->
+<!-- Entry template -->
+<!-- ############## -->
+
+<!-- First, create the problem files in directories                           -->
+<!-- Organized in directories as in the document tree, cut off at chunk level -->
+<!-- Then chunk the document to write reasonable problem definition files     -->
+<xsl:template match="/mathbook">
+    <xsl:apply-templates select="." mode="generic-warnings" />
+    <xsl:message>C: <xsl:value-of select="$chunk-level" /></xsl:message>
+    <xsl:apply-templates mode="problems" />
+    <xsl:apply-templates mode="chunking" />
+</xsl:template>
+
+<!-- Handle <webwork-reps> element carefully -->
+<!-- Recurse into other elements        -->
+<xsl:template match="*" mode="problems">
+    <xsl:apply-templates select="webwork-reps" mode="problems" />
+    <xsl:apply-templates select="*[not(self::webwork-reps)]" mode="problems" />
+</xsl:template>
+
+<!-- Kill non-element content outside of webwork -->
+<xsl:template match="text()" mode="problems" />
+
+
+<!-- ################## -->
+<!-- Extraction Wrapper -->
+<!-- ################## -->
+
+<!-- String for document root, but not docinfo -->
+<xsl:template name="root-directory">
+    <xsl:for-each select="/mathbook/*">
+        <xsl:if test="not(self::docinfo)">
+            <xsl:apply-templates select="." mode="numbered-title-filesafe" />
+            <xsl:text>/</xsl:text>
+        </xsl:if>
+    </xsl:for-each>
+</xsl:template>
+
+<!-- Directory path, recursively climb structural nodes,  -->
+<!-- record names as pass up through chunk-level barrier  -->
+<!-- Includes root document node (book, article, etc)     -->
+<xsl:template match="*" mode="directory-path">
+    <xsl:variable name="structural">
+        <xsl:apply-templates select="." mode="is-structural"/>
+    </xsl:variable>
+    <xsl:variable name="current-level">
+        <xsl:choose>
+            <xsl:when test="$structural = 'true'">
+                <xsl:apply-templates select="." mode="level" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>undefined</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="self::mathbook" /> <!-- done -->
+        <xsl:when test="$structural='false'">  <!-- skip up -->
+            <xsl:apply-templates select="parent::*" mode="directory-path" />
+        </xsl:when>
+        <!-- structural is true now, compare levels -->
+        <xsl:when test="$current-level > $chunk-level">  <!-- also skip up -->
+            <xsl:apply-templates select="parent::*" mode="directory-path" />
+        </xsl:when>
+        <xsl:otherwise> <!-- append current node name -->
+            <xsl:apply-templates select="parent::*" mode="directory-path" />
+            <xsl:apply-templates select="." mode="numbered-title-filesafe" />
+            <xsl:text>/</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Append a filename to the directory path              -->
+<xsl:template match="webwork-reps" mode="filename">
+    <xsl:apply-templates select="." mode="directory-path" />
+    <xsl:apply-templates select="parent::exercise" mode="numbered-title-filesafe" />
+    <xsl:text>.pg</xsl:text>
+</xsl:template>
+
+<!-- For problems from the OPL, just report the @source -->
+<xsl:template match="webwork-reps[pg/@source]" mode="filename">
+    <xsl:value-of select="pg/@source" />
+</xsl:template>
+
+<!-- Extract an authored problem into its own file        -->
+<!-- This is a wrapper around the "normal" representation -->
+<xsl:template match="webwork-reps[pg][not(pg/@source)]" mode="problems">
+    <xsl:variable name="filename">
+        <xsl:apply-templates select="." mode="filename" />
+    </xsl:variable>
+    <exsl:document href="{$filename}" method="text">
+        <xsl:call-template name="sanitize-text">
+            <xsl:with-param name="text" select="pg" />
+        </xsl:call-template>
+    </exsl:document>
+</xsl:template>
+
+<!-- OPL problems just get killed, they live on the server already -->
+<xsl:template match="webwork-reps[pg/@source]" mode="problems" />
+
+
+<!-- ################# -->
+<!-- Chunking Def Files-->
+<!-- ################# -->
+
+<!-- A complete file for a structural subdivision -->
+<xsl:template match="&STRUCTURAL;" mode="chunk">
+    <!-- Separate webwork within any exercises into their own set. -->
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="content">
+            <xsl:apply-templates select=".//webwork-reps[not(ancestor::exercises)]" mode="def-info-v2" />
+        </xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="exercises" select="true()" />
+        <xsl:with-param name="content">
+            <xsl:apply-templates select=".//webwork-reps[ancestor::exercises]" mode="def-info-v2" />
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- A summary file for a structural subdivision                -->
+<!-- Any webwork not in a subdivision (say, in an introduction) -->
+<!-- The // is OK here (rather than descendant-or-self) since   -->
+<!-- there will at least be an intervening "exercise" wrapper   -->
+<xsl:template match="&STRUCTURAL;" mode="intermediate">
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="content">
+            <xsl:apply-templates select="*[not(&STRUCTURAL-FILTER;)]//webwork-reps" mode="def-info-v2" />
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+
+<!-- ##################### -->
+<!-- Def File Construction -->
+<!-- ##################### -->
+
+<!-- A *.def file for a structural subdivision -->
+<xsl:template match="&STRUCTURAL;" mode="file-wrap">
+    <xsl:param name="content" />
+    <xsl:param name="exercises" select="false()" />
+    <!-- no problems, no def infos, then no file -->
+    <xsl:if test="not($content = '')">
+        <!-- filenames -->
+        <xsl:variable name="def-filename">
+            <xsl:call-template name="root-directory" />
+            <xsl:text>def/</xsl:text>
+            <!-- mandatory filename initial string -->
+            <xsl:text>set</xsl:text>
+            <xsl:apply-templates select="." mode="numbered-title-filesafe" />
+            <xsl:if test="$exercises">
+                <xsl:text>_Exercises</xsl:text>
+            </xsl:if>
+            <xsl:text>.def</xsl:text>
+        </xsl:variable>
+        <xsl:variable name="header-filename">
+            <xsl:call-template name="root-directory" />
+            <xsl:text>header/</xsl:text>
+            <xsl:apply-templates select="." mode="numbered-title-filesafe" />
+            <xsl:if test="$exercises">
+                <xsl:text>_Exercises</xsl:text>
+            </xsl:if>
+            <xsl:text>.pg</xsl:text>
+        </xsl:variable>
+        <!-- set-definition file -->
+        <exsl:document href="{$def-filename}" method="text">
+            <xsl:variable name="open" select="substring(date:date-time(),1,10)" />
+            <xsl:variable name="due" select="date:add($open,'P6M')" />
+            <xsl:variable name="answer" select="$due" />
+            <xsl:text>openDate          = </xsl:text>
+            <xsl:value-of select="substring($open, 6, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($open, 9, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($open, 1, 4)" />
+            <xsl:text> at 12:00am&#xa;</xsl:text>
+            <xsl:text>dueDate           = </xsl:text>
+            <xsl:value-of select="substring($due, 6, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($due, 9, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($due, 1, 4)" />
+            <xsl:text> at 10:00pm&#xa;</xsl:text>
+            <xsl:text>answerDate        = </xsl:text>
+            <xsl:value-of select="substring($due, 6, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($due, 9, 2)" />
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="substring($due, 1, 4)" />
+            <xsl:text> at 10:00pm&#xa;</xsl:text>
+            <xsl:text>paperHeaderFile   = </xsl:text>
+            <xsl:value-of select="$header-filename" />
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:text>screenHeaderFile  = </xsl:text>
+            <xsl:value-of select="$header-filename" />
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:text>description       = </xsl:text>
+            <xsl:apply-templates select="." mode="title-simple" />
+            <xsl:text>&#xa;</xsl:text>
+            <!-- Version 1 problem list lead-in -->
+            <!-- <xsl:text>problemList       = &#xa;</xsl:text> -->
+            <!--                                                -->
+            <!-- Version 2 problem list lead-in -->
+            <xsl:text>problemListV2&#xa;</xsl:text>
+            <xsl:copy-of select="$content" />
+        </exsl:document>
+        <!-- set-header file -->
+        <!-- a bit of a hack to write a second file here -->
+        <!-- but we avoid the entire $content used above -->
+        <exsl:document href="{$header-filename}" method="text">
+            <xsl:apply-templates select="." mode="header-content" />
+        </exsl:document>
+    </xsl:if>
+</xsl:template>
+
+<!-- Version 1 problem info -->
+<!-- Each problem gets its own line in the problem set   -->
+<!-- definition file. Be careful to create no content if -->
+<!-- there are no problems in a subdivision as we employ -->
+<!-- non-emptieness up the wrapping chain to ensure      -->
+<!--  no trivial problem definition files are created.   -->
+<!-- http://webwork.maa.org/wiki/Set_Definition_Files#Version_1 -->
+<xsl:template match="webwork-reps" mode="def-info-v1">
+    <xsl:apply-templates select="." mode="filename" />
+    <xsl:text>, </xsl:text>
+    <xsl:text>1</xsl:text> <!-- default weight -->
+    <xsl:text>, </xsl:text>
+    <xsl:text>-1</xsl:text> <!-- default max attempts is unlimited -->
+    <xsl:text>, </xsl:text>
+    <xsl:text></xsl:text> <!-- default SMA is blank -->
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Version 2 problem info -->
+<!-- Each problem gets its own line in the problem set   -->
+<!-- definition file. Be careful to create no content if -->
+<!-- there are no problems in a subdivision as we employ -->
+<!-- non-emptieness up the wrapping chain to ensure      -->
+<!--  no trivial problem definition files are created.   -->
+<!-- http://webwork.maa.org/wiki/Set_Definition_Files#Version_2 -->
+<xsl:template match="webwork-reps" mode="def-info-v2">
+    <xsl:text>problem_start&#xa;</xsl:text>
+    <xsl:text>source_file = </xsl:text> <!-- PG file -->
+    <xsl:apply-templates select="." mode="filename" />
+    <xsl:text>&#xa;</xsl:text>
+    <!--Much of the following commented out until we decide we should include them.   -->
+    <!--WeBWorK provides good default values, customizable by sysadmin or instructor. -->
+    <!--<xsl:text>value = 1&#xa;</xsl:text>--> <!-- default problem weight -->
+    <!--<xsl:text>max_attempts = -1&#xa;</xsl:text>--> <!-- default max attempts is unlimited -->
+    <!--<xsl:text>showMeAnother = -1&#xa;</xsl:text>--> <!-- default SMA is off -->
+    <xsl:text>problem_id = </xsl:text>
+    <xsl:apply-templates select="ancestor::exercise" mode="serial-number" />
+    <xsl:text>&#xa;</xsl:text>
+    <!--<xsl:text>counts_parent_grade = 0&#xa;</xsl:text>--> <!-- for JIT sets only -->
+    <!--<xsl:text>att_to_open_children = 0&#xa;</xsl:text>--> <!-- for JIT sets only -->
+    <xsl:text>problem_end&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Header file content -->
+<!-- Gives some information about where in the MBX project the set came from -->
+<!-- Some info changes with WW variables, such as due date -->
+<xsl:template match="*" mode="header-content">
+    <!-- Inneficient: indented text in variable, then strip indentation -->
+    <!-- Alternative: wrap each line in "text" with linefeeds           -->
+    <xsl:variable name="header-text">
+        <xsl:text>
+        # Header file for problem set </xsl:text><xsl:apply-templates select="." mode="numbered-title-filesafe" />
+        <xsl:text>
+        # This header file can be used for both the screen and hardcopy output
+
+        DOCUMENT();
+
+        loadMacros(
+            "PG.pl",
+            "PGbasicmacros.pl",
+            "PGML.pl",
+            "PGcourse.pl",
+        );
+
+        TEXT($BEGIN_ONE_COLUMN);
+
+        $texTopLine = "\noindent {\large \bf $studentName}\hfill{\large \bf {".protect_underbar($courseName)."}}";
+        if (defined($sectionName) and ($sectionName ne '')) {$texTopLine .= "  {\large \bf { Section: ".protect_underbar($sectionName)." } }"}; 
+        $texTopLine .= "\par";
+
+        ####################################################
+        #
+        # MODES provides for distinct output for TeX and HTML
+        #
+        ####################################################
+
+        TEXT(MODES(
+            TeX =&gt;"$texTopLine",
+            HTML=&gt;"",
+        ));
+
+        TEXT(MODES(
+            TeX =>"\noindent{\large \sc {Assignment ".protect_underbar($setNumber)." due $formatedDueDate}}\par".
+                  "\noindent \bigskip ",
+            HTML=>"&lt;span style='font-variant: small-caps; font-size:large;'&gt;WeBWorK Assignment ".protect_underbar($setNumber)." is due: $formattedDueDate. &lt;/span&gt;$PAR",
+        ));
+        </xsl:text><xsl:choose><xsl:when test="//frontmatter/colophon/website"><xsl:text>
+        TEXT(MODES(
+            TeX =>"\noindent This assignment contains exercises from </xsl:text><xsl:apply-templates select="." mode="division-name" /><xsl:text> </xsl:text><xsl:apply-templates select="." mode="number" /><xsl:text> of </xsl:text><xsl:apply-templates select="/mathbook/book|/mathbook/article"  mode="title-simple" /><xsl:text>.",
+            HTML=>"This assignment contains exercises from ".htmlLink(qq!</xsl:text><xsl:apply-templates select="//frontmatter/colophon/website" /><xsl:text>/</xsl:text><xsl:apply-templates select="." mode="internal-id" /><xsl:text>.html!,"</xsl:text><xsl:apply-templates select="." mode="division-name" /><xsl:text> </xsl:text><xsl:apply-templates select="." mode="number" /><xsl:text>")." of </xsl:text><xsl:apply-templates select="/mathbook/book|/mathbook/article"  mode="title-simple" /><xsl:text>."
+        ));
+        </xsl:text></xsl:when><xsl:otherwise><xsl:text>
+        TEXT("This assignment contains exercises from </xsl:text><xsl:apply-templates select="." mode="division-name" /><xsl:text> </xsl:text><xsl:apply-templates select="." mode="number" /><xsl:text> of </xsl:text><xsl:apply-templates select="/mathbook/book|/mathbook/article"  mode="title-simple" /><xsl:text>.");
+        </xsl:text></xsl:otherwise></xsl:choose><xsl:text>
+        TEXT($END_ONE_COLUMN);
+
+        ENDDOCUMENT();
+        </xsl:text>
+    </xsl:variable>
+    <!-- lazy, strips indentation, etc -->
+    <xsl:call-template name="sanitize-text">
+        <xsl:with-param name="text" select="$header-text" />
+    </xsl:call-template>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Before I forget, do you want to handle all the copyrights after this one?

Assuming you still have the merged XML from the previous stage of all this, you now do: `make mini-problem-sets` and `make sample-chapter-problem-sets`.

When we did all this way back when, I argued that everything should go into a `local` root folder. In practice, I found that was not the way to go and it's a big enough deal that I made the call to change this. With the WW File Manager, it's just easier to put it in `local` if you really want it there, but so much harder to pull it back up a level. (And there is another technical WW reason I won't get into.) So something you will have to contend with in your diff comparisons is the presence/absence of `local`.

I think I made some improvements to the set definition and set header production, so you will see diffs there. The PG files should also reveal changes. Hopefully all improvements.

If you can upload it all to your own WW server, great. But I did make this demonstration site:
https://webwork.pcc.edu/webwork2/pretext-demonstration/
Perhaps premature, but feel free to link to this when the time comes. I can't think of a good way to update its content though all the time like you do with the sample documents.