### PR TITLE
Support true display math in webwork

### DIFF
--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -1204,7 +1204,7 @@
 <!-- ######### -->
 
 <!-- extract-pg.xsl documentation -->
-<!-- PGML inline math uses its own delimiters: [`...`] and [``...``]       -->
+<!-- PGML inline math uses its own delimiters: [`...`] and [```...```]     -->
 <!-- NB: we allow the "var" element as a child                             -->
 <!-- To support a PTX author's custom LaTeX macros when the problem is     -->
 <!-- used within WeBWorK, we must define each macro as it is used within   -->
@@ -1212,7 +1212,7 @@
 <!-- support HTML_mathjax, HTML_dpng, and TeX display modes.               -->
 
 <!-- extract-pg-ptx.xsl documentation -->
-<!-- PGML inline math uses its own delimiters: [`...`] and [``...``]       -->
+<!-- PGML inline math uses its own delimiters: [`...`] and [```...```]     -->
 <!-- NB: we allow the "var" element as a child                             -->
 
 <!-- Common documentation -->
@@ -1236,22 +1236,21 @@
     <xsl:text>`]</xsl:text>
 </xsl:template>
 
-<!-- PGML [``...``] creates displaystyle math, but does not by itself      -->
-<!-- center it on a new line, so we manually apply that here.              -->
+<!-- PGML [```...```] creates display math -->
 <xsl:template match="webwork//me">
     <xsl:param name="b-verbose" />
     <xsl:text>&#xa;&#xa;</xsl:text>
     <xsl:if test="ancestor::ul|ancestor::ol">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
-    <xsl:text>&gt;&gt; [``</xsl:text>
+    <xsl:text>[```</xsl:text>
     <xsl:if test="$b-verbose">
         <xsl:call-template name="select-latex-macros"/>
     </xsl:if>
     <xsl:apply-templates select="text()|var" />
     <!-- look ahead to absorb immediate clause-ending punctuation -->
     <xsl:apply-templates select="." mode="get-clause-punctuation" />
-    <xsl:text>``] &lt;&lt;&#xa;&#xa;</xsl:text>
+    <xsl:text>```]&#xa;&#xa;</xsl:text>
     <xsl:if test="following-sibling::text()[normalize-space()] or following-sibling::*">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
@@ -1263,28 +1262,27 @@
         <xsl:if test="ancestor::ul|ancestor::ol">
             <xsl:call-template name="potential-list-indent" />
         </xsl:if>
-    <xsl:text>&gt;&gt; </xsl:text>
     <xsl:choose>
         <xsl:when test="contains(., '&amp;') or contains(., '\amp')">
-            <xsl:text>[``</xsl:text>
+            <xsl:text>[```</xsl:text>
             <xsl:if test="$b-verbose">
                 <xsl:call-template name="select-latex-macros"/>
             </xsl:if>
             <xsl:text>\begin{aligned}&#xa;</xsl:text>
             <xsl:apply-templates select="mrow" />
-            <xsl:text>\end{aligned}``]</xsl:text>
+            <xsl:text>\end{aligned}```]</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:text>[``</xsl:text>
+            <xsl:text>[```</xsl:text>
             <xsl:if test="$b-verbose">
                 <xsl:call-template name="select-latex-macros"/>
             </xsl:if>
             <xsl:text>\begin{gathered}&#xa;</xsl:text>
             <xsl:apply-templates select="mrow" />
-            <xsl:text>\end{gathered}``]</xsl:text>
+            <xsl:text>\end{gathered}```]</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:text> &lt;&lt;&#xa;&#xa;</xsl:text>
+    <xsl:text>&#xa;&#xa;</xsl:text>
     <xsl:if test="following-sibling::text()[normalize-space()] or following-sibling::*">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>


### PR DESCRIPTION
New PGML delimiters ````[```...```]```` have been merged into the webwork develop branch. I pulled into both AIM WeBWorK severs, as well as the PCC webwork server. These new delimiters are for true display math, as opposed to ```[``...``]``` which just put `\displaystyle{}` in front of inline math. 

This commit changes how PTX converts to PG, now making use of the new display math delimiter instead of faking it with centering and ```[``...``]```.