### PR TITLE
Use permid for HTML id, when it exists

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -391,7 +391,7 @@ the xsltproc executable.
         the first non-trivial character.
         -->
 
-        <section xml:id="section-sage-cells">
+        <section permid="Abc" xml:id="section-sage-cells">
             <title>Computing Integrals with Sage (<m>\int</m>)</title>
             <!-- Index testing, semi-realistic -->
             <idx><h>Sage</h><h>integration</h></idx>
@@ -573,7 +573,7 @@ the xsltproc executable.
         <section xml:id="interesting-corollary">
             <title>An Interesting Corollary</title>
 
-            <objectives xml:id="objectives-structures">
+            <objectives permid="dEf" xml:id="objectives-structures">
                 <title>Fundamental Structures</title>
 
                 <introduction>
@@ -602,13 +602,13 @@ the xsltproc executable.
 
                 <todo>Should equation references come with parentheses?</todo>
 
-                <corollary xml:id="corollary-FTC-derivative">
+                <corollary permid="ghI" xml:id="corollary-FTC-derivative">
                     <creator>Leibniz, Newton</creator>
                     <idx><h>Fundamental Theorem of Calculus</h><h>Corollary</h></idx>
                     <statement>
                         <p>Suppose <m>f(x)</m> is a continuous function.  Then <men xml:id="equation-alternate-FTC">\frac{d}{dx}\definiteintegral{a}{x}{f(t)}{t}=f(x)</men>.</p>
                     </statement>
-                    <proof xml:id="proof-FTC-corollary">
+                    <proof permid="Jkl" xml:id="proof-FTC-corollary">
                         <p>We simply take the indicated derivative, applying Theorem<nbsp /><xref ref="theorem-FTC" /> at <xref ref="equation-use-FTC" /><mdn>
                             <mrow xml:id="equation-use-FTC">\frac{d}{dx}\definiteintegral{a}{x}{f(t)}{t}&amp;=\frac{d}{dx}\left(F(x)-F(a)\right)</mrow>
                             <mrow number="no">&amp;=\frac{d}{dx}F(x)-\frac{d}{dx}F(a)</mrow>
@@ -632,7 +632,7 @@ the xsltproc executable.
                     <input>2+2</input>
                 </sage>
 
-                <example xml:id="example-mysterious">
+                <example permid="mNo" xml:id="example-mysterious">
                     <title>A Mysterious Derivative!</title>
                     <p>So if we define a function with its variable employed as a limit of integration, like so <me>K(z)=\definiteintegral{345}{z}{x^4\sin(x^2)}{x}</me> then we get the derivative of that function so easily it seems like a mystery, <me>\frac{d}{dz}K(z)=z^4\sin(z^2)</me>. That's it.</p>
 
@@ -667,7 +667,7 @@ the xsltproc executable.
                             <p>A case may also have a <c>title</c>, whose formatting and structure is entirely up to the author.  This then becomes the text of a cross-reference, as well.</p>
                         </case>
 
-                        <case direction="forward" xml:id="forward">
+                        <case permid="pqR" direction="forward" xml:id="forward">
                             <title>Necessity</title>
 
                             <p>If you like, you can have both indications.</p>
@@ -701,7 +701,7 @@ the xsltproc executable.
 
                     <p>The Fundamental Theorem explains why we use the same notation for a definite integral, which is a numerical calculation,<fn>Which I think sometimes students lose sight of.</fn> and an antiderivative, which is a symbolic expression.</p>
 
-                    <exercise xml:id="exercise-essay">
+                    <exercise permid="Stu" xml:id="exercise-essay">
                         <title>Essay Question: Compare and Contrast</title>
                         <statement>
                             <p>Write a short paragraph which compares, and contrasts, the definite and indefinite integral. This is an exercise which sits in the midst of the narrative, so is formatted more like an example or a remark.  It can have a hint and a solution, but this one does not.  It can have a title, which this one does.</p>
@@ -757,8 +757,8 @@ the xsltproc executable.
                         <hint>
                             <p>A good hint.</p>
                         </hint>
-                        <answer>
-                            <p>42.</p>
+                        <answer permid="Vwx">
+                            <p permid="Xyz">42.</p>
                         </answer>
                         <solution>
                             <p>What was the question?</p>
@@ -843,7 +843,7 @@ the xsltproc executable.
                         <p>An <c>&lt;aside&gt;</c> is similar to a remark, but is not as critical to the narrative.  It is not numbered, and so requires a title.  It can be the target of a cross-reference.  They are meant to be short, and so are not knowlized at their first appearance.  If the content is appropriate, these can be marked as <c>&lt;historical&gt;</c> or <c>&lt;biographical&gt;</c>, though longer items should use subdivisions (<eg /> sections, subsections) instead.</p>
                     </aside>
 
