### PR TITLE
modify mbx to add eps output for asymptote

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -1415,6 +1415,8 @@ elif args.component == 'asy':
         asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'pdf')
     elif args.format == 'svg':
         asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'svg')
+    elif args.format == 'eps':
+        asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'eps')
     elif args.format == 'source':
         asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'source')
     else:


### PR DESCRIPTION
It is useful to allow asymptote to output its (default) eps files. Some 3d files will fail using pdf output but will succeed with eps. This helps in debugging, and, in the worst case, allows a really bad file to be converted to svg by exceptional special processing. 

