### PR TITLE
Ggb calculator

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -140,7 +140,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.css.server" select="'https://pretextbook.org'" />
 <xsl:param name="html.css.version" select="'0.2'" />
 <xsl:param name="html.js.server" select="'https://pretextbook.org'" />
-<xsl:param name="html.js.version" select="'0.1'" />
+<xsl:param name="html.js.version" select="'0.11'" />
 <xsl:param name="html.css.colorfile" select="''" />
 <xsl:variable name="html-css-colorfile">
     <xsl:choose>
@@ -7577,6 +7577,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
        <xsl:text>var role = 'student';&#xa;</xsl:text>
        <xsl:text>var guest_access = true;&#xa;</xsl:text>
        <xsl:text>var login_required = false;&#xa;</xsl:text>
+       <xsl:text>var js_version = </xsl:text><xsl:value-of select='$html.js.version'/><xsl:text>;&#xa;</xsl:text>
     </script>
 </xsl:template>
 
@@ -8931,6 +8932,11 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     </xsl:choose>
 </xsl:template>
 
+<xsl:template match="*" mode="calculator-toggle">
+    <div id="calculator-toggle" class="toolbar-item button toggle" title="Show calculator">Calc</div>
+</xsl:template>
+
+
 <!-- Compact Buttons -->
 <!-- These get smashed consecutively into a single "tool-bar" -->
 <xsl:template match="*" mode="compact-buttons">
@@ -9038,6 +9044,10 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                                     <xsl:apply-templates select="." mode="index-button" />
                                 </xsl:otherwise>
                             </xsl:choose>
+                            <!-- Button to show/hide the calculator -->
+                            <xsl:if test="$b-has-calculator">
+                                <xsl:apply-templates select="." mode="calculator-toggle" />
+                            </xsl:if>
                             <!-- Span to encase Prev/Up/Next buttons and float right    -->
                             <!-- Each button gets an id for keypress recognition/action -->
                             <xsl:element name="span">
@@ -9150,16 +9160,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 
 <xsl:template match="*" mode="calculator">
     <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
-        <!-- <style>
-            .geogebra-container {
-                position: fixed;
-                bottom: 20px;
-                right: 10px;
-                width: 320px;
-                height: 600px;
-            }
-        </style> -->
-        <div id="geogebra-container" class="geogebra-container">
+        <div id="calculator-container" class="calculator-container" style="display: none">
             <div id="geogebra-calculator"></div>
         </div>
         <script>
@@ -9179,26 +9180,25 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             <!-- width and height are required parameters                   -->
             <!-- All the rest is customizing some things away from defaults -->
             <!-- (or maybe in some cases explicitly using the defaults)     -->
-            <!-- The last parameters have to do with scaling. This combination allows the 320x600 applet to scale up -->
-            <!-- to the size of the geogebra-container (class) div. The applet will only scale proportionately. With -->
-            <!-- the setup below, only the width can constrain it.                                                   -->
+            <!-- The last parameters have to do with scaling. This combination allows the 330x600 applet -->
+            <!-- to scale up or down to the width of the contining div with class calculator-container.  -->
+            <!-- The applet's height will scale proportionately.                                         -->
             <xsl:text>
-                "width": 320,
+                "width": 330,
                 "height": 600,
                 "showToolBar": true,
                 "showAlgebraInput": true,
                 "perspective": "G/A",
                 "algebraInputPosition": "bottom",
                 <!-- "appletOnLoad": onLoad, -->
-                "showFullscreenButton": true,
-                "scaleContainerClass": "geogebra-container",
+                "scaleContainerClass": "calculator-container",
                 "allowUpscale": true,
                 "autoHeight": true,
                 "disableAutoScale": false},
             true);
-            window.addEventListener("load", function() {
-                ggbApp.inject('geogebra-calculator');
-            });
+            <!--   The calculator is created by                    -->
+            <!--   ggbApp.inject('geogebra-calculator');           -->
+            <!--   which is inserted by code in pretext_add_on.js  -->
             </xsl:text>
         </script>
     </xsl:if>
@@ -9709,6 +9709,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     <script src="{$html.js.server}/js/lib/jquery.sticky.js" ></script>
     <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
+    <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js"></script>
 </xsl:template>
 
 <!-- Font header -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -155,6 +155,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- A space-separated list of CSS URLs (points to servers or local files) -->
 <xsl:param name="html.css.extra"  select="''" />
 
+<!-- Calculator -->
+<!-- Possible values are geogebra-classic, geogebra-graphing -->
+<!-- geogebra-geometry, geogebra-3d                          -->
+<!-- Default is empty, meaning the calculator is not wanted. -->
+<xsl:param name="html.calculator" select="''" />
+<xsl:variable name="b-has-calculator" select="not($html.calculator = '')" />
+
 <!-- Annotation -->
 <xsl:param name="html.annotation" select="''" />
 <xsl:variable name="b-activate-hypothesis" select="boolean($html.annotation='hypothesis')" />
@@ -8439,7 +8446,10 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                         <xsl:copy-of select="$content" />
                     </div>
                 </main>
+                <!-- Overlaid extras, such as a calculator -->
+                <xsl:apply-templates select="." mode="overlays" />
             </div>
+
             <xsl:apply-templates select="$docinfo/analytics" />
             <xsl:call-template name="pytutor-footer" />
             <xsl:call-template name="login-footer" />
@@ -9132,6 +9142,69 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         </aside> -->
 </xsl:template>
 
