### PR TITLE
Add math examples to Showcase Article

### DIFF
--- a/examples/showcase/mathematics.ptx
+++ b/examples/showcase/mathematics.ptx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- This file is part of the PreTeXt Showcase article. -->
+<!--                                                    -->
+<!-- Copyright (©) 2019 The PreTeXt Organization.       -->
+<!-- See the README file for contributing guidelines.   -->
+
+<section xml:id="mathematics">
+  <title>Mathematics</title>
+
+  <subsection>
+    <title>The Quadratic Formula</title>
+
+    <p>
+      There is a derivation of the quadratic formula that avoids using fractions
+      until the very end. Suppose that we have an equation <m>ax^2+bx+c=0</m>,
+      where <m>a\neq0</m>. Since <m>4a</m> is also not equal to <m>0</m>,
+      we may mutliply each side of the equation by <m>4a</m> and not lose any information:
+      <md>
+        <mrow>4a^2x^2+4abx+4ac\amp=0</mrow>
+        <intertext>Subtract <m>4ac</m> from each side:</intertext>
+        <mrow>4a^2x^2+4abx\amp=-4ac</mrow>
+        <intertext>Complete the square on the left side by adding <m>b^2</m> to each side:</intertext>
+        <mrow>4a^2x^2+4abx+b^2\amp=b^2-4ac</mrow>
+        <mrow>(2ax+b)^2\amp=b^2-4ac</mrow>
+        <mrow>\lvert 2ax+b\rvert\amp=\sqrt{b^2-4ac}</mrow>
+        <mrow>2ax+b\amp=\pm\sqrt{b^2-4ac}</mrow>
+        <mrow>2ax\amp=-b\pm\sqrt{b^2-4ac}</mrow>
+        <intertext>Since <m>a\neq0</m>, we may divide by <m>2a</m> on each side:</intertext>
+        <mrow>x\amp=\frac{-b\pm\sqrt{b^2-4ac}}{2a}</mrow>
+      </md>
+      And this is the famous quadratic formula.
+    </p>
+  </subsection>
+
+  <subsection>
+    <title>Some Amusing Identities</title>
+
+    <p>These equations are amusing, although maybe only to mathematicians. Largely taken from <url href="https://math.stackexchange.com/questions/505367/surprising-identities-equations">math.stackexchange.com</url>.
+      <me>
+        \sqrt[\sqrt{2}]{2}=\sqrt{2}^{\sqrt{2}}
+      </me>
+      <me>
+        2592=2^59^2
+      </me>
+      <me>
+        \sqrt{2025}=20+25
+      </me>
+      <me>
+        \sum_{n=1}^{\infty}\frac{1}{n^n}=\int_{0}^1\frac{1}{x^x}\,dx
+      </me>
+      <me>
+        3^3 + 4^4 + 3^3 + 5^5 = 3435
+      </me>
+      <me>
+        \int_{-\infty}^{\infty}\frac{\sin x}{x}\,dx=\int_{-\infty}^{\infty}\frac{\sin^2 x}{x^2}\,dx
+      </me>
+      <me>
+        \log(1+2+3)=\log(1)+\log(2)+\log(3)
+      </me>
+      <me>
+        \int_{0}^{\infty}\frac1{1+x^2}\frac1{1+x^{\pi}}\,dx=\int_{0}^{\infty}\frac1{1+x^2}\frac1{1+x^e}\,dx
+      </me>
+    </p>
+  </subsection>
+
+</section>

--- a/examples/showcase/pretext-showcase.ptx
+++ b/examples/showcase/pretext-showcase.ptx
@@ -62,6 +62,7 @@
       </abstract>
     </frontmatter>
 
+    <xi:include href="mathematics.ptx" />
     <xi:include href="latex-image.ptx" />
 
   </article>


### PR DESCRIPTION
I couldn't stand the Showcase Article going on without something more in it, especially at least demonstrating some math content. So I added these things while I sit through 3_ hours of ORCCA compiling. Still getting a feel for what tone you'd like the SC to have, so feel free to criticize.

@davidfarmer may want to make use of semantic macros here.

Unless the accessibility issues are a detractor, I think that the build script for the HTML should toss in the GeoGebra calculator.

It would be good to show off the index too. But there needs to be some things in there worth indexing. Enough to have knowls that show several types of blocks, as well as index links to several types of division.