### PR TITLE
Look for stack presence when determining width percentage of video, e…

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -4003,8 +4003,8 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     </xsl:variable>
     <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
     <xsl:choose>
-        <xsl:when test="parent::figure">
-            <xsl:variable name="panel-number" select="count(parent::figure/preceding-sibling::*) + 1" />
+        <xsl:when test="parent::figure or parent::stack">
+            <xsl:variable name="panel-number" select="count(parent::*/preceding-sibling::*) + 1" />
             <xsl:value-of select="$layout/width[$panel-number]" />
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
…tc. in sbs

I had a video and some p's in a stack, in a sbs. (For a course [calendar](http://spot.pcc.edu/~ajordan/MTH65Spring2019/section-calendar-mw.html).) When I went to make PDF, it wants to make the qrcodes, but to do so it needs to calculate the video's width. It came back as NaN because the way this template was not considering the possibility that the video could be in a stack.