### PR TITLE
Text after a multicolumn list

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2752,6 +2752,8 @@ the xsltproc executable.
                     <li>Tres item.</li>
                     <li>Quattro items.</li>
                 </ul></p>
+
+                <p>And a paragraph after that list so that spacing can be checked.</p>
             </subsection>
 
             <subsection>


### PR DESCRIPTION
There was a long-standing but unnoticed CSS problem when a multicolumn list
has a paragraph after it.  This adds an example.

The CSS problem has not been fixed yet.