### PR TITLE
Allow math mode in titles of tcolorbox elements

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1018,6 +1018,12 @@ the xsltproc executable.
                 <assemblage>
                     <p>This is a small <c>assemblage</c> with no title, simply to make sure the surrounding box behaves properly, especially for <latex /> output.</p>
                 </assemblage>
+                
+                <assemblage>
+                  <title>Assemblages containing <m>\mu \forall \tau \mathbb{H} = \emptyset \kappa</m></title>
+
+                  <p>It is acceptable for an assmblage to contain mathematical content, even in its title.</p>
+                </assemblage>
             </subsection>
 
             <subsection xml:id="subsection-intro-conclude">

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -889,7 +889,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newtcolorbox{assemblage}[1][]&#xa;</xsl:text>
         <xsl:text>  {breakable, skin=enhanced, arc=2ex, colback=blue!5, colframe=blue!75!black,&#xa;</xsl:text>
         <xsl:text>   colbacktitle=blue!20, coltitle=black, boxed title style={sharp corners, frame hidden},&#xa;</xsl:text>
-        <xsl:text>   fonttitle=\bfseries, attach boxed title to top left={xshift=4mm,yshift=-3mm}, top=3mm, title=#1}&#xa;</xsl:text>
+        <xsl:text>   fonttitle=\bfseries, attach boxed title to top left={xshift=4mm,yshift=-3mm}, top=3mm, title={#1}}&#xa;</xsl:text>
         <xsl:text>%% end: assemblage&#xa;</xsl:text>
     </xsl:if>
     <!-- Following chould be duplicated as three environments, perhaps with  \tcbset{}   -->
@@ -900,7 +900,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newtcolorbox{aside}[1]&#xa;</xsl:text>
         <xsl:text>  {breakable, skin=enhanced, sharp corners, colback=blue!3, colframe=blue!50!black,&#xa;</xsl:text>
         <xsl:text>   add to width=-1ex, shadow={1ex}{-1ex}{0ex}{black!50!white},&#xa;</xsl:text>
-        <xsl:text>   coltitle=black, fonttitle=\bfseries, title=#1, detach title, before upper={\tcbtitle\ \ }}&#xa;</xsl:text>
+        <xsl:text>   coltitle=black, fonttitle=\bfseries, title={#1}, detach title, before upper={\tcbtitle\ \ }}&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="//objectives">
         <xsl:text>%% objectives: early in a subdivision, introduction/list/conclusion&#xa;</xsl:text>


### PR DESCRIPTION
Previously, titles of assemblages (and I assume asides) that contained math mode content would throw an error when compiling with pdflatex.  To fix this, I wrapped the title content of each of these with braces, as suggested here: https://tex.stackexchange.com/questions/204577/math-inside-title-in-tcolorbox.

Added example to sample article.  Compiles correctly (latex and html work).