-                    <project xml:id="project-structured">
+                    <project permid="aBc" xml:id="project-structured">
                         <title>A very structured project</title>
 
                         <prelude>
@@ -859,7 +859,7 @@ the xsltproc executable.
                             <p>This first task is very simple, just a paragraph.  In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
                         </task>
 
-                        <task>
+                        <task permid="abC">
                             <p>Now three paragraphs.  In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
                             <p>In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
                             <p>In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
@@ -970,7 +970,7 @@ the xsltproc executable.
                         </statement>
                         <solution>
                             <p>This solution will migrate to a list of solutions in the backmatter.  We include a <c>sidebyside</c> as a test.</p>
-                            <sidebyside width="30%">
+                            <sidebyside permid="dEf" width="30%">
                                 <p>This is a skinny paragraph which should be just 30<percent /> of the width.</p>
                                 <p>And another skinny paragraph which should also be just 30<percent /> of the width.</p>
                             </sidebyside>
@@ -988,7 +988,7 @@ the xsltproc executable.
 
                     <!-- content will happen here automatically -->
 
-                    <conclusion>
+                    <conclusion permid="deF">
                         <p>And a conclusion to this solutions division, which may not be readily apparent as distinct from the final division's worth of solutions, but since it is not prefixed with a number, it may be different enough.</p>
                     </conclusion>
                 </solutions>
@@ -1035,7 +1035,7 @@ the xsltproc executable.
                 </paragraphs>
 
 
-                <assemblage xml:id="assemblage-basics">
+                <assemblage permid="Ghi" xml:id="assemblage-basics">
                     <title>Assemblages: Collections and Summaries</title>
 
                     <p>An <c>&lt;assemblage&gt;</c> is a collection, or summary, that does not have much structure to it.  So you are limited to paragraphs and friends (<c>p</c>, <c>blockquote</c>, <c>pre</c>) and side-by-sides that do not contain captioned items (<c>sidebyside</c>, <c>sbsgroup</c>).  The intent is that contents are not numbered, so cannot be cross-referenced individually, and so also do not become knowls.  You may place <c>&lt;image&gt;</c>, <c>&lt;tabular&gt;</c>, and <c>&lt;program&gt;</c> inside a <c>&lt;sidebyside&gt;</c>, in addition to other objects that do not have captions.  Note that <c>p</c> may by extension contain lists (<c>ol</c>, <c>ul</c>, <c>dl</c>).  Despite limited structure, the presentation should draw attention to it, because the contents should be seen as more important in some way.  It should be <q>highlighted</q> in some manner.  If you need to connect the entire assemblage with material elsewhere, you can do that with the usual <c>xref/xml:id</c> mechanism.<idx><h>assemblage</h></idx></p>
@@ -1124,7 +1124,7 @@ the xsltproc executable.
                     <p>This is a <tag>outcomes</tag> element you are reading, and this is its introduction.  This early section has really grown and we have tried to accomplish many things.  Not all of them are listed here.</p>
                 </introduction>
 
-                <ol>
+                <ol permid="gHi">
                     <li>Display various <q>blocks</q>, fundamental units of the flow.</li>
                     <li xml:id="outcome-structure">More, and this is what the cross-references above are pointing to.</li>
                     <li>Evermore.</li>
@@ -1148,7 +1148,7 @@ the xsltproc executable.
         in HTML, which are similar, but not identical.
         -->
 
-        <section>
+        <section permid="Bcd">
             <title>Some Facts and Figures</title>
 
             <!-- This is not implemented
@@ -1209,7 +1209,7 @@ the xsltproc executable.
                 <li><p>Black</p></li>
                 <li><p>Orange</p></li>
                 <li><p>Pink</p></li>
-                <li><p>Salmon<idx><h>strange colors</h></idx></p></li>
+                <li permid="bCd"><p permid="bcD">Salmon<idx><h>strange colors</h></idx></p></li>
                 <li><p>Aqua</p></li>
                 <li><p>Cyan</p></li>
                 <li><p>Puce<idx><h>strange colors</h></idx></p></li>
@@ -1528,7 +1528,7 @@ the xsltproc executable.
                     <p>So.  Do not take any extra steps and let <latex /> figure out the breaks.  If you do not like a break, modify the <c>md</c> or <c>mdn</c> to go back to the AMSmath default behavior and not break at all.  Ever.  Or rather, go further and modify an individual <c>mrow</c> to suggest that it is a good place for a break.</p>
                 </example>
 
