### PR TITLE
ToC as list, along with js and css reorganization

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -9959,7 +9959,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="date-string" select="'2018-07-10'" />
         <xsl:with-param name="message" select="'the obsolete  html.css.file  parameter has been removed, please use html.css.colorfile to choose a color scheme'" />
             <xsl:with-param name="incorrect-use" select="($html.css.file != '')" />
-</xsl:call-template>
+    </xsl:call-template>
     <!--  -->
     <!-- 2018-09-26  appendix subdivision confusion resolved -->
     <xsl:call-template name="deprecation-message">

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -1268,7 +1268,7 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <!-- to define a user variable as empty, and then supply defaults -->
 <!-- to an internal variable.                                     -->
 
-<xsl:variable name="html.js.server" select="''"/>
+<xsl:variable name="html.css.file" select="''"/>
 
 <!-- The old (incomplete) methods for duplicating components of -->
 <!-- exercises have been deprecated as of 2018-11-07.  We keep  -->
@@ -9953,13 +9953,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the &quot;solution-list&quot; element has been deprecated, please switch to using the improved &quot;solutions&quot; division in your back matter (and elsewhere)'" />
     </xsl:call-template>
     <!--  -->
-    <!-- 2018-07-27  transitional  html.js.server  removed -->
+    <!-- 2019-02-10  obsolete  html.css.file  removed -->
     <!-- Still exists in "Variable Bad Bank" for use here  -->
     <xsl:call-template name="parameter-deprecation-message">
-        <xsl:with-param name="date-string" select="'2018-07-27'" />
-        <xsl:with-param name="message" select="'the transitional  html.js.server  parameter has been removed'" />
-            <xsl:with-param name="incorrect-use" select="($html.js.server != '')" />
-    </xsl:call-template>
+        <xsl:with-param name="date-string" select="'2018-07-10'" />
+        <xsl:with-param name="message" select="'the obsolete  html.css.file  parameter has been removed, please use html.css.colorfile to choose a color scheme'" />
+            <xsl:with-param name="incorrect-use" select="($html.css.file != '')" />
+</xsl:call-template>
     <!--  -->
     <!-- 2018-09-26  appendix subdivision confusion resolved -->
     <xsl:call-template name="deprecation-message">

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -9602,7 +9602,6 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <xsl:template name="css">
     <link href="{$html.css.server}/css/{$html.css.version}/pretext.css" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/pretext_add_on.css" rel="stylesheet" type="text/css" />
-    <link href="{$html.css.server}/css/{$html.css.version}/{$html.css.colorfile}" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/toc.css" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/{$html.css.colorfile}" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/setcolors.css" rel="stylesheet" type="text/css" />

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -135,13 +135,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- or to specify the particular CSS file, which may have   -->
 <!-- different color schemes.  The defaults should work      -->
 <!-- fine and will not need changes on initial or casual use -->
-<!-- #0 to #5 on mathbook-modern for different color schemes -->
-<!-- We just like #3 as the default                          -->
-<!-- N.B.:  This scheme is transitional and may change             -->
-<!-- N.B.:  without warning and without any deprecation indicators -->
-<!-- 2018-07-27:  html.js.server  stringparam removed with no fallback -->
-<xsl:param name="html.css.server" select="'https://aimath.org'" />
-<xsl:param name="html.css.file"   select="'mathbook-3.css'" />
+<!-- Files with name colors_*.css set the colors.            -->
+<!-- colors_default is similar to the old mathbook-3.css     -->
+<xsl:param name="html.css.server" select="'https://pretextbook.org'" />
+<xsl:param name="html.css.version" select="'0.2'" />
+<xsl:param name="html.js.server" select="'https://pretextbook.org'" />
+<xsl:param name="html.js.version" select="'0.1'" />
+<xsl:param name="html.css.colorfile"   select="'colors_default.css'" />
 <!-- A space-separated list of CSS URLs (points to servers or local files) -->
 <xsl:param name="html.css.extra"  select="''" />
 
@@ -4064,7 +4064,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- as indicated by $initial, we do not produce an empty paragraph -->
     <!-- NB: this means first display must check for no predecessor,    -->
     <!-- and react accordingly to employ the real paragraph's id.  See  -->
-    <!-- the modal "insert-paragraph-id" jsut below, and its employment -->
+    <!-- the modal "insert-paragraph-id" just below, and its employment -->
     <!--                                                                -->
     <!-- all interesting nodes of paragraph, before first display       -->
     <xsl:variable name="initial" select="$displays[1]/preceding-sibling::*|$displays[1]/preceding-sibling::text()" />
@@ -5617,7 +5617,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- With sidebars killed, this stuff is extraneous     -->
                     <!-- <xsl:apply-templates select="." mode="sidebars" /> -->
                     <main class="main">
-                        <div id="content" class="mathbook-content">
+                        <div id="content" class="pretext-content">
                             <!-- This is content passed in as a parameter -->
                             <xsl:copy-of select="$content" />
                           </div>
@@ -6397,7 +6397,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$content" />
         </xsl:when>
         <!-- 2nd exceptional case, xref in mrow of display math  -->
