### PR TITLE
Warning about trailing slashes in "webwork.server".

### DIFF
--- a/doc/author-guide/webwork.xml
+++ b/doc/author-guide/webwork.xml
@@ -250,6 +250,7 @@
                     <input>xsltproc --stringparam webwork.server https://webwork.myschool.edu &lt;xsl&gt; &lt;xml&gt;</input>
                 </console>
             </sidebyside>
+            <p>Note: Make sure not to use a trailing slash (/) in the string parameter for <c>webwork.server</c>.</p>
             <p>If your <c>webwork.server</c> is running version 2.11 (the first version which can be used with MBX), then you should additionally pass <c>--stringparam webwork.version 2.11</c>.</p>
             <p>For HTML output, this is all that is needed. For <latex />, you may need to do more first. See <xref ref="webwork-latex-output"/>.</p>
         </subsection>


### PR DESCRIPTION
Using a trailing slash in this string leads to JavaScript problems when the `checkOrigin` parameter of `iFrameResize` is evaluated.