-                <p>This is a poorly-authored paragaph to test the conversion to <init>HTML</init>.  There are two displayed equations, separated by a period ending the first one's sentence, which should migrate into the display, and not leave behind an empty paragraph: <me>z+y = z</me>.  <me>a + b = c</me>.  This final sentence should remain, inside another <init>HTML</init> paragraph, without the second equation's period.</p>
+                <p permid="Cde">This is a poorly-authored paragaph to test the conversion to <init>HTML</init>.  There are two displayed equations, separated by a period ending the first one's sentence, which should migrate into the display, and not leave behind an empty paragraph: <me permid="Fgh">z+y = z</me>.  <me>a + b = c</me>.  This final sentence should remain, inside another <init>HTML</init> paragraph, without the second equation's period.</p>
             </subsection>
 
             <subsection>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -3064,7 +3064,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     </xsl:variable>
     <xsl:choose>
         <xsl:when test="$intermediate='true' or $chunk='true'">
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:value-of select="$file-extension" />
         </xsl:when>
         <!-- Halts since "mathbook" element will be chunk (or earlier) -->
@@ -3424,11 +3424,11 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- these pages as the basis for scraping preview images.  So we  -->
 <!-- place a template here to achieve consistency across uses.     -->
 <xsl:template match="video|interactive" mode="standalone-filename">
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.html</xsl:text>
 </xsl:template>
 <xsl:template match="*" mode="standalone-filename">
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>-ERROR-no-standalone-filename.html</xsl:text>
 </xsl:template>
 
@@ -3625,23 +3625,26 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- for use on the root element        -->
 <xsl:variable name="b-index-is-available" select="not(//@xml:id[.='index'])" />
 
-<!-- A *unique* text identifier for any element    -->
+<!-- Two text identifiers for any element:         -->
+<!--     internal-id for anchors and labels        -->
+<!--     file-id for file names                    -->
+<!-- internal-id uses @permid if it exists,        -->
+<!--     and otherwise uses file-id                -->
+<!-- file-id uses the xml:id if it exists,         -->
+<!-- otherwise elementname-serialnumber (doc-wide) -->
 <!-- NB: only count from root of content portion   -->
 <!-- (not duplicates that might appear in docinfo) -->
 <!-- Uses:                                      -->
 <!--   HTML: filenames (pages and knowls)       -->
 <!--   HTML: anchors for references into pages  -->
 <!--   LaTeX: labels, ie cross-references       -->
-<!-- Format:                                          -->
-<!--   the content (text) of an xml:id if provided    -->
-<!--   otherwise, elementname-serialnumber (doc-wide) -->
 <!-- MathJax:                                                   -->
 <!--   Can manufacture an HTML id= for equations, so            -->
 <!--   we configure MathJax to use the TeX \label contents      -->
 <!--   which we must be sure to provide via this routine here   -->
 <!--   Then our URL/anchor scheme will point to the right place -->
-<!--   So this is applied to men and (numbered) mrow elements    -->
-<xsl:template match="*" mode="internal-id">
+<!--   So this is applied to men and (numbered) mrow elements   -->
+<xsl:template match="*" mode="file-id">
     <xsl:choose>
         <xsl:when test="@xml:id">
             <xsl:value-of select="@xml:id" />
@@ -3657,7 +3660,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Override for document root node,          -->
 <!-- slide in "index" as preferential default, -->
 <!-- presuming it is not in use anywhere else  -->
-<xsl:template match="/mathbook/*[not(self::docinfo)]|/pretext/*[not(self::docinfo)]" mode="internal-id">
+<xsl:template match="/mathbook/*[not(self::docinfo)]|/pretext/*[not(self::docinfo)]" mode="file-id">
     <xsl:choose>
         <xsl:when test="@xml:id">
             <xsl:value-of select="@xml:id" />
@@ -3672,6 +3675,18 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
+
+<xsl:template match="*" mode="internal-id">
+    <xsl:choose>
+        <xsl:when test="@permid">
+            <xsl:value-of select="@permid" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="file-id" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 
 <!-- We manufacture Javascript variables sometimes using            -->
 <!-- this id to keep them unique, but a dash (encouraged in PTX)    -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1571,13 +1571,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The file extension is *.html so recognized as OK by Moodle, etc -->
 <xsl:template match="*" mode="xref-knowl-filename">
     <xsl:text>./knowl/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.html</xsl:text>
 </xsl:template>
 
 <xsl:template match="*" mode="hidden-knowl-filename">
     <xsl:text>./knowl/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>-hidden.html</xsl:text>
 </xsl:template>
 
