### PR TITLE
Add aria-label to TOC toggle button.

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8299,6 +8299,9 @@ function() { </xsl:text><xsl:value-of select="$applet-name" /><xsl:text>.inject(
                     <xsl:attribute name="class">
                         <xsl:text>sidebar-left-toggle-button button active</xsl:text>
                     </xsl:attribute>
+                    <xsl:attribute name="aria-label">
+                        <xsl:text>Show or hide table of contents sidebar</xsl:text>
+                    </xsl:attribute>
                     <xsl:call-template name="type-name">
                         <xsl:with-param name="string-id" select="'toc'" />
                     </xsl:call-template>


### PR DESCRIPTION
The "hamburger" icon in the TOC toggle button is distracting for users of screen
readers.  This  aria-label may correct that problem, unless there is an issue with the
character being inserted as a ":before" element from CSS.