### PR TITLE
Remove calls to generate-id() when @sortby exists for idx or h

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1305,7 +1305,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                 <!-- salt prevents accidental key collisions -->
                                 <xsl:when test="@sortby">
                                     <xsl:value-of select="translate(@sortby, &UPPERCASE;, &LOWERCASE;)" />
-                                    <xsl:value-of select="generate-id(.)" />
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:value-of select="translate($content, &UPPERCASE;, &LOWERCASE;)" />
@@ -1332,7 +1331,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <!-- salt prevents accidental key collisions -->
                                     <xsl:when test="@sortby">
                                         <xsl:value-of select="translate(@sortby, &UPPERCASE;, &LOWERCASE;)" />
-                                        <xsl:value-of select="generate-id(.)" />
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:value-of select="translate($content, &UPPERCASE;, &LOWERCASE;)" />


### PR DESCRIPTION
It's not clear why generate-id() is being called to create the key when `@sortby` exists, and I can demonstrate that doing so creates a bug. Test on [index-bug.ptx.txt](https://github.com/rbeezer/mathbook/files/3360218/index-bug.ptx.txt), which is really a PreTeXt file but GitHub is picky about what file extensions can be used so I had to append `.txt`.

With the current `dev` version of `mathbook-html.xsl`, one gets the flawed index shown below. Notice that the subentries marked in red should be merged as should the two marked in cyan.
![Screen Shot 2019-07-04 at 12 59 04 PM](https://user-images.githubusercontent.com/8580151/60683143-dbe5e500-9e5b-11e9-8db4-770195ff53d5.png)

With the patch proposed in this PR, one gets the behavior shown in the screenshot below.
![Screen Shot 2019-07-04 at 12 57 40 PM](https://user-images.githubusercontent.com/8580151/60683145-df796c00-9e5b-11e9-9aa5-41b4106c2a3c.png)

I don't have a document with an index with many `@sortby`~s, other than the index of the version of Basics Reference part of The Guide that currently lives at `mitchkeller/mathbook:basics`. That work actually is what showed me this behavior. If you checkout that branch, look at the entry for `<example>`, which exhibits the behavior shown in the screenshot above.