### PR TITLE
Draft mode for HTML

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -1172,6 +1172,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- very temporary, just for testing -->
 <xsl:param name="debug.exercises.forward" select="''"/>
 
+<!-- text for a watermark that is centered, -->
+<!-- running at a 45 degree angle           -->
+<xsl:param name="watermark.text" select="''" />
+<xsl:variable name="b-watermark" select="not($watermark.text = '')" />
+
+<!-- watermark uses a 5cm font, which can be scaled                     -->
+<!-- and scaling by 0.5 makes "CONFIDENTIAL" fit well in 600 pixel HTML -->
+<!-- and in the default body width for LaTeX                            -->
+<xsl:param name="watermark.scale" select="'0.5'" />
+
+
+
 <!-- Commentary is meant for an enhanced edition, -->
 <!-- like an "Instructor's Manual".  A publisher  -->
 <!-- will need to consciously elect "yes".        -->
@@ -1321,6 +1333,22 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <xsl:param name="task.text.hint" select="''" />
 <xsl:param name="task.text.answer" select="''" />
 <xsl:param name="task.text.solution" select="''" />
+
+<!-- These are deprecated in favor of watermark.text and watermark.scale -->
+<!-- which are now managed in common. These still "work" for now.        -->
+<xsl:param name="latex.watermark" select="''"/>
+<xsl:variable name="b-latex-watermark" select="not($latex.watermark = '')" />
+<xsl:param name="latex.watermark.scale" select="''"/>
+<xsl:variable name="latex-watermark-scale">
+    <xsl:choose>
+        <xsl:when test="not($latex.watermark.scale = '')">
+            <xsl:value-of select="$latex.watermark.scale"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>2.0</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
 
 <!-- ############## -->
 <!-- Entry Template -->
@@ -3048,6 +3076,7 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <xsl:template match="*" mode="serialize">
     <xsl:text>&lt;</xsl:text>
     <xsl:value-of select="name()"/>
+    <xsl:apply-templates select="." mode="serialize-namespace" />
     <xsl:apply-templates select="@*" mode="serialize" />
     <xsl:choose>
         <xsl:when test="node()">
@@ -3070,6 +3099,28 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
     <xsl:value-of select="."/>
     <xsl:text>"</xsl:text>
 </xsl:template>
+
+<!-- A namespace "attribute" is not really an attribute, and not captured by @* above.   -->
+<!-- There seems to be no way to separate an element's actual namespaces from those that -->
+<!-- are explicitly written where the element was created. Here, we loop through all the -->
+<!-- element's namespaces, discarding some that can be safley assumed to not be in the   -->
+<!-- original element declaration. And then serialize what is left.                      -->
+<xsl:template match="*" mode="serialize-namespace">
+    <xsl:for-each select="./namespace::*">
+        <!-- test taken from http://lenzconsulting.com/namespace-normalizer/normalize-namespaces.xsl -->
+        <xsl:if test="name()!='xml' and not(.=../preceding::*/namespace::* or .=ancestor::*[position()>1]/namespace::*)">
+            <xsl:text> xmlns</xsl:text>
+            <xsl:if test="not(name(current())='')">
+                <xsl:text>:</xsl:text>
+                <xsl:value-of select="name(current())"/>
+            </xsl:if>
+            <xsl:text>="</xsl:text>
+            <xsl:value-of select="current()"/>
+            <xsl:text>"</xsl:text>
+        </xsl:if>
+    </xsl:for-each>
+</xsl:template>
+
 
 <xsl:template match="text()" mode="serialize">
     <xsl:value-of select="."/>
