### PR TITLE
Give ARIA attributes to fillin

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -6753,6 +6753,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:value-of select="5 * $characters div 11" />
                     <xsl:text>em;</xsl:text>
                 </xsl:attribute>
+                <xsl:attribute name="role">
+                    <xsl:text>img</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-label">
+                    <xsl:value-of select="$characters" />
+                    <xsl:text>-character blank</xsl:text>
+                </xsl:attribute>
             </xsl:element>
         </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
This puts `role="img"` and `aria-label="10-character blank"` (or some other number) on the spans for fillins that are not inside math. This makes them accessible. Note I considered other roles, but nothing available seems to be a great fit.

For a fillin inside math, there is nothing to do right now.  Volker says it can't be made accessible right now. But it is on his roadmap to do something, as a similar issue has come to his attention with Ximera. 