-        <!-- Requires http://aimath.org/mathbook/mathjaxknowl.js -->
+        <!-- Requires https://pretextbook.org/js/lib/mathjaxknowl.js -->
         <!-- loaded as a MathJax extension for knowls to render  -->
         <xsl:when test="parent::mrow">
             <!-- MathJax expects similar constructions, variation is here -->
@@ -7485,7 +7485,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template name="login-header">
-    <link href="https://pretextbook.org/css/0.1/features.css" rel="stylesheet" type="text/css"/>
+    <link href="{$html.css.server}/css/{$html.css.version}/features.css" rel="stylesheet" type="text/css"/>
     <script>
        <xsl:text>var logged_in = false;&#xa;</xsl:text>
        <xsl:text>var role = 'student';&#xa;</xsl:text>
@@ -7496,7 +7496,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template name="login-footer">
     <div class="login-link"><span id="loginlogout" class="login">login</span></div>
-    <script src="https://pretextbook.org/js/0.1/login.js"></script>
+    <script src="{$html.js.server}/js/{$html.js.version}/login.js"></script>
 </xsl:template>
 
 <!-- Console Session -->
@@ -7713,7 +7713,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- load header libraries (for all "slate") -->
                 <xsl:apply-templates select="." mode="header-libraries" />
             </head>
-            <body class="mathbook-content">
+            <body class="pretext-content">
                 <!-- potential document-id per-page -->
                 <xsl:call-template name="document-id"/>
                 <div>
@@ -8351,7 +8351,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
                 <main class="main">
-                    <div id="content" class="mathbook-content">
+                    <div id="content" class="pretext-content">
                         <xsl:copy-of select="$content" />
                     </div>
                 </main>
