### PR TITLE
Update logic to include alphanumeric, to match comment

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -1086,7 +1086,7 @@ def sanitize_url(url):
 def sanitize_alpha_num_underscore(param):
     """Verify parameter is a string containing only alphanumeric and undescores"""
     import string
-    allowed = set(string.ascii_lowercase + string.ascii_uppercase + '_')
+    allowed = set(string.ascii_letters + string.digits + '_')
     _verbose('verifying parameter: {}'.format(param))
     if not(set(param) <= allowed):
         raise ValueError('param {} contains characters other than a-zA-Z0-9_ '.format(param))


### PR DESCRIPTION
The existing `mbx` sanitization logic for user strings is intended to allow alphanumeric and underscores; however, it was only allowing alpha and underscores. 

This is a tiny little edit that re-writes the check using more appropriate python logic, to allow WebWork UIDs that contain numbers, among other sanitized logic. This also causes the logic to match its documentation. The `ascii_letters` and `digits` macros work in Python 2 and Python 3.

There does not appear to be an existing ticket for this issue, but its pretty trivial fix.