### PR TITLE
Put answers in WW extraction

### DIFF
--- a/doc/author-guide/webwork.xml
+++ b/doc/author-guide/webwork.xml
@@ -12,55 +12,16 @@
     <author>Alex Jordan</author>
 
     <introduction>
-        <p>With a <webwork /> server (version 2.14 or higher, or <url href="https://webwork-ptx.aimath.org"><c>webwork-ptx.aimath.org</c></url>) and a little setup work, you can embed <webwork /> exercises<idx><h><webwork /></h><h><webwork /> exercise</h></idx> in your <pretext /> project. HTML output will have interactive problem cells. PDF output will contain static versions of exercises. And all such exercises can be archived by the <c>mbx</c> script into a file tree to be uploaded onto the <webwork /> server for use in the <q>traditional</q> way.</p>
+        <p>With a <webwork/> server (version 2.14 or higher, or <url href="https://webwork-ptx.aimath.org"><c>webwork-ptx.aimath.org</c></url>) and a little setup work, you can embed <webwork/> exercises<idx><h><webwork/></h><h><webwork/> exercise</h></idx> in your <pretext/> project. HTML output can have interactive problem cells or print problems in <q>static</q> form. PDF output will print static versions. And all such exercises can be archived into a file tree to be uploaded onto a <webwork/> server for use in the <q>traditional</q> way.</p>
+
+        <p>See the <pretext/> Publishing Guide for how to configure a <webwork/> course and server to process your <webwork/> problems, and then how to process them.</p>
     </introduction>
 
-    <section xml:id="webwork-configuration">
-        <title>Configuring a <webwork /> Course for <pretext /></title>
-        <p>We assume a mild familiarity with administrating a <webwork /> server. The version of <webwork /> needs to be 2.14 or later for use with <pretext />. Using the <c>admin</c> course, create a course named <c>anonymous</c>. In the course's Course Configuration menu, set all permissions to <c>admin</c> (or perhaps set some to the even more restrictive <c>nobody</c>). Except set <q>Allowed to login to the course</q> to <c>login_proctor</c>.</p>
-        <p>In the Classlist Editor, add a user named <c>anonymous</c>, and set that user's permission level to <c>login_proctor</c>, the permission level one higher than <c>student</c>. Set that user's password to <c>anonymous</c>. Note that because this is public information, anyone will be able to log into this course as user <c>anonymous</c>. This is why setting the permissions earlier is very important. (Especially preventing this user from changing its own password.)</p>
-        <p>Add the following lines to the <c>course.conf</c> file (which lives in the parent folder of the <c>templates/</c> folder.)</p>
-        <pre>
-        # Hide message about previewing hints and solutions for instructors
-        $pg{specialPGEnvironmentVars}{ALWAYS_SHOW_HINT_PERMISSION_LEVEL} = 100;
-        $pg{specialPGEnvironmentVars}{ALWAYS_SHOW_SOLUTION_PERMISSION_LEVEL} = 100;
-        </pre>
-        <p>In the <c>templates/macros/</c> folder, edit <c>PGcourse.pl</c> (or create it if need be) and add the lines:</p>
-        <pre>
-        <![CDATA[
-        #### Replace essay boxes with a message
-        sub essay_box {
-            my $out = MODES(
-                TeX => '',
-                Latex2HTML => '',
-                HTML => qq!<P>If you were logged into a WeBWorK course
-                and this problem were assigned to you,
-                you would be able to submit an essay answer
-                that would be graded later by a human being.</P>!,
-                PTX => '',
-            );
-            $out;
-        };
-
-        #### Suppress essay help link
-        sub essay_help {};
-
-        #### How many attempts until hint is available
-        $showHint = -1;
-        # May be a bug that WeBWorK requires -1 instead of 0
-        # for immediate access to hints
-
-        1;
-        ]]>
-        </pre>
-        <p>Now <pretext /> will be able to communicate with this course to retrieve what is needed.</p>
-    </section>
-
     <section xml:id="webwork-source">
-        <title><webwork /> Problems in Source</title>
+        <title><webwork/> Problems</title>
 
         <introduction>
-            <p>A <tag>webwork</tag><idx><webwork /></idx> tag must be inside an <tag>exercise</tag>, optionally preceded by an <tag>introduction</tag>, and optionally followed by a <tag>conclusion</tag>.</p>
+            <p>A <tag>webwork</tag><idx><webwork /></idx> tag must be inside an <tag>exercise</tag>, <em>optionally</em> preceded by an <tag>introduction</tag>, and <em>optionally</em> followed by a <tag>conclusion</tag>.</p>
             <pre>
             <![CDATA[
             <exercise>
@@ -75,23 +36,20 @@
             </exercise>
             ]]>
             </pre>
-            <p>There are several methods for putting content into the <tag>webwork</tag>. (Note that an empty <tag>webwork</tag> with no attributes will simply produce the camelcase <webwork /> logo.)</p>
+            <p>There are several methods for putting content into the <tag>webwork</tag>. (Note that an empty <tag>webwork</tag> with no attributes will simply produce the camelcase <webwork/> logo.)</p>
         </introduction>
 
         <subsection>
-            <title>Using an Existing <webwork /> Problem</title>
-            <p>If a problem already exists and is accessible from the <c>anonymous</c> course's <c>templates/</c> folder, then you can simply include it as a <attr>source</attr> attribute. For example, if it is a problem in the Open Problem Library (OPL) then relative to the <c>templates/</c> folder, its path is <c>Library/...</c> and you may use:</p>
-            <pre>
-            <![CDATA[
-            <webwork source="Library/PCC/BasicAlgebra/Exponents/exponentsMultiplication0.pg" />
-            ]]>
-            </pre>
-            <p>Or if you have a problem's PG file, you can upload it into the <c>anonymous</c> course's <c>templates/local/</c> folder and use it with:</p>
-            <pre>
-            <![CDATA[
-            <webwork source="local/my_problem.pg" />
-            ]]>
-            </pre>
+            <title>Using an Existing <webwork/> Problem</title>
+            <p>
+                If a problem already exists and is accessible from the hosting course's <c>templates/</c> folder, then you can simply include it as a <attr>source</attr> attribute. For example if it is a problem in the Open Problem Library (OPL), then relative to the <c>templates/</c> folder, its path is <c>Library/...</c> and you may use:
+
+                <cd>&lt;webwork source="Library/PCC/BasicAlgebra/Exponents/exponentsMultiplication0.pg" /></cd>
+
+                Or if you have a problem's PG file, you can upload it into the hosting course's <c>templates/local/</c> folder and use it with:
+
+                <cd>&lt;webwork source="local/my_problem.pg" /></cd>
+            </p>
         </subsection>
 
         <subsection>
