### PR TITLE
Improvements to EPUB generation

### DIFF
--- a/examples/epub/build.sh
+++ b/examples/epub/build.sh
@@ -58,6 +58,16 @@ declare OUTFILE=sampler.epub
 
 # removal of detritus (clear $SCRATCH by hand before execution)
 
+# sed -i is different depending on if you have BSD sed (macOS)
+# or GNU sed (Linux and Windows Subystem for Linux)
+# To deal with this, we see which is in use and define a function called
+# sed_i that we invoke rather than plain sed.
+# https://unix.stackexchange.com/questions/92895/how-can-i-achieve-portability-with-sed-i-in-place-editing
+case $(sed --help 2>&1) in
+  *GNU*) sed_i () { sed -i "$@"; };;
+  *) sed_i () { sed -i '' "$@"; };;
+esac
+
 # create directory structure
 install -d ${EPUBOUT} ${EPUBOUT}/EPUB/xhtml ${EPUBOUT}/EPUB/xhtml/images
 install -d ${EPUBOUT}/EPUB/css
@@ -70,7 +80,7 @@ install -d ${DEBUG}
 cp -a ${SRC}/images ${EPUBOUT}/EPUB/xhtml
 mv ${EPUBOUT}/EPUB/xhtml/images/${COVERIMAGE} ${EPUBOUT}/EPUB/xhtml/images/cover.png
 for f in ${EPUBOUT}/EPUB/xhtml/images/*.svg; do 
-    sed -i -f ${EPUBSCRIPT}/mbx-epub-images.sed $f
+    sed_i -f ${EPUBSCRIPT}/mbx-epub-images.sed $f
 done
 
 # make files via xsltproc, into existing directory structure
@@ -80,7 +90,7 @@ xsltproc --xinclude  ${MBXSL}/mathbook-epub.xsl ${SRCMASTER}
 # fixup file header to make obviously XHTML
 declare GLOBIGNORE="${EPUBOUT}/EPUB/xhtml/cover-page.xhtml:${EPUBOUT}/EPUB/xhtml/title-page.xhtml:${EPUBOUT}/EPUB/xhtml/table-contents.xhtml"
 for f in ${EPUBOUT}/EPUB/xhtml/*.xhtml; do
-    sed -i -f ${EPUBSCRIPT}/mbx-epub-xhtml-header.sed $f
+    sed_i -f ${EPUBSCRIPT}/mbx-epub-xhtml-header.sed $f
 done
 unset GLOBIGNORE
 
@@ -100,7 +110,7 @@ for f in ${EPUBOUT}/EPUB/xhtml/*.xhtml; do
     # rm $f.temp;
     mv $f.temp ${DEBUG};
     cp -a $f ${DEBUG};
-    sed -i -f ${EPUBSCRIPT}/mbx-epub.sed $f;
+    sed_i -f ${EPUBSCRIPT}/mbx-epub.sed $f;
 done
 unset GLOBIGNORE
 

--- a/examples/epub/build.sh
+++ b/examples/epub/build.sh
@@ -86,8 +86,8 @@ install -d ${EPUBOUT}/EPUB/xhtml/images
 INPUT="${EPUBOUT}/xhtml/image-list.txt"
 while IFS= read -r LINE
 do
-    SVGFILE=${LINE//[$'\t\r\n']}
-    cp -a ${SRC}/${SVGFILE} ${EPUBOUT}/EPUB/xhtml/${SVGFILE}
+    IMGFILE=${LINE//[$'\t\r\n']}
+    cp -a ${SRC}/${IMGFILE} ${EPUBOUT}/EPUB/xhtml/${IMGFILE}
 done < "$INPUT"
 # make sure the image list doesn't get bundled in the EPUB
 rm ${EPUBOUT}/xhtml/image-list.txt #${EPUBOUT}

--- a/examples/epub/pretext-epub.css
+++ b/examples/epub/pretext-epub.css
@@ -830,12 +830,12 @@ figcaption .type + .codenumber::before {
 }
 
 figcaption .codenumber:after {
-    content: ".\2002";  /* en space */
+    content: "";  /* en space */
 }
 
 figcaption .codenumber:last-child:after {
     display: inline;
-    content: ". ";
+    content: " ";
 }
 
 .definition-like p > em {
@@ -970,12 +970,12 @@ figcaption .codenumber{
     font-family: "PT Serif", "Times New Roman", Times, serif;
 }
 .sidebyside figcaption .codenumber:after {
-    content: ".\2002";  /* en space */
+    content: "\2002";  /* en space */
 }
 
 .sidebyside figcaption .codenumber:last-child:after {
     display: inline;
-    content: ". ";
+    content: " ";
 }
 
 
@@ -2173,7 +2173,7 @@ article > a > .heading > .title:not(.punctuated):last-child::after {
 article > .heading .type:last-child::after,
 article > .heading .codenumber:last-child::after,
 article > .heading .title:not(:empty):not(.punctuated):last-child::after {
-    content: ".\2009 ";
+    content: "";
 }
 .aside-like > .heading .type:last-child::after,
 .aside-like > .heading .codenumber:last-child::after,
@@ -2194,7 +2194,7 @@ a article > .heading .codenumber:not(:empty)::after {
 }
 
 .exercise-like > .heading .codenumber:not(:empty):after {
-    content: ".\2009 ";
+    content: "\2009 ";
 }
 
 .objectives > .heading {


### PR DESCRIPTION
This cleans up three issues with the EPUB conversion. One impacts the CSS by ensuring that it no longer adds periods after codenumbers that now have them added by the XSLT. The other two impact build.sh by making it cross-platform (fixing the `sed -i` issue) and getting us closer to validating by only including images declared in the manifest (via the `images-list.txt` file that the XSLT generates).