### PR TITLE
Add option to asymptote command for no-GUI support

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -106,7 +106,7 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)
             asypng = "{}_*.png".format(filebase)
-            asy_cmd = [asy_executable, '-batchMask', '-outformat', outformat, asydiagram]
+            asy_cmd = [asy_executable, '-offscreen', '-batchMask', '-outformat', outformat, asydiagram]
             _verbose("converting {} to {}".format(asydiagram, asyout))
             _debug("asymptote conversion {}".format(asy_cmd))
             subprocess.call(asy_cmd, stdout=devnull, stderr=subprocess.STDOUT)


### PR DESCRIPTION
The `mbx` script's `asymptote_conversion` function uses a command that tries to open an X11 display when creating SVG graphics. This didn't work on the Vagrant box, which is CLI-only, but adding one switch at the command line seems to resolve the problem. Tested on a GUI Linux installation to make sure that `mbx -c asy -f svg ...` still works there. 😄 