### PR TITLE
Support xref in mrow in webwork

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -263,8 +263,8 @@
                     </statement>
 
                     <solution>
-                        <p>We <em>add</em> the exponents as follows:<md>
-                            <mrow><var name="$expression" />&amp;=x^{<var name="$a" />+<var name="$b" />}</mrow>
+                        <p>We <em>add</em> the exponents as follows, while including a gratuitous reference to the quadratic formula:<md>
+                            <mrow><var name="$expression" />&amp;=x^{<var name="$a" />+<var name="$b" />}&amp;<xref ref="theorem-quadratic-formula" text="type-global"/></mrow>
                             <mrow>&amp;=x^{<var name="$c" />}</mrow>
                         </md></p>
                     </solution>

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -1284,7 +1284,7 @@
     <xsl:if test="ancestor::ul|ancestor::ol">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
-    <xsl:apply-templates select="text()|var" />
+    <xsl:apply-templates select="text()|var|xref" />
     <xsl:if test="not(following-sibling::*[self::mrow or self::intertext])">
         <!-- look ahead to absorb immediate clause-ending punctuation -->
         <!-- pass the enclosing environment (md) as the context       -->


### PR DESCRIPTION
Thanks to ff244d4, now it seems like xref is behaving well in WW. This issue had been the nbsp character used in xref text. 

(We don't actually link from a WW problem, since the problem could have a life of its own. But we would like to print the text at least. Authors should be careful that a reference to "Theorem 2.1" may have meaning in the context their book, but not elsewhere.)

This change gets mrow to actually process its xref children, and puts an example in the sample chapter. After processing, look at the solution to checkpoint 1.4 for an xref in an mrow, and in part 1 of checkpoint 2.2 for an xref not in an mrow. Working, both in HTML and PDF.

All with no changes to WeBWorK :)