### PR TITLE
Streamline knowls

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -735,6 +735,16 @@ the xsltproc executable.
                         </solution>
                     </exercise>
 
+                    <example xml:id="example-math-title">
+                        <title>An Example of with <m>\frac12</m> math formula <m>\displaystyle{\int e^x \, dx}</m> in the title</title>
+                        <statement>
+                            <p>
+                               Just for testing math in knowls,
+                               and also extra whitespace in a <c>&lt;p&gt;</c>.
+                            </p>
+                        </statement>
+                    </example>
+
                     <p>There are many different blocks you can employ, and they mostly behave the same way.  A <c>&lt;project&gt;</c><idx><h>project</h></idx> is very similar to a <c>&lt;question&gt;</c><idx><h>question</h></idx> or <c>&lt;problem&gt;</c><idx><h>problem</h></idx></p>
 
                     <project>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8410,7 +8410,7 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
     <xsl:choose>
         <xsl:when test="$docinfo/brandlogo">
             <a id="logo-link" href="{$docinfo/brandlogo/@url}" target="_blank" >
-                <img src="{$docinfo/brandlogo/@source}" alt="Logo image for document"/>
+                <img src="{$docinfo/brandlogo/@source}" alt="Logo image"/>
             </a>
         </xsl:when>
         <xsl:otherwise>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8277,7 +8277,6 @@ This is a Java Applet created using GeoGebra from www.geogebra.org - it looks li
 
 <!-- Knowl header -->
 <xsl:template name="knowl">
-<link href="https://aimath.org/knowlstyle.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript" src="https://aimath.org/knowl.js"></script>
 </xsl:template>
 


### PR DESCRIPTION
Eliminate knowlstyle.css, because that code is elsewhere.

Add an example of math in knowls.

Shorten the alt text for the logo image (because the existing alt text disrupts the
layout too much when the logo image is not available).

Tested on sample article and looks okay.