@@ -9265,7 +9265,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         <xsl:text>    jax: ["input/AsciiMath"],&#xa;</xsl:text>
         <xsl:text>    extensions: ["asciimath2jax.js"],&#xa;</xsl:text>
         <xsl:text>    TeX: {&#xa;</xsl:text>
-        <xsl:text>        extensions: ["extpfeil.js", "autobold.js", "https://aimath.org/mathbook/mathjaxknowl.js", ],&#xa;</xsl:text>
+        <xsl:text>        extensions: ["extpfeil.js", "autobold.js", "https://pretextbook.org/js/lib/mathjaxknowl.js", ],&#xa;</xsl:text>
         <xsl:text>        // scrolling to fragment identifiers is controlled by other Javascript&#xa;</xsl:text>
         <xsl:text>        positionToHash: false,&#xa;</xsl:text>
         <xsl:text>        equationNumbers: { autoNumber: "none", useLabelIds: true, },&#xa;</xsl:text>
@@ -9324,7 +9324,6 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <!-- so we load the relevant JavaScript onto every page if -->
 <!-- a cell occurs *anywhere* in the entire document       -->
 <xsl:template name="jquery-sagecell">
-    <script src="https://sagecell.sagemath.org/static/jquery.min.js"></script>
     <xsl:if test="$document-root//sage">
         <script src="https://sagecell.sagemath.org/embedded_sagecell.js"></script>
     </xsl:if>
@@ -9534,7 +9533,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 
 <!-- Knowl header -->
 <xsl:template name="knowl">
-<script src="https://aimath.org/knowl.js"></script>
+<script src="{$html.js.server}/js/lib/knowl.js"></script>
 </xsl:template>
 
 <!-- Header information for favicon -->
@@ -9549,9 +9548,10 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <!-- Mathbook Javascript header -->
 <xsl:template name="mathbook-js">
     <!-- condition first on toc present? -->
-    <script src="https://aimath.org/mathbook/js/lib/jquery.sticky.js" ></script>
-    <script src="https://aimath.org/mathbook/js/lib/jquery.espy.min.js"></script>
-    <script src="https://pretextbook.org/js/0.1/pretext.js"></script>
+    <script src="{$html.js.server}/js/lib/jquery.min.js"></script>
+    <script src="{$html.js.server}/js/lib/jquery.sticky.js" ></script>
+    <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
+    <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
 </xsl:template>
 
 <!-- Font header -->
@@ -9600,8 +9600,12 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <!-- CSS header -->
 <!-- The "one-css" template is defined elsewhere -->
 <xsl:template name="css">
-    <link href="{$html.css.server}/mathbook/stylesheets/{$html.css.file}" rel="stylesheet" type="text/css" />
-    <link href="https://aimath.org/mathbook/mathbook-add-on3.css" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/pretext.css" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/pretext_add_on.css" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/{$html.css.colorfile}" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/toc.css" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/{$html.css.colorfile}" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/setcolors.css" rel="stylesheet" type="text/css" />
     <!-- If extra CSS is specified, then unpack multiple CSS files -->
     <!-- The prepared list (extra blank space) will cause failure  -->
     <!-- if $html.css.extra is empty (i.e. not specified)          -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -9027,7 +9027,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     <div id="sidebar-left" class="sidebar" role="navigation">
         <div class="sidebar-content">
             <nav id="toc">
+              <ul>
                  <xsl:apply-templates select="." mode="toc-items" />
+              </ul>
             </nav>
             <div class="extras">
                 <nav>
@@ -9101,7 +9103,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                     <xsl:apply-templates select="." mode="perm-id" />
                 </xsl:variable>
                 <!-- The link itself -->
-                <h2 class="{$class}">
+                <li class="{$class}">
                     <xsl:element name="a">
                         <xsl:attribute name="href">
                             <xsl:value-of select="$outer-url" />
@@ -9120,7 +9122,6 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                             <xsl:apply-templates select="." mode="title-short" />
                         </span>
                     </xsl:element>
-                </h2>
                 <!-- Any "part" or "backmatter" displayed as top-level items     -->
                 <!-- have children that are also considered as top-level items,  -->
                 <!-- so we do not examine the children of "part" or "backmatter" -->
@@ -9169,6 +9170,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                         </ul>
                     </xsl:if>
                 </xsl:if>  <!-- end $toc-level > 1 -->
+                </li>
             </xsl:if>  <!-- end structural, level 1 -->
         </xsl:for-each>
     </xsl:if>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1388,7 +1388,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <!-- knowl or traditional hyperlink     -->
                         <!-- mutually exclusive by construction -->
                         <xsl:if test="knowl">
-                            <xsl:attribute name="knowl">
+                            <xsl:attribute name="data-knowl">
                                 <xsl:value-of select="knowl" />
                             </xsl:attribute>
                         </xsl:if>
@@ -2062,13 +2062,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
     <xsl:element name="a">
         <!-- empty, indicates content *not* in a file -->
-        <xsl:attribute name="knowl" />
+        <xsl:attribute name="data-knowl" />
         <!-- id-ref class means content is in div referenced by id -->
         <xsl:attribute name="class">
             <xsl:text>id-ref</xsl:text>
         </xsl:attribute>
         <!-- and the id via a template for consistency -->
-        <xsl:attribute name="refid">
+        <xsl:attribute name="data-refid">
             <xsl:apply-templates select="." mode="hidden-knowl-id" />
         </xsl:attribute>
         <!-- the object could be the target of an in-context link, and     -->
@@ -2122,7 +2122,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The link for a duplicate hidden knowl -->
 <xsl:template match="*" mode="duplicate-hidden-knowl-link">
     <xsl:element name="a">
-        <xsl:attribute name="knowl">
+        <xsl:attribute name="data-knowl">
             <xsl:apply-templates select="." mode="hidden-knowl-filename" />
         </xsl:attribute>
         <!-- add HTML title attribute to the link -->
@@ -6422,7 +6422,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <xsl:when test="$knowl='true'">
                         <!-- build a modern knowl -->
-                        <xsl:attribute name="knowl">
+                        <xsl:attribute name="data-knowl">
                             <xsl:apply-templates select="$target" mode="xref-knowl-filename" />
                         </xsl:attribute>
                     </xsl:when>
@@ -8274,7 +8274,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             <!-- favicon -->
             <xsl:call-template name="favicon"/>
             <!-- jquery used by sage, webwork, knowls -->
-            <xsl:call-template name="jquery-sagecell" />
+            <xsl:call-template name="sagecell-code" />
             <xsl:call-template name="mathjax" />
             <!-- webwork's iframeResizer needs to come before sage -->
             <xsl:if test="$document-root//webwork-reps">
@@ -8382,7 +8382,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             <meta name="viewport" content="width=device-width,  initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0" />
 
             <!-- jquery used by sage, webwork, knowls -->
-            <xsl:call-template name="jquery-sagecell" />
+            <xsl:call-template name="sagecell-code" />
             <xsl:call-template name="mathjax" />
             <!-- webwork's iframeResizer needs to come before sage -->
             <xsl:if test="$document-root//webwork-reps">
@@ -9323,7 +9323,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 <!-- We never know if a Sage cell might be inside a knowl, -->
 <!-- so we load the relevant JavaScript onto every page if -->
 <!-- a cell occurs *anywhere* in the entire document       -->
-<xsl:template name="jquery-sagecell">
+<xsl:template name="sagecell-code">
     <xsl:if test="$document-root//sage">
         <script src="https://sagecell.sagemath.org/embedded_sagecell.js"></script>
     </xsl:if>


### PR DESCRIPTION
The ToC is a nested list, with no `h2`s.

Javascript and CSS now taken from pretextbook.org.  Each also has version numbers.
(So, `html.js.server` is no longer deprecated.)

The attributes `knowl` and `refid` are now prefixed with `data-`, along with corresponding
javascript and CSS changes.

Colors are specified by `html.css.colorfile`, but `colors_default.css` is the only option
currently available.  Consequently, `html.css.file` is deprecated.

The class `mathbook-content` has been replaced by `pretext-content`, and CSS updated.
This may break custom css implemented by publishers.

The new default colors are not quite the same, but I can fix that later.
(Will not require a pull request.)

I will prepare an announcement describing these changes.



