### PR TITLE
switch latex.print hyperref setting to hide links instead of deactivate

### DIFF
--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -2025,11 +2025,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:if test="$latex.print='no'">
         <xsl:text>%% Hyperlinking active in electronic PDFs, all links solid and blue&#xa;</xsl:text>
-        <xsl:text>\hypersetup{colorlinks=true,linkcolor=blue,citecolor=blue,filecolor=blue,urlcolor=blue}&#xa;</xsl:text>
+        <xsl:text>\hypersetup{hidelinks=false,colorlinks=true,linkcolor=blue,citecolor=blue,filecolor=blue,urlcolor=blue}&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="$latex.print='yes'">
-        <xsl:text>%% latex.print parameter set to 'yes', all hyperlinks black and inactive&#xa;</xsl:text>
-        <xsl:text>\hypersetup{draft}&#xa;</xsl:text>
+        <xsl:text>%% latex.print parameter set to 'yes', all hyperlinks "hidden", set to textcolor (but still active to preserve spacing)&#xa;</xsl:text>
+        <xsl:text>\hypersetup{hidelinks=true,colorlinks=true,linkcolor=blue,citecolor=blue,filecolor=blue,urlcolor=blue}&#xa;</xsl:text>
     </xsl:if>
     <xsl:text>\hypersetup{pdftitle={</xsl:text>
     <xsl:apply-templates select="." mode="title-short" />


### PR DESCRIPTION
Added "hidelinks" option in both latex.print=yes (true) and latex.print=no (false) to allow a publisher to quickly switch inside the .tex file.  Modified latex comments accordingly.