@@ -10304,6 +10355,22 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="occurrences" select="$docinfo//rename[@lang]" />
         <xsl:with-param name="date-string" select="'2019-02-20'" />
         <xsl:with-param name="message" select="'the &quot;@lang&quot; attribute of &quot;rename&quot; has been replaced by &quot;@xml:lang&quot;, and is now optional if your document only uses one language'"/>
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2019-03-07  replace latex.watermark with watermark.text         -->
+    <!-- Still exists and is respected, move to Variable Bad Bank later  -->
+    <xsl:call-template name="parameter-deprecation-message">
+        <xsl:with-param name="date-string" select="'2019-03-07'" />
+        <xsl:with-param name="message" select="'the  latex.watermark  parameter has been replaced by  watermark.text  which is effective in HTML as well as LaTeX'" />
+            <xsl:with-param name="incorrect-use" select="($latex.watermark != '')" />
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2019-03-07  replace latex.watermark.scale with watermark.scale  -->
+    <!-- Still exists and is respected, move to Variable Bad Bank later  -->
+    <xsl:call-template name="parameter-deprecation-message">
+        <xsl:with-param name="date-string" select="'2019-03-07'" />
+        <xsl:with-param name="message" select="'the  latex.watermark.scale  parameter has been replaced by  watermark.scale  which is effective in HTML as well as LaTeX'" />
+            <xsl:with-param name="incorrect-use" select="($latex.watermark.scale != '')" />
     </xsl:call-template>
 </xsl:template>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -419,6 +419,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="heading-level" select="$heading-level"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="." mode="author-byline"/>
+        <!-- If there is watermark text, we print it here in an assistive p -->
+        <!-- so that it is the first thing read by a screen-reader user.    -->
+        <xsl:if test="$b-watermark and $heading-level = 2">
+            <p class="watermark">
+                <xsl:text>Watermark text: </xsl:text>
+                <xsl:value-of select="$watermark.text"/>
+                <xsl:text></xsl:text>
+            </p>
+        </xsl:if>
         <!-- Most divisions are a simple list of elements to be       -->
         <!-- processed in document order, once we handle metadata     -->
         <!-- properly, and also kill it so it is not caught up here.  -->
@@ -5725,6 +5734,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%2014%2096%2068%22%20style%3D%22cursor%3Apointer%3B%22%20preserveAspectRatio%3D%22none%22%3E%3Cpath%20fill%3D%22%23e62117%22%20d%3D%22M94.98%2C28.84c0%2C0-0.94-6.6-3.81-9.5c-3.64-3.81-7.72-3.83-9.59-4.05c-13.4-0.97-33.52-0.85-33.52-0.85s-20.12-0.12-33.52%2C0.85c-1.87%2C0.22-5.95%2C0.24-9.59%2C4.05c-2.87%2C2.9-3.81%2C9.5-3.81%2C9.5S0.18%2C36.58%2C0%2C44.33v7.26c0.18%2C7.75%2C1.14%2C15.49%2C1.14%2C15.49s0.93%2C6.6%2C3.81%2C9.5c3.64%2C3.81%2C8.43%2C3.69%2C10.56%2C4.09c7.53%2C0.72%2C31.7%2C0.89%2C32.54%2C0.9c0.01%2C0%2C20.14%2C0.03%2C33.54-0.94c1.87-0.22%2C5.95-0.24%2C9.59-4.05c2.87-2.9%2C3.81-9.5%2C3.81-9.5s0.96-7.75%2C1.02-15.49v-7.26C95.94%2C36.58%2C94.98%2C28.84%2C94.98%2C28.84z%20M38.28%2C61.41v-27l25.74%2C13.5L38.28%2C61.41z%22%2F%3E%3C%2Fsvg%3E</xsl:text>
 </xsl:variable>
 
