### PR TITLE
Defer equation xref to @title

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -8465,7 +8465,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
             <xsl:apply-templates select="$target/personname" />
         </xsl:when>
         <!-- equation override -->
-        <xsl:when test="$b-is-equation-target">
+        <xsl:when test="$b-is-equation-target and $text-style != 'title'">
             <xsl:if test="$b-has-content">
                 <xsl:copy-of select="$custom-text" />
                 <xsl:apply-templates select="." mode="xref-text-separator"/>


### PR DESCRIPTION
This tells the `xref-text` template to handle equation xrefs just like other xrefs when you have `@text="title"`.

Maybe there is still a need for discussion about the wisdom of not providing a number.

The other thing is, what will this do when there is no custom test? Like `<xref ref="my-equation" text="title"/>`. As this is, it will try to apply the `mode="title-xref"` to the equation target, which I think will not end happily. I have thought of two ways to handle this. One would be to give equations like this a default title like `mode="title-xref"` does for other things. The other way would be to change this edit from ` and $text-style != 'title'` to ` and not($text-style = 'title' and $b-has-content)` so it's a more obtuse condition right here, but for equations, we only reach the general `text=title` portion of the template when there actually is content.