@@ -142,13 +100,13 @@
             ]]>
             </pre>
 
-            <p>Many special contexts are automatically detected by <pretext />, and it loads the appropriate macro file into the PG problem. However you may need to explicitly load a macro file as described in <xref ref="webwork-pg-code">Subsection</xref>.</p>
+            <p>Many special contexts are automatically detected by <pretext/>, and it loads the appropriate macro file into the PG problem. However you may need to explicitly load a macro file as described in <xref ref="webwork-pg-code">Subsection</xref>.</p>
 
         </subsection>
 
         <subsection xml:id="webwork-pg-code">
             <title>PG code in Problems</title>
-            <p>To have randomization in problems or otherwise take advantage of the algorithmic programming capabilities of Perl and <webwork />'s PG language requires using a <tag>setup</tag> tag. Having at least a little familiarity with coding problems in <webwork /> is necessary, although for simpler problems you could get away with mimicking the sample article in <c>mathbook/examples/webwork/</c>. A <tag>statement</tag>, (optional) <tag>hint</tag>, and (optional) <tag>solution</tag> follow.</p>
+            <p>To have randomization in problems or otherwise take advantage of the algorithmic programming capabilities of Perl and <webwork/>'s PG language requires using a <tag>setup</tag> tag. Having at least a little familiarity with coding problems in <webwork/> is necessary, although for simpler problems you could get away with mimicking the sample article in <c>mathbook/examples/webwork/</c>. A <tag>statement</tag>, <em>optional</em> <tag>hint</tag>, and <em>optional</em> <tag>solution</tag> follow.</p>
             <pre>
             <![CDATA[
             <webwork>
@@ -169,16 +127,15 @@
             ]]>
             </pre>
 
-            <p>The <tag>setup</tag> contains a <tag>pg-code</tag>. If you are familiar with code for <webwork /> PG problems, the <tag>pg-code</tag> contains lines of PG code that would appear in the <q>setup</q> portion of the problem. Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>. If your code needs any special <webwork /> macro libraries, you may load them in a <tag>pg-macros</tag> tag prior to <tag>setup</tag>, with each such <c>.pl</c> file's name inside a <tag>macro-file</tag> tag. However many of the most common macro libraries will be loaded automatically based on the content and attributes you use in the rest of your problem.</p>
+            <p>The <tag>setup</tag> contains a <tag>pg-code</tag>. If you are familiar with code for <webwork/> PG problems, the <tag>pg-code</tag> contains lines of PG code that would appear in the <q>setup</q> portion of the problem. Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>. If your code needs any special <webwork/> macro libraries, you may load them in a <tag>pg-macros</tag> tag prior to <tag>setup</tag>, with each such <c>.pl</c> file's name inside a <tag>macro-file</tag> tag. However many of the most common macro libraries will be loaded automatically based on the content and attributes you use in the rest of your problem.</p>
 
             <p>Here is a small example. Following the example, we'll continue discussing <tag>statement</tag> and <tag>solution</tag>.</p>
             <pre>
             <![CDATA[
             <webwork>
-                <title>Integer Addition</title>
-
                 <setup>
                     <pg-code>
+                        Context("LimitedNumeric");
                         $a = Compute(random(1, 9, 1));
                         $b = Compute(random(1, 9, 1));
                         $c = $a + $b;
@@ -186,13 +143,13 @@
                 </setup>
 
                 <statement>
-                    <p>Compute <m><var name="$a" />+<var name="$b" /></m>.</p>
+                    <p>Compute <m><var name="$a"/> + <var name="$b"/></m>.</p>
                     <instruction>Type your answer without using the <c>+</c> sign.</instruction>
-                    <p>The sum is <var name="$c" width="2" />.</p>
+                    <p>The sum is <var name="$c" width="2"/>.</p>
                 </statement>
 
                 <solution>
-                    <p><m><var name="$a" />+<var name="$b" />=<var name="$c" /></m>.</p>
+                    <p><m><var name="$a"/> + <var name="$b"/> = <var name="$c"/></m>.</p>
                 </solution>
             </webwork>
             ]]>
@@ -202,18 +159,20 @@
 
             <p>Within the <tag>statement</tag>, a <tag>var</tag> tag with either a <attr>width</attr> or <attr>form</attr> attribute creates an input field. The <attr>name</attr> attribute declares what the answer will be.</p>
 
-            <p>A <tag>var</tag> can have <attr>form="essay"</attr>, in which case it need not have a <attr>name</attr> attribute. This is for open-ended questions that must be graded by a human. The form field will be an expandable input block if the question is served to an authenticated user within <webwork />. But for the <webwork /> cells in PTX HTML output, there will just be a message explaining that there is no place to enter an answer.</p>
+            <p>A <tag>var</tag> can have <attr>form="essay"</attr>, in which case it need not have a <attr>name</attr> attribute. This is for open-ended questions that must be graded by a human. The form field will be an expandable input block if the question is served to an authenticated user within <webwork/>. But for the <webwork/> cells in PTX HTML output, there will just be a message explaining that there is no place to enter an answer.</p>
 
-            <p>A <tag>var</tag> can have <attr>form="array"</attr>. You would use this when the answer is a Matrix or Vector MathObject (a <webwork /> classification) to cause the input form to be an array of smaller fields instead of one big field.</p>
+            <p>A <tag>var</tag> can have <attr>form="array"</attr>. You would use this when the answer is a Matrix or Vector MathObject (a <webwork/> classification) to cause the input form to be an array of smaller fields instead of one big field.</p>
 
             <p>A <tag>var</tag> can have <attr>form="popup"</attr> or <attr>form="buttons"</attr> for multiple choice questions.</p>
 
-            <p>If you are familiar with PG, then in your <tag>pg-code</tag> you might write a custom evaluator (a combination of a custom answer checker, post filters, pre filters, <etc />). If you store this similar to</p><pre>$my_evaluator = $answer -> cmp(...);</pre><p>then the <tag>var</tag> can have <attr>evaluator="$my_evaluator"</attr>.</p>
+            <p>If you are familiar with PG, then in your <tag>pg-code</tag> you might write a custom evaluator (a combination of a custom answer checker, post filters, pre filters, <etc/>). If you store this similar to
+            <cd>$my_evaluator = $answer -> cmp(...);</cd>
+            then the <tag>var</tag> can have <attr>evaluator="$my_evaluator"</attr>.</p>
 
             <p>An <tag>instruction</tag> is specific instructions for how the reader might type or otherwise electronically submit their answer. Contents of an <tag>instruction</tag> will be omitted from print and other static output forms. The <tag>instruction</tag> is a peer to <tag>p</tag>, but may only contain <q>short text</q> children.</p>
 
