### PR TITLE
Allow optional Exercises, Solutions, References in unstructured Article

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -51,7 +51,12 @@
                 MetaDataSubtitle,
                 ArticleFrontMatter?,
                 (
-                    (BlockDivision | Paragraphs | Commentary)+
+                    (
+                        (BlockDivision | Paragraphs | Commentary)+,
+                        Exercises?,
+                        Solutions?,
+                        References?
+                    )
                 |
                     (
                         IntroductionDivision?,
@@ -275,7 +280,7 @@
         <p><term>Long text</term> is everything that is short text, but also allows for references, both external (internet <init>URL</init>s) and internal (cross-references).  It is used for the content of footnotes and captions.  The <webwork /> variant allows for variables in inline mathematics.</p>
 
         <fragment xml:id="shorttext">
-        TextSimple = mixed { 
+        TextSimple = mixed {
             Character* }
         TextShort = mixed { (
             Character |
@@ -358,7 +363,7 @@
         <p>See below for elements that can be used to form groupings with left and right delimiters.  For example, a simple quotation should use a left double quote and a right double quote, and these characters should look different (so-called <term>smart</term> quotes).  Notice that a keyboard only has a single <term>dumb</term> quote.  If you need these characters in isolation (<ie />, not in pairs), these are the best way to ensure you get what you want in all possible conversions.  Note that left and right braces (<q>curly brackets</q>) are previously defined with the <latex /> characters.</p>
 
         <fragment xml:id="delimiter-character">
-        Character |= 
+        Character |=
             element lsq {empty} |
             element rsq {empty} |
             element rq {empty} |
@@ -370,7 +375,7 @@
         <p>There is a variety of dashes of various lengths.  Use the keyboard character for a <term>hyphen</term>, use an <term>ndash</term> to seperate a range of numbers or dates, and use an <term>mdash</term> as punctuation within a sentence to isolate a clause.  These are implemented differently for different conversions, so their use is strongly encouraged.</p>
 
         <fragment xml:id="dash-character">
-        Character |= 
+        Character |=
             element nbsp {empty} |
             element ndash {empty} |
             element mdash {empty}
@@ -380,14 +385,14 @@
 
         <fragment xml:id="fillin-character">
         FillIn = element fillin {attribute characters {xsd:integer}?, empty}
-        Character |= 
+        Character |=
             FillIn
         </fragment>
 
         <p>We define a few characters to help with simple expressions in arithmetic.  The <term>solidus</term> is slightly different from the <term>slash</term> found on a keyboard and is used for fractions and ratios.  These are for simple uses in regular text, not for actual mathematics, which is described later.</p>
 
         <fragment xml:id="arithmetic-character">
-        Character |= 
+        Character |=
             element solidus {empty} |
             element times {empty}
         </fragment>
@@ -395,7 +400,7 @@
         <p>The following are largely conveniences.  They are typically not available on keyboards, and their implementations for various conversions can involve some subtleties.  Again, their use is encouraged for the best quality output.</p>
 
         <fragment xml:id="exotic-character">
-        Character |= 
+        Character |=
             element ellipsis {empty} |
             element asterisk {empty} |
             element backtick {empty} |
@@ -413,7 +418,7 @@
         <p>We support musical notation as if they were characters: accidentals, scale degrees, notes, and chords.  Implementation of these is about as complicated as inline mathematical notation, hence they have identical rules about placement.</p>
 
         <fragment xml:id="music-character">
-        Music = 
+        Music =
             element doublesharp {empty} |
             element sharp {empty} |
             element natural {empty} |
@@ -458,7 +463,7 @@
 
         <!-- webwork, latex will need work -->
         <fragment xml:id="generator">
-        Generator = 
+        Generator =
             element today {empty} |
             element timeofday {empty} |
             element tex {empty} |
@@ -487,7 +492,7 @@
                 attribute prefix {text}?,
                 attribute base {text},
                 attribute exp {xsd:integer}?
-        Generator |= 
+        Generator |=
             element quantity {
                 element mag {text}?,
                 element unit {UnitSpecification}*,
@@ -498,7 +503,7 @@
         <p>Some markup is for just ASCII characters, in other words, unadorned verbatim text.</p>
 
         <fragment xml:id="verbatim">
-        Verbatim = 
+        Verbatim =
             element c {text} |
             element email {text}
         </fragment>
@@ -506,7 +511,7 @@
         <p>Simple markup is groupings of text that gets a different typographic appearance, either through font changes or through delimiters.  Examples are emphasis or paired quotations, non-examples are cross-references or footnotes.</p>
 
         <p>Abbreviations are sequences of characters that shorten some longer word or words (<eg /> <abbr>vs.</abbr> for the Latin <foreign>versus</foreign>), initialisms are formed from the first letters of a sequence of words (<eg /> <init>HTML</init>), acronyms are pronouncable as words (<eg /> <acro>SCUBA</acro>).</p>
-        
+
         <fragment xml:id="abbreviation-group">
         Group |=
             element abbr {TextSimple} |
@@ -517,7 +522,7 @@
         <p>Notice that long text can be part of a grouping construction, and that long text can can contain a group construction.  The effect is that these groupings can be nested arbitrarily deep.</p>
 
         <fragment xml:id="delimiter-group">
-        Group |= 
+        Group |=
             element q {TextLong} |
             element sq {TextLong} |
             element braces {TextLong} |
@@ -527,7 +532,7 @@
         </fragment>
 
         <fragment xml:id="highlight-group">
-        Group |= 
+        Group |=
             element em {TextLong} |
             element term {TextLong} |
             element alert {TextLong} |
@@ -540,7 +545,7 @@
         </fragment>
 
         <fragment xml:id="editing-group">
-        Group |= 
+        Group |=
             element delete {TextLong} |
             element insert {TextLong} |
             element stale {TextLong}
@@ -591,7 +596,7 @@
             element m {
                 mixed {(FillIn | WWVariable)*}
             }
-        MathRow = 
+        MathRow =
             element mrow {
                 MetaDataTarget,
                 (
@@ -679,21 +684,21 @@
             element interlude {BlockText+}
         Postlude =
             element postlude {BlockText+}
-        Statement = 
+        Statement =
             element statement {
                 BlockStatement+
             }
-        Hint = 
+        Hint =
             element hint {
                 MetaDataTitleOptional,
                 BlockStatement+
             }
-        Answer = 
+        Answer =
             element answer {
                 MetaDataTitleOptional,
                 BlockStatement+
             }
-        Solution = 
+        Solution =
             element solution {
                 MetaDataTitleOptional,
                 BlockStatement+
@@ -750,8 +755,8 @@
         Xref =
             element xref {
                     (
-                        attribute ref {text} | 
-                        (attribute first {text}, attribute last {text}) | 
+                        attribute ref {text} |
+                        (attribute first {text}, attribute last {text}) |
                         attribute provisional {text}
                     ),
                     attribute text { XrefTextStyle }?,
@@ -795,7 +800,7 @@
                 attribute sortby {text}?,
                 attribute start {text}?,
                 attribute finish {text}?,
-                (   
+                (
                     TextShort
                 |
                     (
@@ -925,7 +930,7 @@
             MetaDataTitleOptional,
             Notation*,
             Statement
-        Definition = 
+        Definition =
             element definition {DefinitionLike}
         </fragment>
     </section>
@@ -936,13 +941,13 @@
         <p>Theorems, corollaries, lemmas <mdash /> they all have statements, and should have proof(s).  Otherwise they are all the same.  A proof may be divided with cases, in no particular rigid way, just as a marker of any number of different, non-overlapping portions of a proof.  Titles can be used to describe each case, or implication arrows may be used (typically with a prrof of an equivalence).  A <c>proof</c> is also allowed to stand on its own as a block, independent of a structure like a <c>theorem</c> or <c>algorithm</c>.</p>
 
         <fragment xml:id="theorem-like">
-        Case = 
+        Case =
             element case {
                MetaDataTitleOptional,
                attribute direction {text}?,
                BlockStatement+
                }
-        Proof = 
+        Proof =
             element proof {
                 MetaDataTitleOptional,
                 (BlockStatement | Case)+
@@ -1035,7 +1040,7 @@
         RemarkLike =
             MetaDataTitleOptional,
             BlockText+
-        Remark = 
+        Remark =
             element remark {RemarkLike}
         |
             element convention {RemarkLike}
@@ -1104,7 +1109,7 @@
         <p>These are containers that carry titles, captions, and numbers and need to be filled with other (indivisable) items.  They have a mandatory <c>caption</c> (which can have no text, but will still produce a numbered caption), and may have a <c>title</c>, which could more appropriately be called a <term>heading</term>.  These are also called <term>captioned items</term>.</p>
 
         <fragment xml:id="table-figure">
-        Caption = 
+        Caption =
             element caption {TextLong}
         Figure =
             element figure {
@@ -1286,7 +1291,7 @@
 
         <fragment xml:id="image">
         Image = ImageRaster | ImageCode
-        ImageRaster = 
+        ImageRaster =
             element image {
                 UniqueID?,
                 attribute width {text}?,
@@ -1294,7 +1299,7 @@
                 element description {TextShort}?,
                 attribute source {text}
             }
-        ImageCode = 
+        ImageCode =
             element image {
                 UniqueID?,
                 attribute width {text}?,
@@ -1306,7 +1311,7 @@
                     element sageplot {text}
                 )
             }
-        ImageWW = 
+        ImageWW =
             element image {
                 attribute pg-name {text}?,
                 element description {(TextShort | WWVariable)*}?
@@ -1337,7 +1342,7 @@
         <p>Some specific interactive goodies.  These are being phased-out in favor of a more general <tag>interactive</tag> element.</p>
 
         <fragment xml:id="interactive">
-        MuseScore = 
+        MuseScore =
             element score {
                 attribute musescoreuser {text},
                 attribute musescore {text}
@@ -1376,7 +1381,7 @@
 
         <fragment xml:id="poetry">
         AlignmentPoem = attribute halign {"left" | "center" | "right"}
-        Poem = 
+        Poem =
             element poem {
                 MetaDataTitleOptional,
                 AlignmentPoem?,
@@ -1386,12 +1391,12 @@
                 }?,
                 (PoemLine+ | Stanza+)
             }
-        Stanza = 
+        Stanza =
             element stanza {
                 MetaDataTitleOptional,
                 PoemLine+
             }
-        PoemLine = 
+        PoemLine =
             element line {
                 attribute indent {xsd:integer}?,
                 TextShort
@@ -1419,9 +1424,9 @@
                     }+
                 }
             )+
-        StatementExercise = 
+        StatementExercise =
             element statement { ExerciseBody }
-        Exercise = 
+        Exercise =
             element exercise {
                 MetaDataTitleOptional,
                 attribute number {text}?,
@@ -1503,12 +1508,12 @@
 
         <fragment xml:id="webwork">
         WebWork = (WebWorkAuthored | WebWorkSource)
-        WebWorkSource = 
+        WebWorkSource =
             element webwork {
                 attribute source {text}?,
                 attribute seed {xsd:integer}?
             }
-        WebWorkAuthored = 
+        WebWorkAuthored =
             element webwork {
                 MetaDataTitleOptional,
                 attribute seed {xsd:integer}?,
@@ -1534,11 +1539,11 @@
                     SideBySideNoCaption
                 )+
             }
-        WWMacros = 
+        WWMacros =
             element pg-macros {
                 element macro-file {text}+
             }
-        WWSetup = 
+        WWSetup =
             element setup {
                 element pg-code {text}?
             }
@@ -1549,7 +1554,7 @@
                 attribute evaluator {text}?,
                 attribute width {text}?,
                 attribute category {"angle" | "decimal" | "exponent" | "formula" | "fraction" | "inequality" | "integer" | "interval" | "logarithm" | "limit" | "number" | "point" | "syntax" | "quantity" | "vector"}?,
-                attribute form {"popup"|"buttons"|"none"}?) | 
+                attribute form {"popup"|"buttons"|"none"}?) |
                 (attribute form {"essay"},
                 attribute width {text}?)
             }
@@ -1699,7 +1704,7 @@
         <p>Articles and books have material at the start, which gets organized in interesting ways. <c>minilicense</c> is very restrictive, <c>shortlicense</c> allows references (<eg /> <init>URL</init>s).  <c>titlepage</c> is like a very small database<mdash />for HTML it migrates to the top of the page for the <c>frontmatter</c>, and for <latex /> it migrates to the half-title and title pages.  Since it generally makes no sense as the target of a cross-reference, <c>titlepagfe</c> does not allow an <c>@xml:id</c> attribute.</p>
 
         <fragment xml:id="frontmatter">
-        ArticleFrontMatter = 
+        ArticleFrontMatter =
             element frontmatter {
                 MetaDataTitleOptional,
                 TitlePage,
@@ -1743,7 +1748,7 @@
                 element title {TextLong},
                 Author+
             }
-        Date = 
+        Date =
             element date {
                 mixed {(Character | Generator)*}
             }
@@ -1771,17 +1776,17 @@
                     element shortlicense {TextLong}?
                 }?
             }
-        Biography = 
+        Biography =
             element biography {
                 MetaDataTitleOptional,
                 (BlockStatementNoCaption | ParagraphsNoNumber | Commentary)+
             }
-        Dedication = 
+        Dedication =
             element dedication {
                 MetaDataTitleOptional,
                 (Paragraph|ParagraphLined)+
             }
-        Acknowledgement = 
+        Acknowledgement =
             element acknowledgement {
                 MetaDataTitleOptional,
                 (BlockStatementNoCaption | ParagraphsNoNumber | Commentary)+
@@ -1797,7 +1802,7 @@
                     |
                     (
                         (BlockStatementNoCaption | ParagraphsNoNumber | Commentary)*,
-                        Contributors, 
+                        Contributors,
                         (BlockStatementNoCaption | ParagraphsNoNumber | Commentary)*
                     )
                 )
@@ -1836,7 +1841,7 @@
         <p>Articles and books have material at the end, structured as a sequence of <c>appendix</c>.  A <c>solutions</c> division should be numbered and rendered as if it was one of the <c>appendix</c>, and so can mix-in in any order.</p>
 
         <fragment xml:id="backmatter">
-        BackMatter = 
+        BackMatter =
             element backmatter {
                 MetaDataTitleOptional,
                 (Appendix|Solutions)*,


### PR DESCRIPTION
Since an article doesn't require a section (the way e.g. a book requires a chapter), it makes sense that an unstructured article may have exercises, solutions, and/or references following the main unstructured content, just as an unstructured section or chapter within an article or book might. (This came up while working on the [worksheet idea](https://groups.google.com/d/topic/pretext-dev/P3QezGyU-0Y/discussion).) Apologies if this should have gone to pretext-dev first.