### PR TITLE
Second method for Font Book

### DIFF
--- a/doc/guide/publisher/latex-styling.xml
+++ b/doc/guide/publisher/latex-styling.xml
@@ -200,7 +200,10 @@
                     <cline>fc-list</cline>
                 </cd></p>
 
-                <p>On a Mac, Mitch Keller reports on 2019-01-02 that <q>I opened the directory on my hard drive containing the <init>OTF</init> file, double clicked on the font (opens the macOS application Font Book, which comes with the OS), and then clicked the <c>Install Font</c> button.</q></p>
+                <p>On a Mac, we have several reports for how to do this.
+                    <ul><li><p>Mitch Keller reports on 2019-01-02 that <q>I opened the directory on my hard drive containing the <init>OTF</init> file, double clicked on the font (opens the macOS application Font Book, which comes with the OS), and then clicked the <c>Install Font</c> button.</q></p></li>
+                        <li><p>Karl-Dieter Crisman reports on 2019-07-01 that <q>I was able to use some fonts already existing in TeXLive with a symbolic link to the Font Book, as suggested at <url href="https://apple.stackexchange.com/a/225824/189102">Ask Different</url>: <c>ln -s /usr/local/texlive/2018/texmf-dist/fonts/opentype/public/lm/ '/Library/Fonts/Latin Modern'</c>, where 2018 indicates when I updated my TeXLive distribution.</q></p></li>
+                    </ul></p>
            </paragraphs>
 
             <paragraphs>


### PR DESCRIPTION
I'm sure you'll want to reorganize this, but I recommend inclusion of this second method, because I found it easier than messing with trying to get stuff from texlive into the Font Book using the GUI - and it kept me from the madness of downloading new versions of these fonts.