### PR TITLE
Summary markup

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1314,6 +1314,14 @@ the xsltproc executable.
                     <mrow>x  \amp {}+{} \amp 3y \amp {}+{} \amp 2z \amp {}={} \amp 13.</mrow>
                 </md>Beautiful.</p>
 
+                <p>A long equation, to check layout on various screen sizes.  This is Weil's <q>explicit formula</q> for the
+                   Riemann <m>\zeta</m>-function:
+                  <men>
+        \sum_\gamma S_-(\gamma) = \frac{\log Q}{\pi} \hat S_-(0) 
+        + \frac{1}{2\pi} \sum_{j=1}^d \Re\left\{ \int_{-\infty}^\infty \frac{\Gamma'}{\Gamma}\left(\frac{1}{4} + \frac{it}{2} + \mu_j\right)S_-(t) dt\right\}
+        - \frac{d}{2\pi}\hat S_-(0)\log \pi
+                  </men>.
+                </p>
                 <example>
                     <title>Excessive Display Mathematics</title>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -444,7 +444,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="section-header" />
         <xsl:apply-templates select="author|objectives|introduction|titlepage|abstract" />
         <nav class="summary-links">
-            <xsl:apply-templates select="*" mode="summary-nav" />
+            <ul>
+                <xsl:apply-templates select="*" mode="summary-nav" />
+            </ul>
         </nav>
         <xsl:apply-templates select="conclusion"/>
     </section>
@@ -460,18 +462,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="url">
         <xsl:apply-templates select="." mode="url" />
     </xsl:variable>
-    <a href="{$url}">
-        <!-- important not include codenumber span -->
-        <xsl:if test="$num!=''">
-            <span class="codenumber">
-                <xsl:value-of select="$num" />
+    <li>
+        <a href="{$url}">
+            <!-- important not include codenumber span -->
+            <xsl:if test="$num!=''">
+                <span class="codenumber">
+                    <xsl:value-of select="$num" />
+                </span>
+            </xsl:if>
+            <!-- title is required on structural elements -->
+            <span class="title">
+                <xsl:apply-templates select="." mode="title-simple" />
             </span>
-        </xsl:if>
-        <!-- title is required on structural elements -->
-        <span class="title">
-            <xsl:apply-templates select="." mode="title-simple" />
-        </span>
-    </a>
+        </a>
+    </li>
 </xsl:template>
 
 <!-- introduction (etc.) and conclusion get dropped -->


### PR DESCRIPTION
Put summary links in a ul, as suggested in issue #804.

Added a wide equation to sample article, for testing different display widths.