### PR TITLE
Logging in

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -980,19 +980,36 @@ the xsltproc executable.
                 <reading-questions>
                     <introduction>
                         <p>A set of reading questions may have an <tag>introduction</tag>, perhaps for preparatory explanation.</p>
+                        <p>If a student has logged in to the HTML version,
+                           then they can answer the reading questions directly in the book.
+                           Inline math LaTeX can be entered using
+                           <c>$</c>...<c>$</c> or <c>\(</c>...<c>\)</c> delimiters,
+                           and inline AsciiMath using backticks <c>`</c>...<c>`</c> as delimiters.
+                        </p>
                     </introduction>
 
                     <exercise xml:id="first-reading">
-                        <statement>
-                            <p>This is a <term>reading question</term> that you might have a student read prior to a class session, based on reading part of the book.</p>
-                        </statement>
-                        <answer>
-                            <p>Which might help make the classroom session improve.</p>
-                        </answer>
+                      <p>
+                        This is a <term>reading question</term> that you might have a student answer prior to a class session,
+                        based on reading part of the book.
+                        A quick glance before class can help you tailor class time to the specific needs of your students.
+                        The perfect reading question will reveal whether the student has read and understood the material,
+                        and will be difficult to answer if they have not.
+                        What do you think of that?
+                      </p>
                     </exercise>
 
                     <exercise>
-                        <p>And a second one, with a cross-reference to the first, as a check on numbering: <xref ref="first-reading" text="type-global"/>.</p>
+                      <p>
+                        And a second one, with a cross-reference to the first,
+                        as a check on numbering:
+                        <xref ref="first-reading" text="type-global"/>.
+                        Reading questions are allowed to have answers,
+                        but providing answers misses the point of a reading question,
+                        and the answer knowl interacts poorly with the mechanism used to
+                        allow students to answer directly in the book.
+                        Do you think the schema should ban answers to reading questions?
+                      </p>
                     </exercise>
 
                     <conclusion>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -981,10 +981,12 @@ the xsltproc executable.
                     <introduction>
                         <p>A set of reading questions may have an <tag>introduction</tag>, perhaps for preparatory explanation.</p>
                         <p>If a student has logged in to the HTML version,
-                           then they can answer the reading questions directly in the book.
+                           then they can `answer the reading` questions directly in the book.
                            Inline math LaTeX can be entered using
                            <c>$</c>...<c>$</c> or <c>\(</c>...<c>\)</c> delimiters,
                            and inline AsciiMath using backticks <c>`</c>...<c>`</c> as delimiters.
+                           Here are some `gratuitous backticks` to check that AsciiMath is only
+                           active in the answers to reading questions.
                         </p>
                     </introduction>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -7359,6 +7359,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <div class="login-link"><span id="loginlogout" class="login">login</span></div>
     <script src="https://pretextbook.org/js/0.1/login.js"></script>
 </xsl:template>
+
 <!-- Console Session -->
 <!-- An interactive command-line session with a prompt, input and output -->
 <xsl:template match="console">
@@ -9085,6 +9086,11 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         <xsl:text>    tex2jax: {&#xa;</xsl:text>
         <xsl:text>        inlineMath: [['\\(','\\)']]&#xa;</xsl:text>
         <xsl:text>    },&#xa;</xsl:text>
+        <xsl:text>    asciimath2jax: {&#xa;</xsl:text>
+        <xsl:text>        ignoreClass: ".*",&#xa;</xsl:text>
+        <xsl:text>        processClass: "has_am"&#xa;</xsl:text>
+        <xsl:text>    },&#xa;</xsl:text>
+        <xsl:text>    jax: ["input/AsciiMath"],&#xa;</xsl:text>
         <xsl:text>    extensions: ["asciimath2jax.js"],&#xa;</xsl:text>
         <xsl:text>    TeX: {&#xa;</xsl:text>
         <xsl:text>        extensions: ["extpfeil.js", "autobold.js", "https://aimath.org/mathbook/mathjaxknowl.js", ],&#xa;</xsl:text>
@@ -9134,7 +9140,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     <!-- mathjax javascript -->
     <xsl:element name="script">
         <xsl:attribute name="src">
-            <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML-full</xsl:text>
+            <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML-full</xsl:text>
         </xsl:attribute>
     </xsl:element>
 </xsl:template>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -7345,6 +7345,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
+<xsl:template name="login-header">
+    <link href="https://pretextbook.org/css/0.1/features.css" rel="stylesheet" type="text/css"/>
+    <script>
+       <xsl:text>var logged_in = false;&#xa;</xsl:text>
+       <xsl:text>var role = 'student';&#xa;</xsl:text>
+       <xsl:text>var guest_access = true;&#xa;</xsl:text>
+       <xsl:text>var login_required = false;&#xa;</xsl:text>
+    </script>
+</xsl:template>
+
+<xsl:template name="login-footer">
+    <div class="login-link"><span id="loginlogout" class="login">login</span></div>
+    <script src="https://pretextbook.org/js/0.1/login.js"></script>
+</xsl:template>
 <!-- Console Session -->
 <!-- An interactive command-line session with a prompt, input and output -->
 <xsl:template match="console">
@@ -8124,6 +8138,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             <xsl:call-template name="geogebra" />
             <xsl:call-template name="jsxgraph" />
             <xsl:call-template name="css" />
+            <xsl:call-template name="login-header" />
             <xsl:call-template name="pytutor-header" />
             <xsl:call-template name="font-awesome" />
         </head>
@@ -8186,6 +8201,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             </div>
             <xsl:apply-templates select="$docinfo/analytics" />
             <xsl:call-template name="pytutor-footer" />
+            <xsl:call-template name="login-footer" />
         </body>
     </html>
     </exsl:document>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -9067,8 +9067,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         <!-- MathJax.Ajax.config.path["Contrib"] = "<some-url>";           -->
         <xsl:text>MathJax.Hub.Config({&#xa;</xsl:text>
         <xsl:text>    tex2jax: {&#xa;</xsl:text>
-        <xsl:text>        inlineMath: [['\\(','\\)']],&#xa;</xsl:text>
+        <xsl:text>        inlineMath: [['\\(','\\)']]&#xa;</xsl:text>
         <xsl:text>    },&#xa;</xsl:text>
+        <xsl:text>    extensions: ["asciimath2jax.js"],&#xa;</xsl:text>
         <xsl:text>    TeX: {&#xa;</xsl:text>
         <xsl:text>        extensions: ["extpfeil.js", "autobold.js", "https://aimath.org/mathbook/mathjaxknowl.js", ],&#xa;</xsl:text>
         <xsl:text>        // scrolling to fragment identifiers is controlled by other Javascript&#xa;</xsl:text>
@@ -9117,7 +9118,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     <!-- mathjax javascript -->
     <xsl:element name="script">
         <xsl:attribute name="src">
-            <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML-full</xsl:text>
+            <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML-full</xsl:text>
         </xsl:attribute>
     </xsl:element>
 </xsl:template>


### PR DESCRIPTION
Enable logging in to the HTML version, and allow a logged-in user to answer reading
questions directly in the text.  See Section 4.2.5 of the sample article.

To log in, hover your mouse in the upper-right corner of the page (may be outside the
top banner, if the browser is wide).  By default, logging-in is enabled, and anyone can
log in for 3 hours as 'guest' with password 'guest'.

Added AsciiMath support in Mathjax, so that reading question answers can use AsciiMath.
This required changing the main MathJax file.  Not sure how to check if there were any
unintended consequences.

Logging in, and answering questions, probably has some accessibility issues.