### PR TITLE
Hide LaTeX macro definitions in HTML WW

### DIFF
--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -370,9 +370,11 @@
         </xsl:variable>
         <xsl:if test="$macros != ''">
             <xsl:text>loadMacros("PCCmacros.pl");&#xa;</xsl:text>
-            <xsl:text>TEXT(KeyboardInstructions(q@\(</xsl:text>
+            <!-- @ character is unlikely to appear in latex macro definitions, -->
+            <!-- so it makes a good delimiter, better than single quote.       -->
+            <xsl:text>TEXT(MODES(PTX=>'',HTML=>q@&lt;div style="display:none;">\(</xsl:text>
             <xsl:value-of select="$macros" />
-            <xsl:text>\)@));&#xa;</xsl:text>
+            <xsl:text>\)&lt;/div>@));&#xa;</xsl:text>
         </xsl:if>
     </xsl:if>
     <xsl:if test="$b-verbose">


### PR DESCRIPTION
See https://pretextbook.org/examples/webwork/sample-chapter/html/section-4.html#exercises-1, exercise "Every Continuous Function has an Antiderivative". You should see a blank line at the top of the webwork. This is where LaTeX macros are defined. 

This PR puts that in a hidden div (styled inline, since PTX styling doesn't affect WW problems) so after the PR, that blank line is not visible.