+<!-- Overlays -->
+<!-- For example, a graphing calculator tool       -->
+<xsl:template match="*" mode="overlays">
+    <xsl:apply-templates select="." mode="calculator" />
+</xsl:template>
+
+<xsl:template match="*" mode="calculator">
+    <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
+        <!-- <style>
+            .geogebra-container {
+                position: fixed;
+                bottom: 20px;
+                right: 10px;
+                width: 320px;
+                height: 600px;
+            }
+        </style> -->
+        <div id="geogebra-container" class="geogebra-container">
+            <div id="geogebra-calculator"></div>
+        </div>
+        <script>
+            <xsl:text>
+            <!-- Here is where we could initialize some things to customize the display.                    -->
+            <!-- But the customization should be different depending on classic, graphing, geometry, or 3d. -->
+            <!-- For instance geometry probably does not benefit from showing the grid.                     -->
+            <!-- If this is not in use, no need to set "appletOnLoad" further below.                        -->
+            <!-- var onLoad = function(applet) {
+                applet.setAxisLabels(1,'x','y','z');
+                applet.setGridVisible(1,true);
+                applet.showFullscreenButton(true);
+            }; -->
+            var ggbApp = new GGBApplet({"appName": "</xsl:text>
+            <xsl:value-of select="substring-after($html.calculator,'-')"/>
+            <xsl:text>", </xsl:text>
+            <!-- width and height are required parameters                   -->
+            <!-- All the rest is customizing some things away from defaults -->
+            <!-- (or maybe in some cases explicitly using the defaults)     -->
+            <!-- The last parameters have to do with scaling. This combination allows the 320x600 applet to scale up -->
+            <!-- to the size of the geogebra-container (class) div. The applet will only scale proportionately. With -->
+            <!-- the setup below, only the width can constrain it.                                                   -->
+            <xsl:text>
+                "width": 320,
+                "height": 600,
+                "showToolBar": true,
+                "showAlgebraInput": true,
+                "perspective": "G/A",
+                "algebraInputPosition": "bottom",
+                <!-- "appletOnLoad": onLoad, -->
+                "showFullscreenButton": true,
+                "scaleContainerClass": "geogebra-container",
+                "allowUpscale": true,
+                "autoHeight": true,
+                "disableAutoScale": false},
+            true);
+            window.addEventListener("load", function() {
+                ggbApp.inject('geogebra-calculator');
+            });
+            </xsl:text>
+        </script>
+    </xsl:if>
+</xsl:template>
+
+
 <!-- Table of Contents Contents (Items) -->
 <!-- Includes "active" class for enclosing outer node              -->
 <!-- Node set equality and subset based on unions of subtrees, see -->
@@ -9665,10 +9738,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 </xsl:template>
 
 <!-- GeoGebra -->
-<!-- The JS necessary to load the "App", which can -->
-<!-- then be loaded with base64 or XML versions    -->
+<!-- The JS necessary to load the "App" for a generic calculator -->
 <xsl:template name="geogebra">
-    <xsl:if test="$b-has-geogebra">
+    <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
         <script src="https://cdn.geogebra.org/apps/deployggb.js"></script>
     </xsl:if>
 </xsl:template>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8447,8 +8447,6 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                         <xsl:copy-of select="$content" />
                     </div>
                 </main>
-                <!-- Overlaid extras, such as a calculator -->
-                <xsl:apply-templates select="." mode="overlays" />
             </div>
 
             <xsl:apply-templates select="$docinfo/analytics" />
@@ -8933,7 +8931,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 </xsl:template>
 
 <xsl:template match="*" mode="calculator-toggle">
-    <div id="calculator-toggle" class="toolbar-item button toggle" title="Show calculator">Calc</div>
+    <button id="calculator-toggle" class="toolbar-item button toggle" title="Show calculator" aria-expanded="false" aria-controls="calculator-container">Calc</button>
 </xsl:template>
 
 
@@ -9047,6 +9045,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                             <!-- Button to show/hide the calculator -->
                             <xsl:if test="$b-has-calculator">
                                 <xsl:apply-templates select="." mode="calculator-toggle" />
+                                <xsl:apply-templates select="." mode="calculator" />
                             </xsl:if>
                             <!-- Span to encase Prev/Up/Next buttons and float right    -->
                             <!-- Each button gets an id for keypress recognition/action -->
@@ -9152,15 +9151,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         </aside> -->
 </xsl:template>
 
-<!-- Overlays -->
-<!-- For example, a graphing calculator tool       -->
-<xsl:template match="*" mode="overlays">
-    <xsl:apply-templates select="." mode="calculator" />
-</xsl:template>
-
 <xsl:template match="*" mode="calculator">
-    <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
-        <div id="calculator-container" class="calculator-container" style="display: none">
+    <xsl:if test="contains($html.calculator,'geogebra')">
+        <div id="calculator-container" class="calculator-container" style="display: none; z-index:100;">
             <div id="geogebra-calculator"></div>
         </div>
         <script>


### PR DESCRIPTION
This gets the calculator going. Just a GGB one, but room for other things later.

I thought about documenting use somewhere. I think I might prefer to wait a bit. After completing work on ggb slates, I'd like to return to this and allow an author to customize the calculator with API commands just like the plan for slates. Any write up of this feature will include a description of that customization option.

There are some accessibility issues with the calculator, as discussed in email. Mainly,

1. We don't know yet if a screen reader user can get much use out of it. There is perceptional accessibility and operational accessibility. It seems to be to have operational accessibility, but perceptional is a question mark to me without some AT user testing.

2. While it's not a full on keyboard trap, getting out of the calculator and back into main content currently requires some special doing. Maybe we can improve upon this with time.

With both issues, especially the first, it may be that GGB itself needs to evolve. In any case, we can give warnings in the documentation about accessibility concerns that can be introduced by activating this feature.

Once this feature is merged, will it be demonstrated in one on of the samples? I wonder which is best. Maybe the sample-chapter, since that already has accessibility issues with the WW iframes? Just trying not to corrupt the accessibility of the other two.
