### PR TITLE
The enclosing tag for an aside is 'aside'

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -2231,7 +2231,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Overall enclosing element -->
 <xsl:template match="&ASIDE-LIKE;" mode="body-element">
-    <xsl:text>article</xsl:text>
+    <xsl:text>aside</xsl:text>
 </xsl:template>
 
 <!-- And its CSS class -->


### PR DESCRIPTION
Asides were an "article".  Now they are an "aside".

The change may seem trivial, but it is a step toward refactoring asides.
With this change, when the screen is narrow an aside will look different:
it will be smaller and shifted right, and the other text will flow around it.