@@ -2016,7 +2016,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- make the anchor a target, eg of an in-context link -->
         <!-- label original -->
         <xsl:attribute name="id">
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
+            <!-- not sure if that should be internal-id or file-id -DWF -->
         </xsl:attribute>
         <!-- marked-up knowl text link *inside* of knowl anchor to be effective -->
         <!-- heading in an HTML container -->
@@ -4583,7 +4584,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="base-pathname">
         <xsl:value-of select="$directory.images" />
         <xsl:text>/</xsl:text>
-        <xsl:apply-templates select="." mode="internal-id" />
+        <xsl:apply-templates select="." mode="file-id" />
     </xsl:variable>
     <xsl:call-template name="svg-wrapper">
         <xsl:with-param name="svg-filename" select="concat($base-pathname, '.svg')" />
@@ -5211,7 +5212,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="data">
             <xsl:value-of select="$directory.images" />
             <xsl:text>/</xsl:text>
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:text>.svg</xsl:text>
         </xsl:attribute>
         <p style="margin:auto">&lt;&lt;Your browser is unable to render this SVG image&gt;&gt;</p>
@@ -5227,7 +5228,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="data">
             <xsl:value-of select="$directory.images" />
             <xsl:text>/</xsl:text>
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:text>.svg</xsl:text>
         </xsl:attribute>
         <p style="margin:auto">&lt;&lt;Your browser is unable to render this SVG image&gt;&gt;</p>
@@ -5243,14 +5244,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="data">
             <xsl:value-of select="$directory.images" />
             <xsl:text>/</xsl:text>
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:text>.svg</xsl:text>
         </xsl:attribute>
         <xsl:element name="img">
             <xsl:attribute name="src">
                 <xsl:value-of select="$directory.images" />
                 <xsl:text>/</xsl:text>
-                <xsl:apply-templates select="." mode="internal-id" />
+                <xsl:apply-templates select="." mode="file-id" />
                 <xsl:text>.png</xsl:text>
             </xsl:attribute>
         </xsl:element>
@@ -5291,12 +5292,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="video-standalone-page" />
 
     <!-- standalone page uses internal-id of the video -->
-    <xsl:variable name="int-id">
-        <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:variable name="file-id">
+        <xsl:apply-templates select="." mode="file-id" />
     </xsl:variable>
     <xsl:choose>
         <xsl:when test="@play-at = 'popout'">
-            <a href="{$int-id}.html" target="_blank">
+            <a href="{$file-id}.html" target="_blank">
             <!-- place a thumbnail as clickable for page already extant -->
                 <xsl:choose>
                     <!-- generic requested -->
@@ -5315,7 +5316,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:when test="(@preview = 'default') or not(@preview)">
                         <xsl:variable name="thumbnail-image">
                             <xsl:text>images/</xsl:text>
-                            <xsl:value-of select="$int-id" />
+                            <xsl:value-of select="$file-id" />
                             <xsl:text>.jpg</xsl:text>
                         </xsl:variable>
                         <img src="{$thumbnail-image}" width="{$width}" height="{$height}"/>
@@ -5336,7 +5337,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- if this case is deprecated, we can drop this thing -->
             <xsl:if test="@play-at = 'select'">
                 <div style="text-align: center;">
-                    <a href="{$int-id}.html" target="_blank">
+                    <a href="{$file-id}.html" target="_blank">
                         <xsl:text>Click to Pop-Out</xsl:text>
                     </a>
                 </div>
@@ -5376,7 +5377,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Use this to ensure consistency -->
 <xsl:template match="*" mode="iframe-filename">
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>-if.html</xsl:text>
 </xsl:template>
 
@@ -7148,7 +7149,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Demonstrations -->
 <!-- A simple page with no constraints -->
 <xsl:template match="demonstration">
-    <xsl:variable name="url"><xsl:apply-templates select="." mode="internal-id" />.html</xsl:variable>
+    <xsl:variable name="url"><xsl:apply-templates select="." mode="file-id" />.html</xsl:variable>
     <a href="{$url}" target="_blank" class="link">
         <xsl:apply-templates select="." mode="title-full" />
     </a>
@@ -7243,6 +7244,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check that the language is Python? -->
     <xsl:variable name="internalid">
         <xsl:apply-templates select="." mode="internal-id" />
+        <!-- The variable name is internalid, but it seems to be used in a file-like way -->
     </xsl:variable>
     <xsl:element name="div">
         <xsl:attribute name="class">
