### PR TITLE
Add {} after \textbar

### DIFF
--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -7152,7 +7152,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Pipe (Vertical Bar) -->
 <xsl:template name="pipe-character">
-    <xsl:text>\textbar</xsl:text>
+    <xsl:text>\textbar{}</xsl:text>
 </xsl:template>
 
 <!-- Other Miscellaneous Symbols, Constructions -->


### PR DESCRIPTION
This is necessary so that an author can write Wolfram|Alpha and not wind up with Wolfram\textbarAlpha throwing errors at them.