### PR TITLE
New temporary CSS file

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -516,7 +516,7 @@ the xsltproc executable.
                 </output>
             </sage>
 
-            <p>Our maximum width for text, designed for readability, suggests you should format your Sage code with a maximum of about 54 characters. On a mobile device, the number of displayed characters might be as low as 28 in portrait orintation, and again around 50 in landscape.  You can use a variety of techniques to shorten long lines, such as using intermediate variables.  Since Sage is just a huge Python library, you can use any of Python's facilities for handling long lines.  These include a continuation character (which I try to avoid using) or natural places where you can break long lines, such as between entries of a list.  Also, if writing loops or functions, you may wish to have your indentation be only two characters wide (rather than, say, four).</p>
+            <p>Our maximum width for text, designed for readability, suggests you should format your Sage code with a maximum of about 54 characters. On a mobile device, the number of displayed characters might be as low as 28 in portrait orientation, and again around 50 in landscape.  You can use a variety of techniques to shorten long lines, such as using intermediate variables.  Since Sage is just a huge Python library, you can use any of Python's facilities for handling long lines.  These include a continuation character (which I try to avoid using) or natural places where you can break long lines, such as between entries of a list.  Also, if writing loops or functions, you may wish to have your indentation be only two characters wide (rather than, say, four).</p>
 
             <p>Sage output can sometimes be quite long, though this has improved with some changes in Sage's output routines.  Output code should be included primarily for doctesting purposes, and in this use, you may break at almost whitespace character and the doctesting framework will adjust accordingly.  You may wish to show sample output in a static format, like a PDF, so you can consider formatting your output to fit the width constraints of that medium.  Or you may even adjust exactly what is output, to keep it from being too verbose.  Sage doctesting also allows for a wild-card style syntax which allows you to skip over huge chunks of meaningless or unpredictable output, such as tracebacks on error messages.</p>
 
@@ -1049,13 +1049,13 @@ the xsltproc executable.
                     <title>Test One</title>
 
                     <p>An intervening subsubsection just after an introduction.</p>
-                </subsubsection> 
+                </subsubsection>
 
                 <subsubsection>
                     <title>Test Two</title>
 
                     <p>An intervening subsubsection just before a conclusion.</p>
-                </subsubsection> 
+                </subsubsection>
 
                 <conclusion>
                     <p>Entirely analogous to introductions are conclusions.  Any subdivision may have a sequence of paragraphs within a <c>&lt;conclusion&gt;</c> that follows previous further subdivisions.  You are reading one now.  They are always leaves of the document structure, so are rendered on some pages that reference the preceding subdivisions.</p>
@@ -1334,7 +1334,7 @@ the xsltproc executable.
                 <p>A long equation, to check layout on various screen sizes.  This is Weil's <q>explicit formula</q> for the
                    Riemann <m>\zeta</m>-function:
                   <men>
-        \sum_\gamma S_-(\gamma) = \frac{\log Q}{\pi} \hat S_-(0) 
+        \sum_\gamma S_-(\gamma) = \frac{\log Q}{\pi} \hat S_-(0)
         + \frac{1}{2\pi} \sum_{j=1}^d \Re\left\{ \int_{-\infty}^\infty \frac{\Gamma'}{\Gamma}\left(\frac{1}{4} + \frac{it}{2} + \mu_j\right)S_-(t) dt\right\}
         - \frac{d}{2\pi}\hat S_-(0)\log \pi
                   </men>.
@@ -2560,7 +2560,13 @@ the xsltproc executable.
                 </p>
 
 
-                <p>This section contains nested lists, to demonstrate how they get assigned labels (numbering, symbols).  But we begin with two simple lists, demonstrating an ordered list and an unordered list.  See the end of section for an example of a description list.Note in the source the optional use of a paragraph (<c>p</c>) for the list items of the list of colors.</p>
+                <p>This section contains nested lists,
+                   to demonstrate how they get assigned labels (numbering, symbols).
+                   But we begin with two simple lists,
+                   demonstrating an ordered list and an unordered list.
+                   See the end of section for an example of a description list.
+                   Note in the source the optional use of a paragraph
+                   (<c>p</c>) for the list items of the list of colors.</p>
 
                 <p><ol>
                     <li>First.</li>
@@ -5233,17 +5239,17 @@ the xsltproc executable.
                     </tabular>
                 </table>
             </subsection>
-            
+
             <subsection>
                 <title>A Single Captionless Image</title>
 
                 <p>Sometimes you may want to include a single <c>image</c> or <c>table</c> in an example or exercise without a caption. You can also achieve this using <c>sidebyside</c>. The first has width <c>10%</c>, and the second has width <c>10%</c> and margins <c>25%</c>.</p>
-                    
+
                 <sidebyside width="10%">
                     <image source="images/cross-square.png"/>
                 </sidebyside>
 
-                <p>A paragraph, just to show where the first stops and the second ends.</p> 
+                <p>A paragraph, just to show where the first stops and the second ends.</p>
 
                 <sidebyside width="10%" margins="25%">
                     <image source="images/cross-square.png"/>
@@ -5269,7 +5275,7 @@ the xsltproc executable.
                 </sidebyside>
 
             </subsection>
-            
+
             <subsection>
                 <title>Vertical Alignment</title>
                 <p>Vertical alignment can be specified using the <c>valign</c> attribute which admits a space-separated list of <c>top</c>, <c>middle</c>, and <c>bottom</c>; the default is <c>top</c>.</p>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8972,7 +8972,7 @@ function() { </xsl:text><xsl:value-of select="$applet-name" /><xsl:text>.inject(
 <!-- The "one-css" template is defined elsewhere -->
 <xsl:template name="css">
     <link href="{$html.css.server}/mathbook/stylesheets/{$html.css.file}" rel="stylesheet" type="text/css" />
-    <link href="https://aimath.org/mathbook/mathbook-add-on.css" rel="stylesheet" type="text/css" />
+    <link href="https://aimath.org/mathbook/mathbook-add-on2.css" rel="stylesheet" type="text/css" />
     <!-- If extra CSS is specified, then unpack multiple CSS files -->
     <!-- The prepared list (extra blank space) will cause failure  -->
     <!-- if $html.css.extra is empty (i.e. not specified)          -->


### PR DESCRIPTION
As part of the transition to the new CSS, there will be some backward-incompatible changes.
This pull request will make that less painful.
The only real change is to have the HTML use mathbook-add-on2.css instead of the old mathbook-add-on.css .

There was some clean-up of the CSS, but the only obvious difference is that the "pink-flash"
works better when you link to a complicated structure like a subsection (previously it looked "jagged").

I also fixed a couple typos and deleted some trailing white space.  I note that in the view on
GitHub it is not easy to see exactly what typos were fixed.  Score one for structured source.