### PR TITLE
Support multicolumn lists in static WW output

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -599,6 +599,79 @@
                 </webwork>
             </exercise>
 
+            <exercise>
+                <introduction>
+                    <p>This exercise illustrates what happens when source has a multicolumn list. In <webwork /> itself, there is no provisioning for multicolumn lists, so live output here should not respect the indicated <c>cols</c> attribute. However, when <pretext /> produces static output, we do recover the value of <c>cols</c>. So in PDF and static HTML these lists should appear with multiple columns.</p>
+                </introduction>
+                <webwork>
+                    <statement>
+                        <p>This list has three columns in static output.<ol cols="3">
+                            <li>
+                                <p>Argentina</p>
+                            </li>
+                            <li>
+                                <p>Belize</p>
+                            </li>
+                            <li>
+                                <p>Canada</p>
+                            </li>
+                            <li>
+                                <p>Denmark</p>
+                            </li>
+                            <li>
+                                <p>Ethiopia</p>
+                            </li>
+                        </ol></p>
+                        <p>This list has one column in static output.<ol>
+                            <li>
+                                <p>Finland</p>
+                            </li>
+                            <li>
+                                <p>Ghana</p>
+                            </li>
+                        </ol></p>
+                    </statement>
+                    <hint>
+                        <p>This (unordered) list has two columns in static output.<ul cols="2">
+                            <li>
+                                <p>Hungary</p>
+                            </li>
+                            <li>
+                                <p>Iceland</p>
+                            </li>
+                            <li>
+                                <p>Jamaica</p>
+                            </li>
+                            <li>
+                                <p>Korea</p>
+                            </li>
+                            <li>
+                                <p>Lesotho</p>
+                            </li>
+                        </ul></p>
+                    </hint>
+                    <solution>
+                        <p>This list has five columns in static output.<ol cols="5">
+                            <li>
+                                <p>Mali</p>
+                            </li>
+                            <li>
+                                <p>Nepal</p>
+                            </li>
+                            <li>
+                                <p>Oman</p>
+                            </li>
+                            <li>
+                                <p>Peru</p>
+                            </li>
+                            <li>
+                                <p>Qatar</p>
+                            </li>
+                        </ol></p>
+                    </solution>
+                </webwork>
+            </exercise>
+
         </section>
 
         <section>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -4152,13 +4152,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Tunnel duplication flag to list items -->
 <xsl:template match="ol|ul">
     <xsl:param name="b-original" select="true()" />
+    <xsl:variable name="cols">
+        <xsl:apply-templates select="." mode="get-cols" />
+    </xsl:variable>
     <xsl:element name="{local-name(.)}">
         <xsl:apply-templates select="." mode="insert-paragraph-id" >
             <xsl:with-param name="b-original" select="$b-original" />
         </xsl:apply-templates>
         <xsl:attribute name="class">
             <xsl:apply-templates select="." mode="html-list-class" />
-            <xsl:if test="@cols">
+            <xsl:if test="string($cols)">
                 <xsl:text> </xsl:text>
                 <!-- HTML-specific, but in mathbook-common.xsl -->
                 <xsl:apply-templates select="." mode="number-cols-CSS-class" />

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -4647,6 +4647,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- introduction, and its absence does not seem      -->
 <!-- to cause any problems.                           -->
 <xsl:template match="ol">
+    <xsl:variable name="cols">
+        <xsl:apply-templates select="." mode="get-cols" />
+    </xsl:variable>
     <xsl:choose>
         <xsl:when test="not(ancestor::ol or ancestor::ul or ancestor::dl or parent::objectives)">
             <xsl:call-template name="leave-vertical-mode" />
@@ -4655,9 +4658,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>%&#xa;</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:if test="@cols">
+    <xsl:if test="string($cols)">
         <xsl:text>\begin{multicols}{</xsl:text>
-        <xsl:value-of select="@cols" />
+        <xsl:value-of select="$cols" />
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
     <xsl:text>\begin{enumerate}</xsl:text>
@@ -4670,7 +4673,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
      <xsl:apply-templates />
     <xsl:text>\end{enumerate}&#xa;</xsl:text>
-    <xsl:if test="@cols">
+    <xsl:if test="string($cols)">
         <xsl:text>\end{multicols}&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
@@ -4679,6 +4682,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- from LaTeX's so we write out a label  -->
 <!-- choice for each such list             -->
 <xsl:template match="ul">
+    <xsl:variable name="cols">
+        <xsl:apply-templates select="." mode="get-cols" />
+    </xsl:variable>
     <xsl:choose>
         <xsl:when test="not(ancestor::ol or ancestor::ul or ancestor::dl or parent::objectives)">
             <xsl:call-template name="leave-vertical-mode" />
@@ -4687,9 +4693,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>%&#xa;</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:if test="@cols">
+    <xsl:if test="string($cols)">
         <xsl:text>\begin{multicols}{</xsl:text>
-        <xsl:value-of select="@cols" />
+        <xsl:value-of select="$cols" />
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
     <xsl:text>\begin{itemize}[label=</xsl:text>
@@ -4697,7 +4703,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>]&#xa;</xsl:text>
     <xsl:apply-templates />
     <xsl:text>\end{itemize}&#xa;</xsl:text>
-    <xsl:if test="@cols">
+    <xsl:if test="string($cols)">
         <xsl:text>\end{multicols}&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
@@ -4711,17 +4717,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>%&#xa;</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:if test="@cols">
-        <xsl:text>\begin{multicols}{</xsl:text>
-        <xsl:value-of select="@cols" />
-        <xsl:text>}&#xa;</xsl:text>
-    </xsl:if>
+    <!-- dl cannot have mutliple columns -->
     <xsl:text>\begin{description}&#xa;</xsl:text>
     <xsl:apply-templates />
     <xsl:text>\end{description}&#xa;</xsl:text>
-    <xsl:if test="@cols">
-        <xsl:text>\end{multicols}&#xa;</xsl:text>
-    </xsl:if>
 </xsl:template>
 
 <!-- List Items -->


### PR DESCRIPTION
This makes it so that when you author a WW problem in your PTX source, and it has a list with `@cols`, then in static output (print and a static HTML version) your `@cols` will be respected. To do this it has to encounter the list in `static` and look back for the corresponding list in `authored`.

Test that this doesn't affect any output in an adverse way. Test that the print sample-chapter behaves as indicated in checkpoint 5.2. Check the same with the HTML output, but you need to set the stringparam `webwork.inline.static` to `yes`.

You may see good ways to compactify the XSLT.