+<!-- LaTeX watermark uses default 5cm font which is then scaled by watermark.scale -->
+<!-- We copy that here. We also copy the 45 degree angle.                          -->
+<!-- Color rgb(204,204,204) matches LaTeX 80% grayscale.                           -->
+<xsl:variable name="watermark-css">
+    <xsl:variable name="watermark-svg">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="600" width="600">
+            <text x="50%" y="50%" text-anchor="middle" transform="rotate(-45,300,300)" fill="rgb(204,204,204)" style="font-family:sans-serif; font-size:{5*$watermark.scale}cm;">
+                <xsl:value-of select="$watermark.text"/>
+            </text>
+        </svg>
+    </xsl:variable>
+    <xsl:text>background-image:url('data:image/svg+xml;utf8,</xsl:text>
+    <xsl:apply-templates select="exsl:node-set($watermark-svg)" mode="serialize" />
+    <xsl:text>');</xsl:text>
+</xsl:variable>
+
 <!-- create a "video" element for author-hosted   -->
 <!-- dimensions and autoplay as parameters        -->
 <!-- Normally $preview is true, and not passed in -->
@@ -8509,6 +8534,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- HTML5 main will be a "main" landmark automatically -->
                 <main class="main">
                     <div id="content" class="pretext-content">
+                        <xsl:if test="$b-watermark">
+                            <xsl:attribute name="style">
+                                <xsl:value-of select="$watermark-css" />
+                            </xsl:attribute>
+                        </xsl:if>
                         <xsl:copy-of select="$content" />
                     </div>
                 </main>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -62,8 +62,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Non-empty string makes it happen    -->
 <!-- Scale works well for "CONFIDENTIAL" -->
 <!-- or  for "DRAFT YYYY/MM/DD"          -->
+<!-- These are deprecated in favor of watermark.text and watermark.scale -->
+<!-- which are now managed in common. These still "work" for now.        -->
 <xsl:param name="latex.watermark" select="''"/>
-<xsl:param name="latex.watermark.scale" select="2.0"/>
+<xsl:variable name="b-latex-watermark" select="not($latex.watermark = '')" />
+<xsl:param name="latex.watermark.scale" select="''"/>
+<xsl:variable name="latex-watermark-scale">
+    <xsl:choose>
+        <xsl:when test="not($latex.watermark.scale = '')">
+            <xsl:value-of select="$latex.watermark.scale"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>2.0</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
 <!--  -->
 <!-- Author's Tools                                            -->
 <!-- Set the author-tools parameter to 'yes'                   -->
@@ -2050,13 +2063,33 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- (above shaded/colored "tcolorbox").  But on 2018-10-24,      -->
     <!-- xwatermark was at v1.5.2d, 2012-10-23, and draftwatermark    -->
     <!-- was at v1.2, 2015-02-19.                                     -->
-    <xsl:if test="$latex.watermark">
+    <!-- latex.watermark and latex.watermark.scale are deprecated,    -->
+    <!-- but effort is made here so they still work for now           -->
+    <xsl:if test="$b-watermark or $b-latex-watermark">
         <xsl:text>\usepackage{draftwatermark}&#xa;</xsl:text>
         <xsl:text>\SetWatermarkText{</xsl:text>
-        <xsl:value-of select="$latex.watermark" />
+        <xsl:choose>
+            <xsl:when test="$b-watermark">
+                <xsl:value-of select="$watermark.text" />
+            </xsl:when>
+            <xsl:when test="$b-latex-watermark">
+                <xsl:value-of select="$latex.watermark" />
+            </xsl:when>
+            <!-- Logically, should never reach this point.  -->
+            <xsl:otherwise/>
+        </xsl:choose>
         <xsl:text>}&#xa;</xsl:text>
         <xsl:text>\SetWatermarkScale{</xsl:text>
-        <xsl:value-of select="$latex.watermark.scale" />
+        <xsl:choose>
+            <xsl:when test="$b-watermark">
+                <xsl:value-of select="$watermark.scale" />
+            </xsl:when>
+            <xsl:when test="$b-latex-watermark">
+                <xsl:value-of select="$latex-watermark-scale" />
+            </xsl:when>
+            <!-- Logically, should never reach this point.  -->
+            <xsl:otherwise/>
+        </xsl:choose>
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="$author-tools-new = 'yes'" >


### PR DESCRIPTION
What are your thoughts on this? For this one, I decided to make something, then discuss. Instead of the usual other way round.

With `--stringparam draft yes`, this hard codes "(Draft)" into the title in a `draft-title` span that could be styled. And it makes an empty `draft-body` div for a background image.

See http://spot.pcc.edu/~ajordan/temp/draft/interesting-corollary.html for what output looks like (once David would properly style it). Right now I'm using some stock "Draft" image for the background, but we'd probably want our own, hosted with the CSS.