-            <p>Some general information on authoring <webwork /> problems can be found in a <url href="http://webwork.maa.org/wiki/Problem_Authoring_Videos">set of videos</url> at<cd>webwork.maa.org/wiki/Problem_Authoring_Videos</cd>
-            Not all of this is relevant to authoring within <pretext /> but there are parts that will be helpful for constructing the Perl code necessary for randomized problems.</p>
+            <p>Some general information on authoring <webwork/> problems can be found in a <url href="http://webwork.maa.org/wiki/Problem_Authoring_Videos">set of videos at <c>webwork.maa.org/wiki/Problem_Authoring_Videos</c></url>.
+            Not all of this is relevant to authoring within <pretext/> but there are parts that will be helpful for constructing the Perl code necessary for randomized problems.</p>
 
         </subsection>
 
@@ -222,112 +181,6 @@
             <p>Planned.</p>
         </subsection>
 
-    </section>
-
-    <section xml:id="webwork-processing">
-        <title>Processing</title>
-
-        <subsection xml:id="extraction-and-merging">
-            <title>Extraction and Merging</title>
-                <p>A <pretext /> project that uses <webwork /> must first have its <webwork /> content extracted into an auxiliary XML file before anything else can be done. Use the <c>mbx</c> script to extract <pretext /> content from the <webwork /> server into a <em>folder</em>, which you might call <c>webwork-extraction/</c> as in this example:</p>
-            <sidebyside>
-                <console>
-                    <prompt>$ </prompt>
-                    <input>mbx -c webwork -s &lt;server&gt; -d webwork-extraction &lt;xml&gt;</input>
-                </console>
-            </sidebyside>
-            <p>The <webwork /> server needs to be version 2.14 or later, specified with its protocol and domain, like <c>https://webwork-ptx.aimath.org</c>. (If you do not have a server, you may use <c>https://webwork-ptx.aimath.org</c>.)</p>
-            <p>You may need to specify a path to the <c>webwork-extraction</c> folder. Any image files that the <webwork /> server generates will be stored inside this folder. An auxiliary XML <em>file</em> called <c>webwork-extraction.xml</c> will be created in this folder. (Note that you can name the folder whatever you like, but the auxiliary file that is created will always be named <c>webwork-extraction.xml</c>.)</p>
-
-            <p>Next, use <c>xsltproc</c> with <c>pretext-merge.xsl</c> to merge your entire source tree with the extracted <webwork /> content. The string parameter <c>webwork.extraction</c> must identify the auxiliary XML file created in the previous step. Store the output in some file, for example <c>merge.ptx</c> in this example:</p>
-
-            <sidebyside>
-                <console>
-                    <prompt>$ </prompt>
-                    <input>xsltproc --stringparam webwork.extraction webwork-extraction.xml pretext-merge.xsl &lt;xml&gt; > merge.ptx</input>
-                </console>
-            </sidebyside>
-            <p>Note that you may need to provide file paths to <c>webwork-extraction.xml</c> and <c>pretext-merge.xsl</c>.</p>
-        </subsection>
-
-        <subsection>
-            <title>HTML output</title>
-            <p>When you execute <c>xsltproc</c><idx><c>xsltproc</c></idx> using <c>mathbook-html.xsl</c>, apply it to the merged file described above, not your original source. For example:</p>
-            <sidebyside>
-                <console>
-                    <prompt>$ </prompt>
-                    <input>xsltproc mathbook-html.xsl merge.ptx</input>
-                </console>
-            </sidebyside>
-            <p>There are several string parameters you may pass to <c>xsltproc</c>.</p>
-            <sidebyside>
-                <tabular valign="top">
-                    <col />
-                    <col width="60%" />
-                    <row bottom="major">
-                        <cell>stringparam</cell>
-                        <cell>options</cell>
-                    </row>
-                    <row bottom="minor">
-                        <cell><c>webwork.inline.static</c></cell>
-                        <cell>
-                            <p><c>'no'</c> (default) means inline exercises render as interactive.</p>
-                            <p><c>'yes'</c> means inline exercises render as static.</p>
-                            <p><c>'preview'</c> (planned) means inline exercises render as static until you click to activate them.</p>
-                        </cell>
-                    </row>
-                    <row bottom="minor">
-                        <cell><c>webwork.divisional.static</c></cell>
-                        <cell>
-                            <p><c>'no'</c> means divisional exercises render as interactive.</p>
-                            <p><c>'yes'</c> (default) means divisional exercises render as static.</p>
-                            <p><c>'preview'</c> (planned) means divisional exercises render as static until you click to activate them.</p>
-                        </cell>
-                    </row>
-                    <row bottom="minor">
-                        <cell><c>html.knowl.exercise.inline</c></cell>
-                        <cell>
-                            <p><c>'no'</c> means inline exercises appear on page load.</p>
-                            <p><c>'yes'</c> (default) means inline exercises are hidden in knowls.</p>
-                        </cell>
-                    </row>
-                    <row bottom="minor">
-                        <cell><c>html.knowl.exercise.sectional</c></cell>
-                        <cell>
-                            <p><c>'no'</c> (default) means divisional exercises appear on page load.</p>
-                            <p><c>'yes'</c> means divisional exercises are hidden in knowls.</p>
-                        </cell>
-                    </row>
-                </tabular>
-            </sidebyside>
-        </subsection>
-
-        <subsection xml:id="webwork-latex-output">
-            <title><latex /> output</title>
-            <p>When you execute <c>xsltproc</c><idx><c>xsltproc</c></idx> using <c>mathbook-latex.xsl</c>, apply it to the merged file described above, not your original source. For example:</p>
-            <sidebyside>
-                <console>
-                    <prompt>$ </prompt>
-                    <input>xsltproc mathbook-latex.xsl merge.ptx</input>
-                </console>
-            </sidebyside>
-            <p>One string parameter you can pass to <c>xsltproc</c> is <c>latex.fillin.style</c>, which can take values <c>'underline'</c> (the default) or <c>'box'</c>.</p>
-        </subsection>
-
-        <subsection>
-            <title>Creating Files for Uploading to <webwork /></title>
-
-            <p>All of the <tag>webwork</tag> that you have written into your project can be <q>harvested</q> and put into their own <c>.pg</c> files by the <c>mbx</c> script. These files are created with a folder structure that follows the chunking scheme you specify. This process also creates set definition files (<c>.def</c>) for each chunk (say, for each section): one for inline exercises and one for divisional exercises. For <tag>webwork</tag> problems that come from the <webwork /> server, the <c>.def</c> file will include them as well. This archiving process creates set header <c>.pg</c> files for each set definition.</p>
-
-            <p>As with other <webwork /> processing, you must use the extraction and merge process first that is described in <xref ref="extraction-and-merging">Subsection</xref>. For example:</p>
-            <sidebyside>
-                <console>
-                    <prompt>$ </prompt>
-                    <input>xsltproc --stringparam chunk.level 1 pretext-ww-problem-sets.xsl merge.ptx</input>
-                </console>
-            </sidebyside>
-            <p>This creates a folder named after your book title, which has a folder tree with all of the <c>.pg</c> and <c>.def</c> files laid out according to your chunk level. You can compress this folder and upload it into an active <webwork /> course where you may then assign the sets to your students (and modify, as you like).</p>
-        </subsection>
     </section>
 
 </chapter>