@@ -7446,7 +7448,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- For more complicated interactives, we just point to the page we generate -->
 <xsl:template match="interactive[@platform]" mode="iframe-interactive">
     <xsl:variable name="int-id">
-        <xsl:apply-templates select="." mode="internal-id" />
+        <xsl:apply-templates select="." mode="file-id" />
     </xsl:variable>
     <iframe id="{$int-id}">
         <xsl:apply-templates select="." mode="size-pixels-attributes" />
@@ -8077,7 +8079,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <xsl:template match="*" mode="simple-file-wrap">
     <xsl:param name="content" />
     <xsl:variable name="filename">
-        <xsl:apply-templates select="." mode="internal-id" />
+        <xsl:apply-templates select="." mode="file-id" />
         <text>.html</text>
     </xsl:variable>
     <exsl:document href="{$filename}" method="html" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat">

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -227,7 +227,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and totally ignore docinfo             -->
 <xsl:template match="/mathbook|/pretext">
     <xsl:variable name="filename">
-        <xsl:apply-templates select="article|book|letter|memo" mode="internal-id" />
+        <xsl:apply-templates select="article|book|letter|memo" mode="file-id" />
         <xsl:text>.tex</xsl:text>
     </xsl:variable>
     <exsl:document href="{$filename}" method="text">
@@ -5840,7 +5840,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>\includegraphics[width=0.80\linewidth,height=\qrsize,keepaspectratio]{</xsl:text>
             <xsl:value-of select="$directory.images" />
             <xsl:text>/</xsl:text>
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:text>.jpg</xsl:text>
             <xsl:text>}</xsl:text>
         </xsl:otherwise>
@@ -5860,7 +5860,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>\includegraphics[width=0.80\linewidth,height=\qrsize,keepaspectratio]{</xsl:text>
             <xsl:value-of select="$directory.images" />
             <xsl:text>/</xsl:text>
-            <xsl:apply-templates select="." mode="internal-id" />
+            <xsl:apply-templates select="." mode="file-id" />
             <xsl:text>.jpg</xsl:text>
             <xsl:text>}</xsl:text>
         </xsl:otherwise>
@@ -7468,7 +7468,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="get-width-fraction" />
     <xsl:text>\linewidth]</xsl:text>
     <xsl:text>{</xsl:text>
-    <xsl:apply-templates select="@source" mode="internal-id" />
+    <xsl:apply-templates select="@source" mode="file-id" />
     <xsl:if test="not($extension)">
         <xsl:text>.pdf&#xa;</xsl:text>
     </xsl:if>
@@ -7484,7 +7484,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}&#xa;</xsl:text>
 </xsl:template>
 
@@ -7495,7 +7495,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\IfFileExists{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}%&#xa;</xsl:text>
     <xsl:text>{\includegraphics[width=</xsl:text>
     <xsl:apply-templates select="." mode="get-width-fraction" />
@@ -7503,7 +7503,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}}%&#xa;</xsl:text>
     <xsl:text>{\includegraphics[width=</xsl:text>
     <xsl:apply-templates select="." mode="get-width-fraction" />
@@ -7511,7 +7511,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.png}}&#xa;</xsl:text>
 </xsl:template>
 
@@ -7571,7 +7571,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\includegraphics[width=0.80\textwidth]{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}&#xa;</xsl:text>
 </xsl:template>
 <!-- 2015/02/08: Deprecated, still functional but not maintained -->
@@ -7581,17 +7581,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\IfFileExists{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}%&#xa;</xsl:text>
     <xsl:text>{\includegraphics[width=0.80\textwidth]{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.pdf}}%&#xa;</xsl:text>
     <xsl:text>{\includegraphics[width=0.80\textwidth]{</xsl:text>
     <xsl:value-of select="$directory.images" />
     <xsl:text>/</xsl:text>
-    <xsl:apply-templates select="." mode="internal-id" />
+    <xsl:apply-templates select="." mode="file-id" />
     <xsl:text>.png}}&#xa;</xsl:text>
 </xsl:template>
 <!-- ################################## -->


### PR DESCRIPTION
The template for internal-id is now supplemented by a file-id template.  Use internal-id
for HTML id~s and LaTeX \label~s, and file-id for filenames.

The internal-id uses the permid attribute if it exists.  Otherwise it uses the file-id
(which is identical to what formerly was called internal-id).

Tested on LaTeX and HTML versions of sample-article.
This worked in all cases I checked, but I could not figure out how to check every possibility.