### PR TITLE
Apply global exercise string params to exercisegroup exercises too

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -2937,7 +2937,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- switch on inline vs. divisional (could do this in match?) -->
             <xsl:choose>
                 <!-- divisional -->
-                <xsl:when test="parent::exercises">
+                <xsl:when test="parent::exercises or parent::exercisegroup">
                     <xsl:apply-templates select="."  mode="exercise-components">
                         <xsl:with-param name="b-original" select="$b-original" />
                         <xsl:with-param name="b-has-statement" select="true()" />


### PR DESCRIPTION
This addresses #952. Haven't thought through everything or scanned for other places this may be needed, but it makes the test case I cited in #952 clear up. And it makes the ORCCA HTML clear up too.