--- a/doc/publisher-guide/publisher-guide.xml
+++ b/doc/publisher-guide/publisher-guide.xml
@@ -34,6 +34,7 @@
         <xi:include href="jupyter-notebook.xml" />
         <xi:include href="instructor-version.xml" />
         <xi:include href="ancillaries.xml" />
+        <xi:include href="webwork.xml" />
         <xi:include href="web-hosting.xml" />
         <xi:include href="latex-styling.xml" />
         <xi:include href="cover-design.xml" />

--- a/doc/publisher-guide/webwork.xml
+++ b/doc/publisher-guide/webwork.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--      PreTeXt Author's Guide                              -->
+<!--                                                          -->
+<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<chapter xml:id="webwork">
+    <title><webwork /> Automated Homework Problems</title>
+    <author>Alex Jordan</author>
+
+    <introduction>
+        <p>With a <webwork/> server (version 2.14 or higher, or <url href="https://webwork-ptx.aimath.org"><c>webwork-ptx.aimath.org</c></url>) and a little setup work, you can embed <webwork/> exercises<idx><h><webwork/></h><h><webwork/> exercise</h></idx> in your <pretext/> project. HTML output can have interactive problem cells or print problems in <q>static</q> form. PDF output will print static versions. And all such exercises can be archived into a file tree to be uploaded onto a <webwork/> server for use in the <q>traditional</q> way.</p>
+
+        <p>See the <pretext/> Authoring Guide for how to include <webwork/> problems in your source.</p>
+    </introduction>
+
+    <section xml:id="webwork-configuration">
+        <title>Configuring a <webwork/> Course for <pretext/></title>
+        <p>We assume a mild familiarity with administrating a <webwork/> server. The version of <webwork/> needs to be 2.14 or later for use with <pretext/>. Using the <c>admin</c> course, create a course named <c>anonymous</c>. (You could name it something else, but we assume the name is <c>anonymous</c> in this guide.) In the course's Course Configuration menu, set all permissions to <c>admin</c> (or perhaps set some to the even more restrictive <c>nobody</c>). Except set <q>Allowed to login to the course</q> to <c>login_proctor</c>.</p>
+        <p>In the Classlist Editor, add a user named <c>anonymous</c> (again, you could use some other name), and set that user's permission level to <c>login_proctor</c>, the permission level one higher than <c>student</c>. Set that user's password to <c>anonymous</c> (again, you could use some other password). Note that because this is public information, anyone will be able to log into this course as this user. This is why setting the permissions earlier is very important. (Especially preventing this user from changing its own password.)</p>
+        <p>Add the following lines to the <c>course.conf</c> file (which lives in the parent folder of the <c>templates/</c> folder.)</p>
+        <pre>
+        # Hide message about previewing hints and solutions for instructors
+        $pg{specialPGEnvironmentVars}{ALWAYS_SHOW_HINT_PERMISSION_LEVEL} = 100;
+        $pg{specialPGEnvironmentVars}{ALWAYS_SHOW_SOLUTION_PERMISSION_LEVEL} = 100;
+        </pre>
+        <p>In the <c>templates/macros/</c> folder, edit <c>PGcourse.pl</c> (or create it if need be) and add the lines:</p>
+        <pre>
+        #### Replace essay boxes with a message
+        sub essay_box {
+            my $out = MODES(
+                TeX => '',
+                Latex2HTML => '',
+                HTML => qq!&lt;P>
+                    If you were logged into a WeBWorK course
+                    and this problem were assigned to you,
+                    you would be able to submit an essay answer
+                    that would be graded later by a human being.
+                &lt;/P>!,
+                PTX => '',
+            );
+            $out;
+        };
+
+        #### Suppress essay help link
+        sub essay_help {};
+
+        #### How many attempts until hint is available
+        $showHint = -1;
+        # May be a bug that WeBWorK requires -1 instead of 0
+        # for immediate access to hints
+
+        1;
+        </pre>
+        <p>Now <pretext/> will be able to communicate with this course to retrieve what is needed.</p>
+    </section>
+
+    <section xml:id="webwork-processing">
+        <title>Processing</title>
+
+        <subsection xml:id="extraction-and-merging">
+            <title>Extraction and Merging</title>
+            <p>A <pretext/> project that uses <webwork/> must first have its <webwork/> content extracted into an auxiliary XML file before anything else can be done. Use the <c>mbx</c> script to extract <pretext/> content from the <webwork/> server into a <em>folder</em>, which you might call <c>webwork-extraction/</c> as in this example:</p>
+
+            <sidebyside>
+                <console>
+                    <prompt>$ </prompt>
+                    <input>mbx -c webwork -s &lt;server&gt; -d webwork-extraction &lt;xml&gt;</input>
+                </console>
+            </sidebyside>
+
+            <warning>
+                <title>File Paths</title>
+                <p>In the previous example and those that follow, you should specify paths as needed. For example, the <c>mbx</c> script is typically at <c>~/mathbook/script/mbx</c>. And the <c>-d</c> option is sepcifying a directory to place the auxiliary file, and if you literally use <c>-d webwork-extraction</c> instead of a full path, the expectation is that <c>webwork-extraction</c> is a folder in your current working folder.</p>
+            </warning>
+
+            <p><c>-c webwork</c> means you are processing the <webwork/> components.</p>
+
+            <p><c>-s</c> specifies the <webwork/> server. The <webwork /> server needs to be version 2.14 or later, specified with its protocol and domain, like <c>https://webwork-ptx.aimath.org</c>. (If you do not have a server, you may use <c>https://webwork-ptx.aimath.org</c>.)</p>
+
+            <p>If any of your hosting course, user for that course, password for the site, or password for the course user are not <c>anonymous</c>, then specify the server like
+            <cd>-s "(https://webwork-ptx.aimath.org,courseID,userID,site_password,course_password)"</cd>
+            The <c>site_password</c> is probably <q>anonymous</q>, but could be something different. Only server administrators can set this.</p>
+
+            <p><c>-d</c> specifies a path to the folder where the auxiliary files will be stored. That folder is named <c>webwork-extraction</c> in the example. Any image files that the <webwork/> server generates will be stored inside this folder. An auxiliary XML <em>file</em> called <c>webwork-extraction.xml</c> will be created in this folder. (Note that you can name the folder whatever you like, but the auxiliary file that is created will always be named <c>webwork-extraction.xml</c>.)</p>
+
+            <p>What is called <q><c>&lt;xml&gt;</c></q> in the example should be the root file for your <pretext/> project.</p>
+
+            <p>The second phase of processing is to merge the extracted content with your original source tree. Use <c>xsltproc</c> with <c>pretext-merge.xsl</c> to do this as in this example:</p>
+
+            <sidebyside>
+                <console>
+                    <prompt>$ </prompt>
+                    <input>xsltproc --stringparam webwork.extraction webwork-extraction.xml pretext-merge.xsl &lt;xml&gt; > merge.ptx</input>
+                </console>
+            </sidebyside>
+
+            <p>The string parameter <c>webwork.extraction</c> must identify the auxiliary XML file created in the previous step. Rather than literally typing <q><c>webwork-extraction.xml</c></q>, you likely need the full path to that file.</p>
+
+            <p>What is called <q><c>&lt;xml&gt;</c></q> in the example should be the root file for your <pretext/> project.</p>
+
+            <p>Store the merged XML tree in some file. The example stored it in <c>merge.ptx</c>. You may want to provide a path.</p>
+        </subsection>
+
+        <subsection>
+            <title>HTML output</title>
+            <p>When you execute <c>xsltproc</c><idx><c>xsltproc</c></idx> using <c>mathbook-html.xsl</c>, apply it to the merged file described above, not your original source. For example:</p>
+            <sidebyside>
+                <console>
+                    <prompt>$ </prompt>
+                    <input>xsltproc mathbook-html.xsl merge.ptx</input>
+                </console>
+            </sidebyside>
+            <p>You may need to specify paths to <c>mathbook-html.xsl</c> and <c>merge.ptx</c>.</p>
+            <p>There are several string parameters you may pass to <c>xsltproc</c>.</p>
+            <sidebyside>
+                <tabular valign="top">
+                    <col />
+                    <col width="60%" />
+                    <row bottom="major">
+                        <cell>stringparam</cell>
+                        <cell>options</cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell><c>webwork.inline.static</c></cell>
+                        <cell>
+                            <p><c>'no'</c> (default) means inline exercises render as interactive.</p>
+                            <p><c>'yes'</c> means inline exercises render as static.</p>
+                            <p><c>'preview'</c> (planned) means inline exercises render as static until you click to activate them.</p>
+                        </cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell><c>webwork.divisional.static</c></cell>
+                        <cell>
+                            <p><c>'no'</c> means divisional exercises render as interactive.</p>
+                            <p><c>'yes'</c> (default) means divisional exercises render as static.</p>
+                            <p><c>'preview'</c> (planned) means divisional exercises render as static until you click to activate them.</p>
+                        </cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell><c>html.knowl.exercise.inline</c></cell>
+                        <cell>
+                            <p><c>'no'</c> means inline exercises appear on page load.</p>
+                            <p><c>'yes'</c> (default) means inline exercises are hidden in knowls.</p>
+                        </cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell><c>html.knowl.exercise.sectional</c></cell>
+                        <cell>
+                            <p><c>'no'</c> (default) means divisional exercises appear on page load.</p>
+                            <p><c>'yes'</c> means divisional exercises are hidden in knowls.</p>
+                        </cell>
+                    </row>
+                </tabular>
+            </sidebyside>
+
+            <p>If your <webwork/> extraction included image files from the <webwork/> server and you are rendering the corresponding problems as static, then you need to copy the images files (from where your extracted auxiliary XML file was placed) over to where your HTML output assumes images files are located.</p>
+        </subsection>
+
+        <subsection xml:id="webwork-latex-output">
+            <title><latex/> output</title>
+            <p>When you execute <c>xsltproc</c><idx><c>xsltproc</c></idx> using <c>mathbook-latex.xsl</c>, apply it to the merged file described above, not your original source. For example:</p>
+            <sidebyside>
+                <console>
+                    <prompt>$ </prompt>
+                    <input>xsltproc mathbook-latex.xsl merge.ptx</input>
+                </console>
+            </sidebyside>
+            <p>You may need to specify paths to <c>mathbook-latex.xsl</c> and <c>merge.ptx</c>.</p>
+
+            <p>One string parameter you can pass to <c>xsltproc</c> is <c>latex.fillin.style</c>, which can take values <c>'underline'</c> (the default) or <c>'box'</c>.</p>
+
+            <p>If your <webwork/> extraction included image files from the <webwork/> server , then you need to copy the images files (from where your extracted auxiliary XML file was placed) over to where your TeX output assumes images files are located.</p>
+        </subsection>
+
+        <subsection>
+            <title>Creating Files for Uploading to <webwork/></title>
+
+            <p>All of the <tag>webwork</tag> that you have written into your project can be <q>harvested</q> and put into their own <c>.pg</c> files by the <c>mbx</c> script. These files are created with a folder structure that follows the chunking scheme you specify. This process also creates set definition files (<c>.def</c>) for each chunk (say, for each section): one for inline exercises (checkpoints) and one for divisional exercises. For <tag>webwork</tag> problems that come from the <webwork/> server, the <c>.def</c> file will include them as well. This archiving process creates set header <c>.pg</c> files for each set definition.</p>
+
+            <p>As with other <webwork/> processing, you must use the extraction and merge process first that is described in <xref ref="extraction-and-merging">Subsection</xref>. Then use <c>xsltproc</c> with <c>pretext-ww-problem-sets.xsl</c>. For example:</p>
+            <sidebyside>
+                <console>
+                    <prompt>$ </prompt>
+                    <input>xsltproc --stringparam chunk.level 2 pretext-ww-problem-sets.xsl merge.ptx</input>
+                </console>
+            </sidebyside>
+            <p>You may need to specify paths to <c>pretext-ww-problem-sets.xsl</c> and <c>merge.ptx</c>.</p>
+
+            <p>With a book, <c>--stringparam chunk.level 2</c> means that each problem set corresponds to a section from the book. Level 1: chapter. Level 3: subsection. With an article there are no chapters, and Level 1 corresponds to sections.</p>
+
+            <p>This creates a folder named after your book title, which has a folder tree with all of the <c>.pg</c> and <c>.def</c> files laid out according to your chunk level. You can compress this folder and upload it into an active <webwork/> course where you may then assign the sets to your students (and modify, as you like).</p>
+        </subsection>
+    </section>
+
+</chapter>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -564,9 +564,9 @@
         </section>
 
         <section>
