### PR TITLE
Fix threejs splines example in sample-article update error

### DIFF
--- a/examples/sample-article/code/threejs/splines.js
+++ b/examples/sample-article/code/threejs/splines.js
@@ -275,7 +275,8 @@ function animate() {
     requestAnimationFrame( animate );
 
     render();
-    stats.update();
+    // DBW, 2019-06-20, stats window was removed, don't update
+    //stats.update();
 
 }
 


### PR DESCRIPTION
In May, the splines.js used in sample-article was edited to remove stats window. This introduced an error when the object (now gone) was asked to do an update call.

Commented this offending line out so that there is no longer an error.