-            <title>PGML Formatting Calisthenics</title>
+            <title>PGML Formatting and Verbatim Calisthenics</title>
 
-            <p>This section has one exercise, designed to test various PGML formatting rules in an exercise with no purpose. Consult the source to see how the special characters and formatting are realized.</p>
+            <p>This section is designed to test various PGML formatting rules and verbatim content returned in answer hashes. Consult the source to see how the special characters and formatting are realized.</p>
 
             <exercise xml:id="ww-PGML-format">
                 <title>PGML Formatting</title>
@@ -575,9 +575,9 @@
                     <statement>
                         <p>Smart double quotes: <q>Life is about making an impact, not making an income.</q></p>
                         <p>Smart single quotes: <sq>Whatever the mind of man can conceive and believe, it can achieve.</sq></p>
+                        <p>Regular apostrophes: My siblings' mother's daughter isn't my daughter's siblings' mother.</p>
                         <p>Emphasis: <em>very important</em></p>
                         <p>Alert: <alert>do not</alert> do it</p>
-                        <p>Verbatim: code, <c>with special characters: a * , a \, a {, a }, and a #</c></p>
                         <p>Braces: <braces>text that looks like a set</braces></p>
                         <!-- uncomment next to test, will not activate generally in sample document -->
                         <!-- <p>Verbatim: code, <c>with banned substring: [|</c></p>                -->
@@ -589,10 +589,17 @@
                         And this [$NDASH]* should not be an en-dash
                         </pre>
 
-                        <p>Some of <tex/>'s and <latex />'s special characters, as empty elements, which will eventually be deprecated:</p>
-                        <p><hash /> <dollar /> <percent /> <circumflex /> <ampersand /> <underscore /> <lbrace /> <rbrace /> <tilde />  <backslash /></p>
+                        <p>
+                            Here is some inline <c>code with special characters &amp; &lt; &gt; " ' # $ % ^ _ { } ~ \ * [ ]</c>,
+                            and here is some <cd>single-line display code with special characters &amp; &lt; &gt; " ' # $ % ^ _ { } ~ \ * [ ]</cd>
+                            and here is some
+                            <cd>
+                                <cline>multi-line display</cline>
+                                <cline>code with special characters &amp; &lt; &gt; " ' # $ % ^ _ { } ~ \ * [ ]</cline>
+                            </cd>
+                        </p>
 
-                        <p>Some raw characters, XML/HTML:    &amp; &lt; &gt;</p>
+                        <p>Some raw characters, XML/HTML:    &amp; &lt; &gt; " '</p>
                         <p>Some raw characters, <latex/>:    # $ % ^ &amp; _ { } ~ \</p>
                         <p>Some raw characters, PGML:        \ * # { } [ ]</p>
 
@@ -626,6 +633,62 @@
                         <p>+ Not an unordered list item</p>
                         <p>- Not an unordered list item</p>
 
+                    </statement>
+                </webwork>
+            </exercise>
+
+            <p>Here we make MathObject String answers to see how they turn out in answer elements.</p>
+
+            <exercise>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                            $xmlchars = q(&lt;>&amp;'";);
+                            $latex0 = '#%&amp;&lt;>\^_`|~';
+                            $latex1 = '${}';
+                            $alphanumeric = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+                            $otherchars = '!()*+,-./:=?@[]';
+                            Context()->strings->add($xmlchars=>{});
+                            Context()->strings->add($latex0=>{});
+                            Context()->strings->add($latex1=>{});
+                            Context()->strings->add($alphanumeric=>{});
+                            Context()->strings->add($otherchars=>{});
+                            $xmlcharsMO = String($xmlchars);
+                            $latex0MO = String($latex0);
+                            $latex1MO = String($latex1);
+                            $alphanumericMO = String($alphanumeric);
+                            $othercharsMO = String($otherchars);
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p><ol>
+                            <li>
+                                <p>Special characters used by XML, character escaping: <var name="$xmlchars" /></p>
+                                <p>Now as a MathObject: <var name="$xmlcharsMO" /></p>
+                                <p><var name="$xmlchars" width="6" /></p>
+                            </li>
+                            <li>
+                                <p>Special characters used by LaTeX, where LaTeX <c>\text</c> and MathJax <c>\text</c> disagree: <var name="$latex0" /></p>
+                                <p>Now as a MathObject: <var name="$latex0MO" /></p>
+                                <p><var name="$latex0" width="11" /></p>
+                            </li>
+                            <li>
+                                <p>Special characters used by LaTeX, where LaTeX <c>\text</c> and MathJax <c>\text</c> can agree: <var name="$latex1" /></p>
+                                <p>Now as a MathObject: <var name="$latex1MO" /></p>
+                                <p><var name="$latex1" width="3" /></p>
+                            </li>
+                            <li>
+                                <p>Alphanumeric characters: <var name="$alphanumeric" /></p>
+                                <p>Now as a MathObject: <var name="$alphanumericMO" /></p>
+                                <p><var name="$alphanumeric" width="62" /></p>
+                            </li>
+                            <li>
+                                <p>Other characters: <var name="$otherchars" /></p>
+                                <p>Now as a MathObject: <var name="$othercharsMO" /></p>
+                                <p><var name="$otherchars" width="15" /></p>
+                            </li>
+                        </ol></p>
+                        <p>In answers, because of <latex/> and MathJax divergence, the first two should come out in verbatim. (And so should any string containing even one of those characters.) The latter three should come out in regular text.</p>
                     </statement>
                 </webwork>
             </exercise>
@@ -676,8 +739,7 @@
                         <pg-code>
                             $theorem = RadioButtons(
                               ["The Quadratic Formula","The Fundamental Theorem of Calculus","The Fundamental Theorem of Arithmetic","None of these"],
-                              "The Fundamental Theorem of Calculus", # correct answer
-                              last => ["None of these"], # can be a list
+                              1, # index of correct answer; could also just be the correct answer
                             );
                         </pg-code>
                     </setup>
@@ -968,16 +1030,9 @@
 
                     <setup>
                         <pg-code>
-                            $color1 = PopUp(
-                                ["?","Red","Blue","Green"],
-                                "Blue",
-                            );
+                            $color1 = PopUp(["?","Red","Blue","Green"], 2);
 
-                            $color2 = RadioButtons(
-                              ["Red","Blue","Green","None of these"],
-                              "Blue", # correct answer
-                              last => ["None of these"], # can be a list
-                            );
+                            $color2 = RadioButtons(["Red","Blue","Green","None of these"], 1);
 
                         </pg-code>
                      <!-- include below in pg-code once checkboxes implemented
@@ -1013,6 +1068,23 @@
                     </solution>
 
                 </webwork>
+            </exercise>
+
+            <exercise>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                              $expressions = RadioButtons(['\(x\)','\(x^2\)','\(2^x\)'], 2);
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p>There is math in each option for this question. Which expression is not a polynomial? <var name="$expressions" form="buttons"/></p>
+                    </statement>
+                    <solution>
+                        <p>The answer is <var name="$expressions"/>.</p>
+                    </solution>
+                </webwork>
+
             </exercise>
 
             <exercise>

--- a/script/mbx
+++ b/script/mbx
@@ -482,7 +482,7 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             if file_empty:
                 raise ValueError(file_empty_msg.format(problem_identifier))
             if no_compile:
-                raise ValueError(no_compile_msg.format(problem_identifier, seed[problem], pg[problem]))
+                raise ValueError(no_compile_msg.format(problem_identifier, seed[problem], response.text))
             if bad_xml:
                 raise ValueError(bad_xml_msg.format(problem_identifier, seed[problem], response.text))
 

--- a/script/mbx
+++ b/script/mbx
@@ -458,7 +458,7 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             msg = "There was a problem collecting a problem,\n Server: {}\nRequest Parameters: {}\n"
             raise ValueError(msg.format(wwurl, server_params) + root_cause)
 
-        # Obtained static, check for errors with PG processing
+        # Check for errors with PG processing
         # First, get booleans file_empty, no_compile, and bad_xml
         file_empty = 'ERROR:  This problem file was empty!' in response.text
         no_compile = 'ERROR caught by Translator while processing problem file:' in response.text
@@ -469,7 +469,7 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             msg = 'failed to import ElementTree from xml.etree'
             raise ValueError(msg)
         try:
-            x = ElementTree.fromstring(response.text)
+            x = ElementTree.fromstring(response.text.encode('utf-8'))
         except:
             bad_xml = True
 
@@ -486,10 +486,46 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             if bad_xml:
                 raise ValueError(bad_xml_msg.format(problem_identifier, seed[problem], response.text))
 
-        # Otherwise...
+        # When a PG Math Object is a text string that has to be rendered in a math environment,
+        # it is wrapped like this: \verb\x85string\x85.
+        # The first thing we want to do is replace all instances with \text{string}.
+        # But \text does not behave equivalently in tex and MathJax.
+        # Certain characters _need_ to be escaped in TeX, but must _not_ be escaped in MathJax.
+        # So we only make the change after checking that none of the dangerous characters are present.
+
+        verbatim_split = re.split(r'(\\verb\x85.*?\x85)', response.text)
+        response_text = ''
+        for item in verbatim_split:
+            if re.compile(r'(\\verb\x85.*?\x85)').match(item):
+                verbatim_content = re.findall(r'\\verb\x85(.*?)\x85', item)[0]
+                if set(['#', '%', '&', '<', '>', '\\', '^', '_', '`', '|', '~']).intersection(set(list(verbatim_content))):
+                    index = 33
+                    while index < 127:
+                        if index in [42, 34, 38, 39, 59, 60, 62] or chr(index) in verbatim_content:
+                            # the one character you cannot use with \verb as a delimiter is chr(42), *
+                            # the others excluded here are the XML control characters,
+                            # and semicolon for good measure (as the closer for escaped characters)
+                            index += 1
+                        else:
+                            break
+                    if index == 127:
+                        print('PTX:WARNING: Could not find delimiter for verbatim expression')
+                        return '!Could not find delimiter for verbatim expression.!'
+                    else:
+                        response_text += item.replace(u'\x85', chr(index))
+                else:
+                    # These three characters are escaped in both TeX and MathJax
+                    text_content = verbatim_content.replace('$', '\\$')
+                    text_content = text_content.replace('{', '\\{')
+                    text_content = text_content.replace('}', '\\}')
+                    response_text += '\\text{' + text_content + '}'
+            else:
+                response_text += item
+
+        # Now if we are not aborting upon recoverable errors
         if not file_empty and not no_compile and not bad_xml:
             # add to dictionary
-            static[problem] = response.text
+            static[problem] = response_text
             # strip out actual PTX code between markers
             start = start_marker.split(static[problem], maxsplit=1)
             static[problem] = start[1]
@@ -517,6 +553,47 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             if title:
                 title = title.group(1)
                 static[problem] = static[problem].replace('<static>\n','<static>\n' + title + '\n\n')
+
+        # Convert answerhashes XML to a sequence of answer elements
+        # This is crude text operation on the XML
+        # If correct_ans_latex_string is nonempty, use it, encased in <p><m>
+        # Else if correct_ans is nonempty, use it, encased in just <p>
+        # Else we have no answer to print out
+        answerhashes = re.findall(r'<AnSwEr\d+ (.*?) />', static[problem])
+        if answerhashes:
+            answer = ''
+            for answerhash in answerhashes:
+                try:
+                    correct_ans = re.search('correct_ans="(.*?)"', answerhash).group(1)
+                except:
+                    correct_ans = ''
+                try:
+                    correct_ans_latex_string = re.search('correct_ans_latex_string="(.*?)"', answerhash).group(1)
+                except:
+                    correct_ans_latex_string = ''
+
+                if correct_ans_latex_string != '' or correct_ans != '':
+                    answer += "<answer>\n  <p>"
+                    if correct_ans_latex_string == '':
+                        answer += correct_ans
+                    else:
+                        answer += '<m>' + correct_ans_latex_string + '</m>'
+                    answer += "</p>\n</answer>\n"
+
+            # Now we need to cut out the answerhashes that came from the server.
+            beforehashes = re.compile('<answerhashes>').split(static[problem])
+            beforehashes = beforehashes[0]
+            afterhashes = re.compile('</answerhashes>').split(static[problem])
+            afterhashes = afterhashes[1]
+            static[problem] = beforehashes + afterhashes
+
+            # We don't just replace it with the answer we just built. To be
+            # schema-compliant, the answer should come right after the latter of
+            # (last closing statement, last closing hint)
+            # By reversing the string, we can just target first match
+            reverse = static[problem][::-1]
+            parts = re.split(r"(\n>tnemetats/<|\n>tnih/<)",reverse, 1)
+            static[problem] = parts[2][::-1] + parts[1][::-1] + answer + parts[0][::-1]
 
         # nice to know what seed was used
         static[problem] = static[problem].replace('<static', '<static seed="' + seed[problem] + '"')

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -714,8 +714,8 @@
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "contextFiniteSolutionSets.pl",&#xa;</xsl:text>
                 </xsl:when>
-                    <xsl:text>"contextFiniteSolutionSets.pl",</xsl:text>
                 <xsl:otherwise>
+                    <xsl:text>"contextFiniteSolutionSets.pl",</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:if>

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -1566,7 +1566,8 @@
 <!-- * -, + Escape these if they are the first non-white space       -->
 <!--       character on a line or they will start an unordered list. -->
 <!--                                                                 -->
-<!-- * ```  three backticks start "code" (seems not?, unimplemented) -->
+<!-- * ```  three backticks start and end "code" which is more like  -->
+<!--        PTX pre                                                  -->
 <!--                                                                 -->
 <!-- * :  A line opening with a colon and two (three) spaces makes   -->
 <!--      preformatted text. (not really a verbatim block)           -->
@@ -1593,6 +1594,7 @@
 <xsl:template name="greater-character">
     <xsl:text>&gt;</xsl:text>
 </xsl:template>
+
 <!-- Percent sign -->
 <xsl:template name="percent-character">
     <xsl:text>%</xsl:text>
@@ -1737,14 +1739,48 @@
     </xsl:choose>
 </xsl:template>
 
+<!-- Lines of Code -->
+<!-- Note this contruct uses PGML ```,                   -->
+<!-- so it will return with the encompassing p closed,   -->
+<!-- and inside a pre. WeBWorK doesn't really know where -->
+<!-- p's open and close, so we can't hop to return cd.   -->
+<xsl:template match="cd">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:call-template name="potential-list-indent" />
+    <xsl:text>```&#xa;</xsl:text>
+    <!-- Subsequent lines of PGML should not be indented -->
+    <xsl:choose>
+        <xsl:when test="cline">
+            <xsl:apply-templates select="cline" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="sanitize-text">
+                <xsl:with-param name="text" select="." />
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>```&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="cline">
+    <xsl:variable name="trimmed-text">
+        <xsl:call-template name="sanitize-text">
+            <xsl:with-param name="text" select="." />
+        </xsl:call-template>
+    </xsl:variable>
+    <!-- Remove carriage return, then append three spaces and carriage return for PGML line break -->
+    <xsl:value-of select="concat(substring($trimmed-text, 1, string-length($trimmed-text) - 1),'   &#xa;')"/>
+</xsl:template>
+
+
 <!-- Preformatted Text -->
 <!-- Sanitization analyzes *all* lines for left margin. -->
 <xsl:template match="pre">
-    <xsl:text>```</xsl:text>
+    <xsl:text>```&#xa;</xsl:text>
     <xsl:call-template name="sanitize-text">
         <xsl:with-param name="text" select="." />
     </xsl:call-template>
-    <xsl:text>```&#xa;</xsl:text>
+    <xsl:text>```&#xa;&#xa;</xsl:text>
 </xsl:template>
 
 <!-- The next three are WW macros that PGML will format  -->

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -1472,10 +1472,10 @@
     <xsl:param name="b-verbose" />
     <xsl:choose>
         <xsl:when test="$b-verbose">
-            <xsl:text>[@MODES(HTML =&gt; '\(\mathrm\LaTeX\)', TeX =&gt; '\LaTeX', PTX =&gt; '&lt;latex/&gt;')@]*</xsl:text>
+            <xsl:text>[$LATEX]*</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:text>[@MODES(HTML=&gt;'\(\mathrm\LaTeX\)',TeX=&gt;'\LaTeX', PTX=&gt;'&lt;latex/&gt;')@]*</xsl:text>
+            <xsl:text>[$TEX]*</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -852,24 +852,7 @@
     <xsl:if test="(count(preceding-sibling::*)+count(preceding-sibling::text()))=0 and parent::p/parent::statement">
         <xsl:text>    </xsl:text>
     </xsl:if>
-    <xsl:text>[</xsl:text>
-    <!-- for small width, print underscores; otherwise, specify by number -->
-    <xsl:choose>
-        <xsl:when test="$width &lt; 13">
-            <xsl:call-template name="duplicate-string">
-                <xsl:with-param name="count" select="$width" />
-                <xsl:with-param name="text"  select="'_'" />
-            </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text>_</xsl:text> <!-- width specified after evaluator -->
-            <!-- NECESSARY? -->
-            <xsl:if test="$b-verbose">
-                <xsl:text>_</xsl:text>
-            </xsl:if>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>]</xsl:text>
+    <xsl:text>[_]</xsl:text>
     <!-- multiplier for MathObjects like Matrix, Vector, ColumnVector -->
     <xsl:if test="@form='array'">
         <xsl:text>*</xsl:text>
@@ -884,18 +867,9 @@
         </xsl:otherwise>
     </xsl:choose>
     <xsl:text>}</xsl:text>
-    <xsl:if test="$width &gt; 12">
-        <xsl:choose>
-            <xsl:when test="$b-verbose">
-                <xsl:text>{width => </xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>{width=></xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-        <xsl:value-of select="$width"/>
-        <xsl:text>}</xsl:text>
-    </xsl:if>
+    <xsl:text>{</xsl:text>
+    <xsl:value-of select="$width"/>
+    <xsl:text>}</xsl:text>
 </xsl:template>
 
 <!-- Checkbox answers -->


### PR DESCRIPTION
In the sample chapter's Makefile, change the server to -dev. Then `make sample-chapter-extraction` should build a `webwork-extraction.xml` file with answer elements for each problem. `make sample-chapter-merge`, `make sample-chapter-pdf`, and `make sample-chapter-html` should all make good things.

Leaving the server as -ptx should still behave too, just with no answers. 

We have the perennial chick and egg problem with WW development. Part of making this work was adding code to WW on -dev. I'll need to open a PR there to WW's develop branch, get it approved, then wait until it merges into WW's master. Or I could bring these changes into -ptx right now while the WW repo chugs along with its development more slowly. Not sure what to do, except that I will wait to open the PR to WW until you've had a chance to comment. (In case I need to do a little more there.)