### PR TITLE
Guide: Basics Reference improvements

### DIFF
--- a/doc/guide/appendices/glossary.xml
+++ b/doc/guide/appendices/glossary.xml
@@ -313,8 +313,8 @@
         </defined-term>
 
         <defined-term>
-                <idx>origin branch</idx>
-            <title>origin branch</title>
+                <idx>origin repository</idx>
+            <title>origin repository</title>
             <p>In git, the default name for the remote repository from which the local repository was cloned.</p>
         </defined-term>
 
@@ -378,7 +378,7 @@
         <defined-term>
                 <idx>pull request</idx>
             <title>pull request</title>
-            <p>In git, a suggestion that the changes to the files in one branched be merged into another branch
+            <p>In git, a suggestion that the changes to the files in one branch be merged into another branch
                (typically in another repository).</p>
         </defined-term>
 
@@ -489,8 +489,8 @@
         </defined-term>
 
         <defined-term>
-                <idx>upstream (git)</idx>
-            <title>upstream</title>
+                <idx>upstream repository (git)</idx>
+            <title>upstream repository</title>
             <p>In git, the usual name for the remote repository from which the local repository was originally forked.</p>
         </defined-term>
 

--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -240,7 +240,8 @@
     <section xml:id="overview-math-results">
         <title>Mathematical Results</title>
         <idx><h>mathematics</h><h>mathematical results</h></idx>
-
+        <idx><h>mathematics</h><h>mathematical results</h><seealso>theorem-like elements</seealso></idx>
+        
         <p>Definitions, theorems, corollaries, <etc /> are supported by the tags:  <tag>theorem</tag>, <tag>corollary</tag>, <tag>lemma</tag>, <tag>algorithm</tag>, <tag>proposition</tag>, <tag>claim</tag>, <tag>fact</tag>, <tag>definition</tag>, <tag>conjecture</tag>, <tag>axiom</tag>, and <tag>principle</tag>.  Each may have a <tag>title</tag> (strongly encouraged), and then contains a <tag>statement</tag> which is a sequence of paragraphs and other elements.  As appropriate, some of these elements (such as a <tag>lemma</tag>) may contain an optional <tag>proof</tag> (or several), while other elements may not have a <tag>proof</tag> (such as a <tag>conjecture</tag>).</p>
 
         <p>A <tag>definition</tag> is a natural place to define notation as well (see <xref ref="overview-index-notation" />), and to use the <tag>term</tag> tag to identify the terminology being defined.</p>

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -176,7 +176,7 @@
         <p>One choice of the parameter will result in just <q>copying</q> your source file and making all the cosmetic source format changes (we refer to this here as <term>normalization</term><idx>normalization</idx>).  This might be a useful thing to do first, all by itself, either as a first step, or an exploratory experiment.  The other value of the parameter will actually make changes, and report some information about progress.</p>
 
         <p>Here are some notes:<ul>
-            <li><p>Be sure to experiment on copies of your source in a scratch directory.  Send your output to another directory.  When finished, use a <c>diff</c> tool to inspect the actual changes made.  You can record your eventual changes using revision-control (<xref ref="git" />).</p></li>
+            <li><p>Be sure to experiment on copies of your source in a scratch directory.  Send your output to another directory.  When finished, use a <c>diff</c> tool to inspect the actual changes made.  You can record your eventual changes using revision-control. (See <pubtitle><url ref="https://pretextbook.org/gfa/html/">Git for Authors</url></pubtitle>.)</p></li>
             <li><p>Do not enable <c>xinclude</c> processing or else your several files will all be merged into one as output and any modularity of your source will be lost.</p></li>
             <li><p>Every single bit of indentation and whitespace in your source will be preserved, except perhaps for some blank lines near the top of your source files, and limited exceptions noted below.</p></li>
             <li><p>Attributes will likely be re-ordered, with normalized spacing between them.</p></li>
@@ -227,7 +227,7 @@
             </console>
         </sidebyside>
 
-        <p>And as above, you can now compare the <c>normal</c> and <c>clean</c> directories to see actual changes.  If you are satisfied with the changes, you can copy the files in the <c>clean</c> directory back onto your source files.  If you are using revision-control (you are, aren't you?) then you can make a commit that holds these changes (<xref ref="git" />).  Or maybe even make two commits, one from the normalization step, and a second with the substantive changes.</p>
+        <p>And as above, you can now compare the <c>normal</c> and <c>clean</c> directories to see actual changes.  If you are satisfied with the changes, you can copy the files in the <c>clean</c> directory back onto your source files.  If you are using revision-control (you are, aren't you?) then you can make a commit that holds these changes. (See <pubtitle><url ref="https://pretextbook.org/gfa/html/">Git for Authors</url></pubtitle>.) Or maybe even make two commits, one from the normalization step, and a second with the substantive changes.</p>
     </section>
 
     <section xml:id="processing-file-management">

--- a/doc/guide/basics/README.md
+++ b/doc/guide/basics/README.md
@@ -1,0 +1,27 @@
+# Contributing to the *Basics Reference* portion of The PreTeXt Guide
+
+## `xml:id` usage
+
+* Add `xml:id`s to all divisions and listings (at a minimum).
+* Within the *Basics Reference*, please ensure that your `xml:id`s begin with "basics".
+* Within the *Basics Reference*, use `ch` for chapter, `s` for section, `ss` for subsection, `l` for listing, and `fig` for figure when constructing `xml:id`s.
+* An `xref` to another portion of the *Basics Reference* can be done via something like `<xref ref="basics-ch-exercises"/>`.
+
+## Cross references to other parts of The Guide
+
+* To help readers develop an understanding for the delineation between the parts of the guide, state which part you are making a reference to. For instance, `The <pubtitle>Author's Guide</pubtitle>  (<xref ref="topic-cross-referencing"/>)
+goes into greater detail` is the preferred style of making an `xref` out of the *Basics Reference*.
+* We encourage contributors to add lots of cross references. The *Basics Reference* is not meant to be the ultimate guide to every feature of PreTeXt.
+
+## Code snippets
+
+* Unless demonstrating something such as inline math or a cross reference that must live within a `p`, you are expected to put your code snippet in a separate file with extension `.ptx`.
+* Follow the model done in existing sections to use `xi:include` twice, once with `@parse="text"` (always within a listing) and once without setting `@parse`. This allows the reader to see how the code is rendered by the PreTeXt converters.
+
+## Index entries
+
+* The initial indexing of the *Basics Reference* is being done by Matt Boelkins, Mitch Keller, and Oscar Levin based on extensive conversations with a larger group at the Portland workshop in 2019. **Please do not add additional `idx` tags to existing portions of the *Basics Reference* while this bullet remains in the `README.md` file.**
+* Code snippets contained in `listing` are required to have at least two index entries. One should have main heading `<pretext/> code for` and subheading that identifies what it is the PreTeXt code for. The second must have the appropriate main heading to identify what the sampmle code for and subheading `<pretext/> code for`.
+* Use `see` and `seealso` liberally in your indexing. Try to think of any other (nontechnical) terms someone might use to look up an idea and put the appropriate `see` entry in the index. For instance, we have "problem" as an index heading with with "as homework" as the subheading. This points the reader to see exercise.
+* When referring to a PreTeXt tag or attribute in the index, use `<tag>` or `<attr>` as appropriate. Also ensure that you use `@sortby` in these cases, as otherwise the index isn't sorted correctly. For instance, you might use something like `<idx sortby="example"><tag>example</tag></idx>` to create a top-level index entry for the PreTeXt example tag.
+* The various "-like" elements need to be indexed carefully. The main index entry needs to follow the lead of example-like elements, which is presented (in output) as "example-like elements (<example>, <problem>, <question>)". When using `<see>` or `<seealso>` to point to a "-like" category, use only the portion that does not list the tags (e.g., `<see>example-like elements</see>`. For the top-level `<pretext/> code for` index entry, the subheading for a "-like" element should be comprehensive: `<idx><h sortby="pretext code for"><pretext/> code for</h><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h></idx>`. This allows a user of the index to scan and realize that if they want to create a `<question>` element, then they can copy the listing given for the example-like elements and change `example` to `question`.

--- a/doc/guide/basics/aside.ptx
+++ b/doc/guide/basics/aside.ptx
@@ -1,8 +1,16 @@
+
 <aside>
-    <title>A Sample Aside</title>
-    <p>Here is some text inside a sample aside. I'm going
-    to put the Pythagorean identity below:
-    <me>\sin^2(x) + \cos^2(x) = 1</me>.</p>
-    <p>This aside has two paragraphs. You can't do
-    that with a footnote.</p>
+  <title>A Sample Aside</title>
+  <p>
+    Here is some text inside a sample aside.
+    I'm going to put the Pythagorean identity below:
+    <me>
+      \sin^2(x) + \cos^2(x) = 1
+    </me>.
+  </p>
+
+  <p>
+    This aside has two paragraphs.
+    You can't do that with a footnote.
+  </p>
 </aside>

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -195,8 +195,8 @@
     <p>
       For inline math,
       just wrap things in the <tag>m</tag> tag.
-          <idx><h>equation</h><h>in-line</h><h><pretext /> code</h></idx>
-          <idx><h><pretext /> code</h><h>in-line equation</h></idx>
+          <idx><h>equation</h><h>in-line</h><h><pretext /> code for</h></idx>
+          <idx><h><pretext /> code for</h><h>in-line equation</h></idx>
       For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <tag>me</tag> and <tag>men</tag> tags; the latter produces a numbered equation.
           <idx><h>mathematics</h><h>environments</h><h>displayed equation</h></idx>
           <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
@@ -204,8 +204,8 @@
 
     <listing xml:id="l-me">
       <caption>Displayed equations</caption>
-      <idx><h><pretext /> code</h><h>displayed equation</h></idx>
-      <idx><h>equation</h><h>displayed</h><h><pretext /> code</h></idx>
+      <idx><h><pretext /> code for</h><h>displayed equation</h></idx>
+      <idx><h>equation</h><h>displayed</h><h><pretext /> code for</h></idx>
 <program>
 <input><xi:include href="me.ptx" parse="text"/></input>
 </program>
@@ -224,8 +224,8 @@
 
     <listing xml:id="l-md">
       <caption>Aligned equations</caption>
-      <idx><h><pretext /> code</h><h>aligned equations</h></idx>
-      <idx><h>equation</h><h>aligned</h><h><pretext /> code</h></idx>
+      <idx><h><pretext /> code for</h><h>aligned equations</h></idx>
+      <idx><h>equation</h><h>aligned</h><h><pretext /> code for</h></idx>
 <program>
 <input><xi:include href="md.ptx" parse="text"/></input>
 </program>
@@ -275,9 +275,9 @@
 
     <listing xml:id="l-ol">
       <caption>An ordered list</caption>
-      <idx><h>list</h><h>ordered</h><h><pretext /> code</h></idx>
-      <idx><h>ordered list</h><h><pretext /> code</h></idx>
-      <idx><h><pretext /> code</h><h>ordered list</h></idx>
+      <idx><h>list</h><h>ordered</h><h><pretext /> code for</h></idx>
+      <idx><h>ordered list</h><h><pretext /> code for</h></idx>
+      <idx><h><pretext /> code for</h><h>ordered list</h></idx>
 <program>
 <input><xi:include href="ol.ptx" parse="text"/></input>
 </program>
@@ -303,9 +303,9 @@
 
     <listing xml:id="l-ul">
       <caption>An unordered list</caption>
-      <idx><h>list</h><h>unordered</h><h><pretext /> code</h></idx>
-      <idx><h>unordered list</h><h><pretext /> code</h></idx>
-      <idx><h><pretext /> code</h><h>unordered list</h></idx>
+      <idx><h>list</h><h>unordered</h><h><pretext /> code for</h></idx>
+      <idx><h>unordered list</h><h><pretext /> code for</h></idx>
+      <idx><h><pretext /> code for</h><h>unordered list</h></idx>
 <program>
 <input><xi:include href="ul.ptx" parse="text"/></input>
 </program>
@@ -552,9 +552,9 @@
 
       <listing xml:id="l-exercise">
         <caption>An exercise</caption>
-        <idx><h>exercise</h><h><pretext /> code</h></idx>
-        <idx><h>inline exercise</h><h><pretext /> code</h></idx>
-        <idx><h><pretext /> code</h><h>exercise</h><h>inline</h></idx>
+        <idx><h>exercise</h><h><pretext /> code for</h></idx>
+        <idx><h>inline exercise</h><h><pretext /> code for</h></idx>
+        <idx><h><pretext /> code for</h><h>exercise</h><h>inline</h></idx>
 <program>
 <input><xi:include href="exercise.ptx" parse="text"/></input>
 </program>
@@ -600,8 +600,8 @@
 
       <listing xml:id="l-exercisegroup">
         <caption>Using an <tag>exercisegroup</tag>.</caption>
-        <idx><h>exercise group</h><h><pretext /> code</h></idx>
-        <idx><h><pretext /> code</h><h>exercise</h><h>group</h></idx>
+        <idx><h>exercise group</h><h><pretext /> code for</h></idx>
+        <idx><h><pretext /> code for</h><h>exercise</h><h>group</h></idx>
 <program>
 <input><xi:include href="exercisegroup.ptx" parse="text"/></input>
 </program>

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -27,6 +27,9 @@
           When you need a more advanced feature not discussed here,
           follow the link to the appropriate portion of the <pubtitle>Author's Guide</pubtitle>
           (<xref ref="part-author"/>).
+          We welcome contributions of intermediate examples to this
+          <pubtitle>Basics Reference</pubtitle>,
+          but the initial goal is not to be comprehensive in adding such examples.
         </li>
 
         <li>
@@ -95,8 +98,8 @@
   <chapter xml:id="ch-divisions">
     <title>Document Structure</title>
     <p>
-      Rob Beezer refers to elements such as <c>chapter</c>, <c>section</c>,
-      and <c>subsection</c> as <term>divisions</term>.
+      Rob Beezer refers to elements such as <tag>chapter</tag>, <tag>section</tag>,
+      and <tag>subsection</tag> as <term>divisions</term>.
           <idx>division</idx>
           <idx>document structure</idx> 
           <idx>section</idx>
@@ -119,19 +122,19 @@
       If a division has other divisions inside it,
       then the structure is a bit more complicated and regimented.
       In particular,
-      if you want text before your first subdivision (<c>subsection</c> in this example),
-      that text must go inside <c>introduction</c>.
+      if you want text before your first subdivision (<tag>subsection</tag> in this example),
+      that text must go inside <tag>introduction</tag>.
           <idx><h>introduction</h><h>of chapter, section, etc.</h></idx>
-      If you want to start with the <c>subsection</c>,
-      then the <c>introduction</c> is optional.
+      If you want to start with the <tag>subsection</tag>,
+      then the <tag>introduction</tag> is optional.
       In the <q>division with subdivisions</q> model,
-      everything <em>must</em> be contained inside <c>introduction</c>, <c>subsection</c> (or whatever your subdivision type is), <c>exercises</c>, <c>references</c>,
-      or <c>conclusion</c>.
+      everything <em>must</em> be contained inside <tag>introduction</tag>, <tag>subsection</tag> (or whatever your subdivision type is), <tag>exercises</tag>, <tag>references</tag>,
+      or <tag>conclusion</tag>.
       This is illustrated in <xref ref="l-section-sub" />.
     </p>
 
     <listing xml:id="l-section-sub">
-      <caption>A <c>section</c> with <c>subsection</c>s.</caption>
+      <caption>A <tag>section</tag> with <tag>subsection</tag>s.</caption>
 
 <program><input><xi:include href="section-sub.ptx" parse="text"/></input> </program>
     </listing>
@@ -145,22 +148,22 @@
         allowed in introductions.
         In general, avoid things that would have numbers.
         For instance,
-        one should not put an <c>example</c> or an <c>exercise</c> in an introduction.
+        one should not put an <tag>example</tag> or an <tag>exercise</tag> in an introduction.
         Once the schema is correct, this text should be updated.
       </p>
     </paragraphs>
 
     <paragraphs>
-      <title>The role of <c>p</c> tags</title>
+      <title>The role of <tag>p</tag> tags</title>
       <idx>paragraph</idx>
-      <idx><c>p</c> tag</idx>
+      <idx><tag>p</tag> tag</idx>
 
       <p>
-        One of the things you'll need to keep an eye out for is when things must be wrapped in <c>p</c> (paragraph) tags.
-        Notice that <c>title</c> tags do not have their content wrapped in <c>p</c>,
+        One of the things you'll need to keep an eye out for is when things must be wrapped in <tag>p</tag> (paragraph) tags.
+        Notice that <tag>title</tag> tags do not have their content wrapped in <tag>p</tag>,
         which places some limits on the sorts of things that can be contained in a title.
         If you find text disappearing or displaying strangely,
-        the culprit is likely an unnecessary or or missing <c>p</c> tag.
+        the culprit is likely an unnecessary or or missing <tag>p</tag> tag.
         See the part of the documentation on validating your source for information on how to use some additional tools to see if your <pretext /> file is valid in terms of following the structural rules in the schema.
       </p>
     </paragraphs>
@@ -191,10 +194,10 @@
 
     <p>
       For inline math,
-      just wrap things in the <c>m</c> tag.
+      just wrap things in the <tag>m</tag> tag.
           <idx><h>equation</h><h>in-line</h><h><pretext /> code</h></idx>
           <idx><h><pretext /> code</h><h>in-line equation</h></idx>
-      For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <c>me</c> and <c>men</c> tags; the latter produces a numbered equation.
+      For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <tag>me</tag> and <tag>men</tag> tags; the latter produces a numbered equation.
           <idx><h>mathematics</h><h>environments</h><h>displayed equation</h></idx>
           <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
     </p>
@@ -216,7 +219,7 @@
 
     <p>
       For a collection of equations all aligned at a designated point,
-      use <c>md</c> and <c>mrow</c>. (There's also <c>mdn</c> for numbered equations.) <idx><h>mathematics</h><h>environments</h><h>aligned equation</h></idx>
+      use <tag>md</tag> and <tag>mrow</tag>. (There's also <tag>mdn</tag> for numbered equations.) <idx><h>mathematics</h><h>environments</h><h>aligned equation</h></idx>
     </p>
 
     <listing xml:id="l-md">
@@ -254,10 +257,10 @@
       There are a variety of places that lists can live,
       but a good mental model is that a list must be put inside an environment
       (or tag)
-      that's similar to <c>p</c>.
+      that's similar to <tag>p</tag>.
       So for example,
-      you can't put your list directly inside a <c>subsection</c>,
-      but instead must wrap the list in a <c>p</c>.
+      you can't put your list directly inside a <tag>subsection</tag>,
+      but instead must wrap the list in a <tag>p</tag>.
     </p>
 
     <p>
@@ -265,9 +268,9 @@
       ordered and unordered.
           <idx><h>list</h><h>ordered</h></idx>
           <idx><h>ordered list</h></idx> (There's also the description list.
-      See the documentation for more information on it.) As in <init>HTML</init>,
-      an ordered list is produced with <c>ol</c> and an unordered list with <c>ul</c>.
-      The items of your list are structured inside <c>li</c> tags.
+      See the <pubtitle>Author's Guide</pubtitle> at <xref ref="topic-lists" /> for more information on it.) As in <init>HTML</init>,
+      an ordered list is produced with <tag>ol</tag> and an unordered list with <tag>ul</tag>.
+      The items of your list are structured inside <tag>li</tag> tags.
     </p>
 
     <listing xml:id="l-ol">
@@ -287,10 +290,10 @@
     <xi:include href="ol.ptx" />
 
     <p>
-      You can use the <c>@label</c> attribute on the <c>ol</c> tag to change the default labeling.
+      You can use the <attr>label</attr> attribute on the <tag>ol</tag> tag to change the default labeling.
       For instance,
-      if the opening tag for the list above were <c>&lt;ol label="A"&gt;</c>,
-      then the list items would be labeled as A. and B. Sensible things to use with <c>@label</c> are i, I, A, a, and 1.
+      if the opening tag for the list above were <tag>ol label="A"</tag>,
+      then the list items would be labeled as A. and B. Sensible things to use with <attr>label</attr> are i, I, A, a, and 1.
       Nesting of lists is possible,
       and there are sensible default labels.
           <idx><h>list</h><h>numbering</h></idx>
@@ -319,7 +322,7 @@
     <xi:include href="ul.ptx" />
 
     <p>
-      You can also use the <c>@cols</c> attribute to split a list
+      You can also use the <attr>cols</attr> attribute to split a list
       (ordered or unordered)
       across multiple columns if the screen/page is suitably wide.
           <idx><h>list</h><h>displayed in columns</h></idx>
@@ -333,9 +336,9 @@
     <idx>theorem-like elements</idx>
 
     <p>
-      The tags <c>theorem</c>, <c>algorithm</c>, <c>claim</c>, <c>corollary</c>, <c>fact</c>, <c>identity</c>, <c>lemma</c>,
-      and <c>proposition</c> have the same structure in <pretext />,
-      so we will just illustrate <c>theorem</c> here.
+      The tags <tag>theorem</tag>, <tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>,
+      and <tag>proposition</tag> have the same structure in <pretext />,
+      so we will just illustrate <tag>theorem</tag> here.
           <idx>theorem</idx>
           <idx><h>algorithm</h><see>theorem</see></idx> 
           <idx><h>claim</h><see>theorem</see></idx>
@@ -362,20 +365,20 @@
     <xi:include href="theorem.ptx" />
 
     <p>
-      The <c>title</c> is optional and typically used for theorems with names or to which you wish to give an attribution.
+      The <tag>title</tag> is optional and typically used for theorems with names or to which you wish to give an attribution.
           <idx><h>theorem</h><h>title</h></idx>
           <idx><h>title</h><h>of a theorem-like element</h></idx>
       Cross references (see <xref ref="s-xref" /> can be made using the name or the number, depending on how the author codes them.
     </p>
 
     <p>
-      You can use <c>definition</c> essentially like <c>theorem</c>,
-      but a <c>definition</c> cannot have a proof.
+      You can use <tag>definition</tag> essentially like <tag>theorem</tag>,
+      but a <tag>definition</tag> cannot have a proof.
           <idx>definition</idx>
-      You are encouraged to use the <c>term</c> tag to set off the word being defined.
+      You are encouraged to use the <tag>term</tag> tag to set off the word being defined.
           <idx>term (in a definition)</idx>
       If you wish to include a list of notation to an appendix as your document,
-      you might also add a <c>notation</c> tag such as shown in <xref ref="l-definition" />.
+      you might also add a <tag>notation</tag> tag such as shown in <xref ref="l-definition" />.
           <idx>notation (to be included in a notation list)</idx>
     </p>
 
@@ -403,15 +406,15 @@
 
     <p>
       <pretext /> provides three closely-related tags for things that are examples or similar.
-      They are <c>example</c>, <c>problem</c>,
-      and <c>question</c>.
+      They are <tag>example</tag>, <tag>problem</tag>,
+      and <tag>question</tag>.
       They all have the same syntax.
-      The <c>title</c> element is optional.
+      The <tag>title</tag> element is optional.
           <idx><h>example</h><h>title</h></idx>
           <idx><h>title</h><h>of example</h></idx>
       You may either use a freeform example, as shown in <xref ref="l-example-simple" />,
           <idx><h>example</h><h>unstructured</h></idx>
-      or an example structured with a <c>statement</c> and zero or more <c>hint</c>s, <c>answer</c>s, and <c>solution</c>s
+      or an example structured with a <tag>statement</tag> and zero or more <tag>hint</tag>s, <tag>answer</tag>s, and <tag>solution</tag>s
       (in that order).
           <idx><h>example</h><h>hint</h></idx>
           <idx><h>example</h><h>answer</h></idx> 
@@ -422,7 +425,7 @@
       This is illustrated in <xref ref="l-example-structured" />.
           <idx><h>example</h><h>structured</h></idx>
       Note that for <init>HTML</init> output,
-      if your <c>example</c> has a <c>solution</c>,
+      if your <tag>example</tag> has a <tag>solution</tag>,
       the solution will be hidden in a knowl,
       and the publisher does not
       (as of June 2019)
@@ -467,13 +470,13 @@
     <p>
       <pretext /> provides several simple tags that fall into the general category of a <q>remark</q>
       that one would like to be numbered.
-      They are <c>convention</c>, <c>insight</c>, <c>note</c>, <c>observation</c>, <c>remark</c>,
-      and <c>warning</c>.
+      They are <tag>convention</tag>, <tag>insight</tag>, <tag>note</tag>, <tag>observation</tag>, <tag>remark</tag>,
+      and <tag>warning</tag>.
       The content of these tags is very simple.
       They allow an optional title,
-      optional <c>idx</c> tags,
-      and then a mixture of <c>p</c>, <c>blockquote</c>,
-      and <c>pre</c>.
+      optional <tag>idx</tag> tags,
+      and then a mixture of <tag>p</tag>, <tag>blockquote</tag>,
+      and <tag>pre</tag>.
           <idx>remark</idx>
           <idx><h>convention</h><see>remark</see></idx>
           <idx><h>insight</h><see>remark</see></idx> 
@@ -504,11 +507,11 @@
 
     <p>
       There are four tags that <pretext /> considers to be <q>project-like</q>.
-      They are <c>activity</c>, <c>exploration</c>, <c>investigation</c>, <c>project</c>.
+      They are <tag>activity</tag>, <tag>exploration</tag>, <tag>investigation</tag>, <tag>project</tag>.
           <idx>project</idx>
           <idx><h>activity</h><see>project</see></idx>
           <idx><h>exploration</h><see>project</see></idx>
-          <idx><h>investigation</h><see>project</see></idx> 			They allow a general, freeform structure similar to the unstructured <c>example</c> in <xref ref="l-example-simple" />; a structure analogous to that of the structured <c>example</c> in <xref ref="l-example-structured" />; and the highly-stuctured <c>introduction</c>, <c>task</c>, <c>conclusion</c> model shown in <xref ref="l-project" />.
+          <idx><h>investigation</h><see>project</see></idx> 			They allow a general, freeform structure similar to the unstructured <tag>example</tag> in <xref ref="l-example-simple" />; a structure analogous to that of the structured <tag>example</tag> in <xref ref="l-example-structured" />; and the highly-stuctured <tag>introduction</tag>, <tag>task</tag>, <tag>conclusion</tag> model shown in <xref ref="l-project" />.
           <idx><h>example</h><h>comparison to project-like elements</h></idx>
     </p>
 
@@ -537,12 +540,12 @@
       <idx><h>inline exercise</h></idx>
 
       <p>
-        You can put an <c>exercise</c> in the middle of a division,
+        You can put an <tag>exercise</tag> in the middle of a division,
         intermixed between theorems and paragraphs and figures.
         In this case, it is labeled as a <q>Checkpoint</q>.<fn>
         See <xref ref="ch-rename" /> for information on how to use something different than
         <q>Checkpoint</q> as the name for these.
-        </fn> You can also put a bunch of <c>exercise</c>s inside an <c>exercises</c> tag within a division,
+        </fn> You can also put a bunch of <tag>exercise</tag>s inside an <tag>exercises</tag> tag within a division,
         which is the typical way for creating a bunch of exercises togther at the end of a section.
             <idx><h>checkpoint</h><see>inline exercise</see></idx>
       </p>
@@ -564,16 +567,16 @@
       <xi:include href="exercise.ptx" />
 
       <p>
-        Note that you can have multiple <c>hint</c>, <c>answer</c>,
-        and <c>solution</c> elements.
+        Note that you can have multiple <tag>hint</tag>, <tag>answer</tag>,
+        and <tag>solution</tag> elements.
             <idx><h>hint</h><h>to exercise</h></idx>
             <idx><h>answer</h><h>to exercise</h></idx>
             <idx><h>solution</h><h>to exercise</h></idx> 
             <idx><h>exercise</h><h>hint</h></idx>
             <idx><h>exercise</h><h>answer</h></idx> 
             <idx><h>exercise</h><h>solution</h></idx>
-        But you must put all the <c>hint</c>s first,
-        then all the <c>answer</c>s, and then all the <c>solution</c>s.
+        But you must put all the <tag>hint</tag>s first,
+        then all the <tag>answer</tag>s, and then all the <tag>solution</tag>s.
         There are a variety of options for determining where hints,
         answers, and solutions appear
         (at all).
@@ -582,21 +585,21 @@
     </section>
 
     <section xml:id="s-exgp">
-      <title><c>exercisegroup</c></title>
+      <title><tag>exercisegroup</tag></title>
       <idx>exercise group</idx>
 
       <p>
         Sometimes you have several exercises that should all have a common set of instructions,
-        which is when you will use the <c>exercisegroup</c> tag.
+        which is when you will use the <tag>exercisegroup</tag> tag.
             <idx><h>exercise group</h><h>instructions</h></idx>
-        An <c>exercisegroup</c> can only be placed inside an <c>exercises</c> element, however!
+        An <tag>exercisegroup</tag> can only be placed inside an <tag>exercises</tag> element, however!
         The portion of this section headed as
         <q><xref ref="ch-sample-exercises" text="global" /> Exercises</q>
         is produced using the code in <xref ref="l-exercisegroup" />.
       </p>
 
       <listing xml:id="l-exercisegroup">
-        <caption>Using an <c>exercisegroup</c>.</caption>
+        <caption>Using an <tag>exercisegroup</tag>.</caption>
         <idx><h>exercise group</h><h><pretext /> code</h></idx>
         <idx><h><pretext /> code</h><h>exercise</h><h>group</h></idx>
 <program>
@@ -605,16 +608,16 @@
       </listing>
 
       <p>
-        If you want the contents of an <c>exercisegroup</c> to be put in multiple columns,
-        you can add a <c>@cols</c> attribute to the <c>exercisegroup</c> of the form <c>cols="3"</c>.
-        The integer value of <c>@cols</c> must be between 2 and 6
+        If you want the contents of an <tag>exercisegroup</tag> to be put in multiple columns,
+        you can add a <attr>cols</attr> attribute to the <tag>exercisegroup</tag> of the form <attr>cols="3"</attr>.
+        The integer value of <attr>cols</attr> must be between 2 and 6
         (inclusive).
             <idx><h>exercise group</h><h>columns</h></idx>
             <idx><h>column</h><h>of an exercise group</h></idx>
       </p>
 
       <p>
-        An <c>exercisegroup</c> generates exercises in a separate section or subsection.
+        An <tag>exercisegroup</tag> generates exercises in a separate section or subsection.
         The code in <xref ref="l-exercisegroup">Listing</xref>
         produces the output seen in <xref ref="ch-sample-exercises">Exercises</xref>.
       </p>
@@ -628,22 +631,22 @@
     <p>
       The preceding sections have provided a lengthy list of <pretext /> tags that behave interchangeably.
       Perhaps you don't like one of their names.
-      If your project will not involve any <c>algorithm</c>s, but you need another theorem-like tag whose name you would like to have rendered as <q>Porism</q>.
-      To do this, you need to add a <c>rename</c> tag to the <c>docinfo</c> block of your code.
+      If your project will not involve any <tag>algorithm</tag>s, but you need another theorem-like tag whose name you would like to have rendered as <q>Porism</q>.
+      To do this, you need to add a <tag>rename</tag> tag to the <tag>docinfo</tag> block of your code.
       For our example,
       the necessary code would be <c>&lt;rename element="algorithm"&gt;Porism&lt;/rename&gt;</c>.
-      The <c>rename</c> tag generates a <em>global</em> change;
+      The <tag>rename</tag> tag generates a <em>global</em> change;
       it is not possible to rename a single instance of a tag or to define your own tags (without writings your own <init>XSLT</init> code.
     </p>
 
     <p>
-      We have included this <c>rename</c> code in this project's <c>docinfo</c>,
+      We have included this <tag>rename</tag> code in this project's <tag>docinfo</tag>,
       and as such,
       we can do the following.
     </p>
 
     <listing xml:id="l-porism">
-      <caption>A porism generated using <c>algorithm</c> and <c>rename</c></caption>
+      <caption>A porism generated using <tag>algorithm</tag> and <tag>rename</tag></caption>
 
 <program>
 <input><xi:include href="porism.ptx" parse="text"/></input>
@@ -721,7 +724,7 @@
   <chapter xml:id="ch-fig">
     <title>Figures and Friends</title>
     <section xml:id="s-fig">
-      <title><c>figure</c></title>
+      <title><tag>figure</tag></title>
       <p>
         The gold standard for graphics to include in <pretext /> documents is, well,
         complicated.
@@ -766,7 +769,7 @@
     </section>
 
     <section xml:id="s-sidebyside">
-      <title><c>sidebyside</c></title>
+      <title><tag>sidebyside</tag></title>
       <p>
         One of the more complex pieces of code in <pretext />,
         by most accounts, is that used for positioning objects
@@ -779,10 +782,10 @@
 
       <p>
         We include two examples here.
-        The first places the <c>sidebyside</c> directly in the current division and places a <c>figure</c> with a caption inside the <c>sidebyside</c>.
-        The second puts the <c>sidebyside</c> inside <c>figure</c> and then uses an <c>image</c> not contained in a <c>figure</c> to include the graphic.
+        The first places the <tag>sidebyside</tag> directly in the current division and places a <tag>figure</tag> with a caption inside the <tag>sidebyside</tag>.
+        The second puts the <tag>sidebyside</tag> inside <tag>figure</tag> and then uses an <tag>image</tag> not contained in a <tag>figure</tag> to include the graphic.
         It's possible to do all sorts of nesting and get nice subnumbering automatically.
-        The sample article demonstrates all the capabilities of <c>sidebyside</c>.
+        The sample article demonstrates all the capabilities of <tag>sidebyside</tag>.
       </p>
 
       <listing xml:id="l-sbs">
@@ -800,7 +803,7 @@
       <xi:include href="sidebyside.ptx" />
 
       <listing xml:id="l-sbs2">
-        <caption>A few more bells and whistles for <c>sidebyside</c></caption>
+        <caption>A few more bells and whistles for <tag>sidebyside</tag></caption>
 
 <program>
 <input><xi:include href="sidebyside2.ptx" parse="text"/></input>
@@ -814,17 +817,17 @@
       <xi:include href="sidebyside2.ptx" />
 
       <p>
-        Another use for <c>sidebyside</c> occurs when you want to center a graphc or tabular environment
+        Another use for <tag>sidebyside</tag> occurs when you want to center a graphc or tabular environment
         (or a number of other things)
-        on a line by itself but without a <c>caption</c> and number.
+        on a line by itself but without a <tag>caption</tag> and number.
       </p>
 
       <p>
-        It is also possible to create a group of <c>sidebyside</c> tags with common <c>@widths</c> by using the <c>sbsgroup</c> tag.
+        It is also possible to create a group of <tag>sidebyside</tag> tags with common <attr>widths</attr> by using the <tag>sbsgroup</tag> tag.
       </p>
 
       <listing xml:id="l-sbsgroup">
-        <caption>Use of <c>sbsgroup</c></caption>
+        <caption>Use of <tag>sbsgroup</tag></caption>
 
 <program>
 <input><xi:include href="sbsgroup.ptx" parse="text"/></input>
@@ -873,7 +876,7 @@
           which can sometimes be the source of configuration headaches for Windows users)
           to make graphics from TikZ
           (or similar)
-          code to include in your <c>HTML</c> pages. <c>pdf2svg</c> is also a piece of the toolchain that may need to be installed separately,
+          code to include in your <init>HTML</init> pages. <c>pdf2svg</c> is also a piece of the toolchain that may need to be installed separately,
           including on macOS. To generate graphics using SageMath,
           you'll need a working installation of it with a proper configuration of its path in the <c>mbx.cfg</c> file.
           Linux and CoCalc can probably get away without extra configuration here,
@@ -894,12 +897,12 @@
 </pre>
 
       <p>
-        in the <c>docinfo</c> tag of your main file. <c>latex-image-preamble</c> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext /> source.
-        Macros that you wish to use more broadly should be put inside <c>macros</c> inside <c>docinfo</c>.
+        in the <tag>docinfo</tag> tag of your main file. <tag>latex-image-preamble</tag> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext /> source.
+        Macros that you wish to use more broadly should be put inside <tag>macros</tag> inside <tag>docinfo</tag>.
       </p>
 
       <listing xml:id="l-tikz">
-        <caption>How to use <c>latex-image</c> to invoke TikZ</caption>
+        <caption>How to use <tag>latex-image</tag> to invoke TikZ</caption>
 
 <program>
 <input><xi:include href="tikz.ptx" parse="text"/></input>
@@ -942,9 +945,9 @@
     <idx>tables</idx>
 
     <p>
-      After <c>sidebyside</c>,
+      After <tag>sidebyside</tag>,
       getting tables to lay out consistently between <init>HTML</init> and <init>PDF</init> is probably the second biggest headache that <pretext /> takes care of for us behind the scenes.
-      Lots of effort has been taken in order to fix some of the challenges inherent to working with the <c>tabular</c> environment in <latex />, and so if you author in <pretext />,
+      Lots of effort has been taken in order to fix some of the challenges inherent to working with the <tag>tabular</tag> environment in <latex />, and so if you author in <pretext />,
       you should be able to forget the hacks you had to learn to make nice tables in <latex />.
     </p>
 
@@ -952,12 +955,12 @@
           <idx><h>table</h><h>not for visual layout</h></idx>
           <idx><h>table</h><h>not for visual layout</h><seealso>side-by-side group</seealso></idx><alert>Tables should only be used to display data.</alert> Too often in other authoring systems, tables are used as a crutch to facilitate the visual layout of a page.
       Do <em>not</em> do that when authoring <pretext />.
-      A good question to ask yourself before using a <c>tabular</c> is
+      A good question to ask yourself before using a <tag>tabular</tag> is
       <q>Do the <m>xy</m>-coordinates of a cell have semantic meaning in terms of my data?</q>
       If the answer is <q>yes</q>,
-      then make a table with <c>tabular</c>.
+      then make a table with <tag>tabular</tag>.
       If not, find a more suitable tag.
-      (Perhaps <c>sidebyside</c> and/or <c>sbsgroup</c>.)
+      (Perhaps <tag>sidebyside</tag> and/or <tag>sbsgroup</tag>.)
       One of the many reasons for this is that screen readers used by individuals with visual impairments read tables in a very specific way that assumes the <m>xy</m>-coordinates of each cell are contributing to the meaning.
       Individuals who use screen readers will find a document that uses tables to do something other than present tabular data very confusing and frustrating.
     </p>
@@ -995,8 +998,8 @@
     <section xml:id="s-sage-cell">
       <title>SageMathCells</title>
       <p>
-        Including computational SageMath cells is pretty easy with <c>sage</c>, <c>input</c>,
-        and <c>output</c>.
+        Including computational SageMath cells is pretty easy with <tag>sage</tag>, <tag>input</tag>,
+        and <tag>output</tag>.
         The last tag is useful for producing a <init>PDF</init> that includes the result of the code's execution.
       </p>
 
@@ -1020,19 +1023,19 @@
     </section>
 
     <section xml:id="s-sageplot">
-      <title><c>sageplot</c></title>
+      <title><tag>sageplot</tag></title>
       <p>
         Sometimes you don't want to provide an interactive SageMath environment in the middle of your book
         (or a chunk of code)
         but you would like to produce a figure to include in your project by using SageMath.
         The cleanest way to do this his to put the SageMath code right in your <pretext /> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats.
-        This is accomplished by using <c>sageplot</c> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig" />.
+        This is accomplished by using <tag>sageplot</tag> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig" />.
         (In particular,
         see the aside in that subsection about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
       </p>
 
       <listing xml:id="l-sageplot">
-        <caption><c>sageplot</c> to produce a graphic</caption>
+        <caption><tag>sageplot</tag> to produce a graphic</caption>
 
 <program>
 <input><xi:include href="sageplot.ptx" parse="text"/></input>
@@ -1085,19 +1088,19 @@
       <p>
         <pretext /> provides a robust set of features for internal cross referencing.
         If you're familiar with <latex />,
-        the equivalent of <c>\label</c> is to use an <c>xml:id</c>.
+        the equivalent of <c>\label</c> is to use an <attr>xml:id</attr>.
         For example,
-        the opening tag for this subsection is <c>&lt;subsection xml:id="s-xref"&gt;</c>.
+        the opening tag for this subsection is <tag>subsection xml:id="s-xref"</tag>.
         Instead of the <c>\ref</c> used by <latex />,
-        we use <c>xref</c> in <pretext />.
-        So we can type <c>&lt;xref ref="s-xref" /&gt;</c> to create a reference to this subsection:
+        we use <tag>xref</tag> in <pretext />.
+        So we can type <tage>xref ref="s-xref"</tage> to create a reference to this subsection:
         <xref ref="s-xref" />.
-        There are lots of options to control what text and number appear when you use <c>xref</c>.
-        The default is the <c>type-gobal</c> option,
+        There are lots of options to control what text and number appear when you use <tag>xref</tag>.
+        The default is <attr>text="type-gobal"</attr>,
         which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>.
         The type is <q>Subsection</q> or <q>Theorem</q>,
         and the <em>global</em> number is 3.3 or 3.1.4. (Global is in contrast to local,
-        which would be just 3 or 4, reespectively,
+        which would be just 3 or 4, respectively,
         for these examples.) The <pubtitle>Author's Guide</pubtitle>
         (<xref ref="topic-cross-referencing"/>)
         goes into greater detail about how to change settings for how cross references appear,
@@ -1109,8 +1112,8 @@
       <title>External links</title>
       <p>
         If you want to provide a link to a resource outside of your project,
-        you will want the <c>url</c> tag.
-        The code <c>&lt;url href="https://pretextbook.org" /&gt;</c> produces <url href="https://pretextbook.org" />.
+        you will want the <tag>url</tag> tag.
+        The code <tage>url href="https://pretextbook.org"</tage> produces <url href="https://pretextbook.org" />.
       </p>
 
       <p>
@@ -1121,17 +1124,17 @@
     <section xml:id="s-fn">
       <title>Footnotes and asides</title>
       <idx>footnote</idx>
-      <idx><c>fn</c> tag</idx>
+      <idx><tag>fn</tag> tag</idx>
 
       <p>
         Footnotes are not too hard,
-        just use <c>fn</c>,
+        just use <tag>fn</tag>,
         but note that for the time being,
         what can go inside a footnote is very, very restricted.<fn>
         This is a sample footnote, just so you can see how one looks.
         </fn> For instance,
-        you can't put a <c>p</c> (and thus you can't put lists) inside a footnote.
-        Also, no displayed math via <c>me</c>.
+        you can't put a <tag>p</tag> (and thus you can't put lists) inside a footnote.
+        Also, no displayed math via <tag>me</tag>.
         This might change,
         but there's a lot of care being taken because of the prospect of footnotes inside footnotes inside footnotes.
             <idx><h>footnote</h><h>restrictions</h></idx>
@@ -1142,15 +1145,15 @@
         it is important to keep them short.
         A good alternative for longer things that are somewhat digressional is the <term>aside</term>,
             <idx>aside</idx>
-        which comes in three flavors: <c>aside</c>, <c>biographical</c>, <c>historical</c>.
+        which comes in three flavors: <tag>aside</tag>, <tag>biographical</tag>, <tag>historical</tag>.
             <idx><h>historical</h><see>aside</see></idx>
             <idx><h>biographical</h><see>aside</see></idx>
-        Each of these allows an optional title and then a variety of tags such as <c>p</c>, <c>figure</c>,
-        and <c>sidebyside</c> (and many more).
+        Each of these allows an optional title and then a variety of tags such as <tag>p</tag>, <tag>figure</tag>,
+        and <tag>sidebyside</tag> (and many more).
       </p>
 
       <listing xml:id="l-aside">
-        <caption>A sample <c>aside</c></caption>
+        <caption>A sample <tag>aside</tag></caption>
         <idx><h>aside</h><h><pretext/> code</h></idx>
 <program>
 <input><xi:include href="aside.ptx" parse="text"/></input>
@@ -1197,24 +1200,24 @@
         To ensure that quotation marks are poperly typeset,
         it is important to use the correct <pretext /> code.
         To set something off in double quotes,
-        use the <c>q</c> tag around what should appear in quotes.
+        use the <tag>q</tag> tag around what should appear in quotes.
         It will supply both the opening and closing quotation marks, as in:
         <q>This is a quotation.</q> If you need single quotes,
-        use <c>sq</c>.
-        Because the content of <c>q</c> and <c>sq</c> is quite restricted,
+        use <tag>sq</tag>.
+        Because the content of <tag>q</tag> and <tag>sq</tag> is quite restricted,
         you may find yourself needing to explicitly access the left and right single and double quotation marks.
-        They are, quite sensibly, <c>lq</c>, <c>rq</c>, <c>lsq</c>,
-        and <c>rsq</c>.
+        They are, quite sensibly, <tag>lq</tag>, <tag>rq</tag>, <tag>lsq</tag>,
+        and <tag>rsq</tag>.
             <idx><h>quote</h><h>single</h></idx>
             <idx><h>quote</h><h>double</h></idx>
       </p>
 
       <p>
-        Longer quotes are best set off using <c>blockquote</c>
+        Longer quotes are best set off using <tag>blockquote</tag>
       </p>
 
       <listing xml:id="l-blockquote">
-        <caption>A sample <c>blockquote</c></caption>
+        <caption>A sample <tag>blockquote</tag></caption>
         <idx><h>blockquote</h><h><pretext/> code</h></idx>
 <program>
 <input><xi:include href="blockquote.ptx" parse="text"/></input>

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -33,16 +33,16 @@
         </li>
 
         <li>
-          Instructions on using <c>xsltproc</c> to convert your <pretext /> <init>XML</init> to another format such as <init>HTML</init> or <latex />.
+          Instructions on using <c>xsltproc</c> to convert your <pretext/> <init>XML</init> to another format such as <init>HTML</init> or <latex/>.
         </li>
 
         <li>
           Instructions on using
-          <webwork /> in <pretext />.
+          <webwork/> in <pretext/>.
           (This reference does show the most basic of syntax for including a problem from the
-          <webwork /> Open Problem Library.
+          <webwork/> Open Problem Library.
           However, it assumes that you already have a project set up to compile correctly with
-          <webwork /> problems,
+          <webwork/> problems,
           which is a more involved task than just running <c>xsltproc</c>.)
         </li>
       </ul>
@@ -58,12 +58,12 @@
           <idx>term</idx>
           <idx>formatting</idx>
           <idx>emphasis</idx>
-      The <pretext /> Principles (<xref ref="list-principles"/>) begin with <q><pretext /> is a markup language that captures the structure of textbooks and research papers</q> (<xref ref="principle-markup"/>).
+      The <pretext/> Principles (<xref ref="list-principles"/>) begin with <q><pretext/> is a markup language that captures the structure of textbooks and research papers</q> (<xref ref="principle-markup"/>).
       By a <term>markup language</term>,
           <idx>markup language</idx>
       we mean that the syntax describes the <em>structure</em>
       of the document and not the presentation of the document.
-      Thus, <pretext /> does not provide, for instance,
+      Thus, <pretext/> does not provide, for instance,
       a way to make text bold or italic or in a larger font.
       If an author seeks a specific type of local typesetting,
       then they need to pause and think about the
@@ -71,7 +71,7 @@
       Is the reason to emphasize a word or phrase?
       Is the reason to alert the reader to a common mistake?
       Is it to designate that a word is a new term being defined by the author?
-      There are ways to mark up such structural ideas in <pretext />,
+      There are ways to mark up such structural ideas in <pretext/>,
       and authors should conscientiously ensure that they use this markup.
     </p>
 
@@ -89,10 +89,10 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-p" /> produces the following output:
+      The code in <xref ref="l-p"/> produces the following output:
     </p>
 
-    <xi:include href="p.ptx" />
+    <xi:include href="p.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-divisions">
@@ -106,15 +106,15 @@
           <idx><h>section</h><seealso>division</seealso></idx>
           <idx><h>subsection</h><see>division</see></idx>
           <idx><h>chapter</h><see>division</see></idx>
-      They are the key organizational elements of the structure of a <pretext /> document and all have (essentially) the same syntax.
+      They are the key organizational elements of the structure of a <pretext/> document and all have (essentially) the same syntax.
       If a division does not contain any other divisions,
-      then its structure looks like what we see in <xref ref="l-section-primitive" />. (Plenty of other things can go inside other than paragraphs,
-      including figures, <etc />)
+      then its structure looks like what we see in <xref ref="l-section-primitive"/>. (Plenty of other things can go inside other than paragraphs,
+      including figures, <etc/>)
     </p>
 
     <listing xml:id="l-section-primitive">
       <caption>The general outline of a section as a model division</caption>
-      <idx><h>section</h><h><pretext/> code</h></idx>
+      <idx><h>section</h><h><pretext/> code for</h></idx>
 <program><input><xi:include href="section.ptx" parse="text"/></input> </program>
     </listing>
 
@@ -130,7 +130,7 @@
       In the <q>division with subdivisions</q> model,
       everything <em>must</em> be contained inside <tag>introduction</tag>, <tag>subsection</tag> (or whatever your subdivision type is), <tag>exercises</tag>, <tag>references</tag>,
       or <tag>conclusion</tag>.
-      This is illustrated in <xref ref="l-section-sub" />.
+      This is illustrated in <xref ref="l-section-sub"/>.
     </p>
 
     <listing xml:id="l-section-sub">
@@ -164,7 +164,7 @@
         which places some limits on the sorts of things that can be contained in a title.
         If you find text disappearing or displaying strangely,
         the culprit is likely an unnecessary or or missing <tag>p</tag> tag.
-        See the part of the documentation on validating your source for information on how to use some additional tools to see if your <pretext /> file is valid in terms of following the structural rules in the schema.
+        See the part of the documentation on validating your source for information on how to use some additional tools to see if your <pretext/> file is valid in terms of following the structural rules in the schema.
       </p>
     </paragraphs>
   </chapter>
@@ -174,29 +174,29 @@
     <idx>mathematics</idx>
 
     <p>
-      Since <pretext /> was originally called MathBook <init>XML</init>,
+      Since <pretext/> was originally called MathBook <init>XML</init>,
       you will not be surprised to learn that it has robust support for mathematical formulas.
           <idx><h>mathematics</h><h>formula</h></idx>
           <idx><h>mathematics</h><seealso>equation</seealso></idx>
-          <idx><h>mathematics</h><h><latex /></h></idx>
+          <idx><h>mathematics</h><h><latex/></h></idx>
           <idx><h>formula</h><see>equation</see></idx> 
           <idx><h>equation</h></idx>
       Inside the tags that delimit math environments,
-      your code is basically <latex /> , with the caveat that you must be careful with &lt;
+      your code is basically <latex/> , with the caveat that you must be careful with &lt;
       and &amp;
       since they are special symbols for <init>XML</init>.
-          <idx><latex /></idx>
-          <idx><h><latex /></h> <h>exceptions: &lt; and &amp;</h></idx>
-          <idx><h>special symbols</h><see><latex /></see></idx>
-      When typing math in your <pretext /> code, use <c>\lt</c> for &lt;, use <c>\gt</c> for &gt; (not strictly necessary, but good for symmetry), and use <c>\amp</c> for &amp;. In <init>HTML</init>, MathJax is used to render math, so <pretext /> generally supports the things that MathJax does <q>out of the box</q> without the need for too many additional packages to be loaded.
+          <idx><latex/></idx>
+          <idx><h><latex/></h> <h>exceptions: &lt; and &amp;</h></idx>
+          <idx><h>special symbols</h><see><latex/></see></idx>
+      When typing math in your <pretext/> code, use <c>\lt</c> for &lt;, use <c>\gt</c> for &gt; (not strictly necessary, but good for symmetry), and use <c>\amp</c> for &amp;. In <init>HTML</init>, MathJax is used to render math, so <pretext/> generally supports the things that MathJax does <q>out of the box</q> without the need for too many additional packages to be loaded.
           <idx>MathJax</idx>
     </p>
 
     <p>
       For inline math,
       just wrap things in the <tag>m</tag> tag.
-          <idx><h>equation</h><h>in-line</h><h><pretext /> code for</h></idx>
-          <idx><h><pretext /> code for</h><h>in-line equation</h></idx>
+          <idx><h>equation</h><h>in-line</h><h><pretext/> code for</h></idx>
+          <idx><h><pretext/> code for</h><h>in-line equation</h></idx>
       For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <tag>me</tag> and <tag>men</tag> tags; the latter produces a numbered equation.
           <idx><h>mathematics</h><h>environments</h><h>displayed equation</h></idx>
           <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
@@ -204,18 +204,18 @@
 
     <listing xml:id="l-me">
       <caption>Displayed equations</caption>
-      <idx><h><pretext /> code for</h><h>displayed equation</h></idx>
-      <idx><h>equation</h><h>displayed</h><h><pretext /> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>displayed equation</h></idx>
+      <idx><h>equation</h><h>displayed</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="me.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-me" /> produces the following output:
+      The code in <xref ref="l-me"/> produces the following output:
     </p>
 
-    <xi:include href="me.ptx" />
+    <xi:include href="me.ptx"/>
 
     <p>
       For a collection of equations all aligned at a designated point,
@@ -224,21 +224,21 @@
 
     <listing xml:id="l-md">
       <caption>Aligned equations</caption>
-      <idx><h><pretext /> code for</h><h>aligned equations</h></idx>
-      <idx><h>equation</h><h>aligned</h><h><pretext /> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>aligned equations</h></idx>
+      <idx><h>equation</h><h>aligned</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="md.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-md" /> produces the following output:
+      The code in <xref ref="l-md"/> produces the following output:
     </p>
 
-    <xi:include href="md.ptx" />
+    <xi:include href="md.ptx"/>
 
     <p>
-      Because most of the early adopters of <pretext /> have been mathematicians,
+      Because most of the early adopters of <pretext/> have been mathematicians,
       there are lots of additional features supported in terms of mathematics.
       See the online documentation for further details.
     </p>
@@ -252,7 +252,7 @@
     <p>
       Lists are important in lots of contexts,
       and the desire to nest lists has led to some very,
-      very complex discussions on the <pretext /> email lists.
+      very complex discussions on the <pretext/> email lists.
       We'll keep it simple here.
       There are a variety of places that lists can live,
       but a good mental model is that a list must be put inside an environment
@@ -268,26 +268,26 @@
       ordered and unordered.
           <idx><h>list</h><h>ordered</h></idx>
           <idx><h>ordered list</h></idx> (There's also the description list.
-      See the <pubtitle>Author's Guide</pubtitle> at <xref ref="topic-lists" /> for more information on it.) As in <init>HTML</init>,
+      See the <pubtitle>Author's Guide</pubtitle> at <xref ref="topic-lists"/> for more information on it.) As in <init>HTML</init>,
       an ordered list is produced with <tag>ol</tag> and an unordered list with <tag>ul</tag>.
       The items of your list are structured inside <tag>li</tag> tags.
     </p>
 
     <listing xml:id="l-ol">
       <caption>An ordered list</caption>
-      <idx><h>list</h><h>ordered</h><h><pretext /> code for</h></idx>
-      <idx><h>ordered list</h><h><pretext /> code for</h></idx>
-      <idx><h><pretext /> code for</h><h>ordered list</h></idx>
+      <idx><h>list</h><h>ordered</h><h><pretext/> code for</h></idx>
+      <idx><h>ordered list</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>ordered list</h></idx>
 <program>
 <input><xi:include href="ol.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-ol" /> produces the following output:
+      The code in <xref ref="l-ol"/> produces the following output:
     </p>
 
-    <xi:include href="ol.ptx" />
+    <xi:include href="ol.ptx"/>
 
     <p>
       You can use the <attr>label</attr> attribute on the <tag>ol</tag> tag to change the default labeling.
@@ -303,23 +303,23 @@
 
     <listing xml:id="l-ul">
       <caption>An unordered list</caption>
-      <idx><h>list</h><h>unordered</h><h><pretext /> code for</h></idx>
-      <idx><h>unordered list</h><h><pretext /> code for</h></idx>
-      <idx><h><pretext /> code for</h><h>unordered list</h></idx>
+      <idx><h>list</h><h>unordered</h><h><pretext/> code for</h></idx>
+      <idx><h>unordered list</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>unordered list</h></idx>
 <program>
 <input><xi:include href="ul.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-ul" /> produces the following output: 
+      The code in <xref ref="l-ul"/> produces the following output: 
           <idx><h>list</h><h>unordered</h></idx>
           <idx><h>unordered list</h></idx>
           <idx><h>itemize</h><see>unordered list</see></idx>
           <idx><h>bulleted list</h><see>unordered list</see></idx>
     </p>
 
-    <xi:include href="ul.ptx" />
+    <xi:include href="ul.ptx"/>
 
     <p>
       You can also use the <attr>cols</attr> attribute to split a list
@@ -333,42 +333,46 @@
 
   <chapter xml:id="ch-thm">
     <title>Theorem-Like Elements</title>
-    <idx>theorem-like elements</idx>
+    <idx>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</idx>
 
     <p>
       The tags <tag>theorem</tag>, <tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>,
-      and <tag>proposition</tag> have the same structure in <pretext />,
+      and <tag>proposition</tag> have the same structure in <pretext/>,
       so we will just illustrate <tag>theorem</tag> here.
           <idx>theorem</idx>
-          <idx><h>algorithm</h><see>theorem</see></idx> 
-          <idx><h>claim</h><see>theorem</see></idx>
-          <idx><h>corollary</h><see>theorem</see></idx> 
-          <idx><h>fact</h><see>theorem</see></idx>
-          <idx><h>identity</h><see>theorem</see></idx> 
-          <idx><h>lemma</h><see>theorem</see></idx>
-          <idx><h>proposition</h><see>theorem</see></idx>
+          <idx><h>algorithm</h><see>theorem-like elements</see></idx> 
+          <idx><h>claim</h><see>theorem-like elements</see></idx>
+          <idx><h>corollary</h><see>theorem-like elements</see></idx> 
+          <idx><h>fact</h><see>theorem-like elements</see></idx>
+          <idx><h>identity</h><see>theorem-like elements</see></idx> 
+          <idx><h>lemma</h><see>theorem-like elements</see></idx>
+          <idx><h>proposition</h><see>theorem-like elements</see></idx>
     </p>
 
     <listing xml:id="l-theorem">
       <caption>A theorem</caption>
-      <idx><h>theorem</h><h><pretext/> code</h></idx>
-      <idx><h>proof</h><h><pretext/> code</h></idx>
+      <idx><h sortby="theorem"><tag>theorem</tag></h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</h></idx>
+      <idx><h>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</h><h><pretext/> code for</h></idx>
+      <idx><h sortby="proof"><tag>proof</tag></h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h sortby="proof"><tag>proof</tag></h></idx>
+
 <program>
 <input><xi:include href="theorem.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-theorem" /> produces the following output:
+      The code in <xref ref="l-theorem"/> produces the following output:
     </p>
 
-    <xi:include href="theorem.ptx" />
+    <xi:include href="theorem.ptx"/>
 
     <p>
       The <tag>title</tag> is optional and typically used for theorems with names or to which you wish to give an attribution.
           <idx><h>theorem</h><h>title</h></idx>
           <idx><h>title</h><h>of a theorem-like element</h></idx>
-      Cross references (see <xref ref="s-xref" /> can be made using the name or the number, depending on how the author codes them.
+      Cross references (see <xref ref="s-xref"/> can be made using the name or the number, depending on how the author codes them.
     </p>
 
     <p>
@@ -378,52 +382,55 @@
       You are encouraged to use the <tag>term</tag> tag to set off the word being defined.
           <idx>term (in a definition)</idx>
       If you wish to include a list of notation to an appendix as your document,
-      you might also add a <tag>notation</tag> tag such as shown in <xref ref="l-definition" />.
+      you might also add a <tag>notation</tag> tag such as shown in <xref ref="l-definition"/>.
           <idx>notation (to be included in a notation list)</idx>
     </p>
 
     <listing xml:id="l-definition">
       <caption>A definition with notation</caption>
-      <idx><h>definition</h><h><pretext/> code</h></idx>
-      <idx><h>notation (to be included in a notation list)</h><h><pretext/> code</h></idx>
+      <idx><h>definition</h><h><pretext/> code for</h></idx>
+      <idx><h>notation (to be included in a notation list)</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="definition.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-definition" /> produces the following output:
+      The code in <xref ref="l-definition"/> produces the following output:
     </p>
 
-    <xi:include href="definition.ptx" />
+    <xi:include href="definition.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-examples">
     <title>Example-Like Elements</title>
-    <idx>example</idx>
-    <idx><h>problem</h><see>example</see></idx>
-    <idx><h>question</h><see>example</see></idx>
+    <idx>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</idx>
+    <idx><h sortby="example"><tag>example</tag></h></idx>
+    <idx><h sortby="example"><tag>example</tag></h><seealso>example-like elements</seealso></idx>
+    <idx><h sortby="problem"><tag>problem</tag></h><see>example-like elements</see></idx>
+    <idx><h>problem</h><h>as homework</h><see><tag>exercise</tag></see></idx>
+    <idx><h sortby="question"><tag>question</tag></h><see>example-like elements</see></idx>
 
     <p>
-      <pretext /> provides three closely-related tags for things that are examples or similar.
+      <pretext/> provides three closely-related tags for things that are examples or similar.
       They are <tag>example</tag>, <tag>problem</tag>,
       and <tag>question</tag>.
       They all have the same syntax.
       The <tag>title</tag> element is optional.
-          <idx><h>example</h><h>title</h></idx>
-          <idx><h>title</h><h>of example</h></idx>
-      You may either use a freeform example, as shown in <xref ref="l-example-simple" />,
-          <idx><h>example</h><h>unstructured</h></idx>
+          <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>title</h></idx>
+          <idx><h>title</h><h>of example-like elements</h></idx>
+      You may either use a freeform example, as shown in <xref ref="l-example-simple"/>,
+            <idx><h sortby="example"><tag>example</tag></h><h>unstructured</h></idx>
       or an example structured with a <tag>statement</tag> and zero or more <tag>hint</tag>s, <tag>answer</tag>s, and <tag>solution</tag>s
       (in that order).
-          <idx><h>example</h><h>hint</h></idx>
-          <idx><h>example</h><h>answer</h></idx> 
-          <idx><h>example</h><h>solution</h></idx>
-          <idx><h>hint</h><h>to example</h></idx> 
-          <idx><h>answer</h><h>to example</h></idx>
-          <idx><h>solution</h><h>to example</h></idx>
-      This is illustrated in <xref ref="l-example-structured" />.
-          <idx><h>example</h><h>structured</h></idx>
+          <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>hint</h></idx>
+          <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>answer</h></idx> 
+          <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>solution</h></idx>
+          <idx><h>hint</h><h>to example-like elements</h></idx> 
+          <idx><h>answer</h><h>to example-like elements</h></idx>
+          <idx><h>solution</h><h>to example-like elements</h></idx>
+      This is illustrated in <xref ref="l-example-structured"/>.
+          <idx><h sortby="example"><tag>example</tag></h><h>structured</h></idx>
       Note that for <init>HTML</init> output,
       if your <tag>example</tag> has a <tag>solution</tag>,
       the solution will be hidden in a knowl,
@@ -434,33 +441,37 @@
 
     <listing xml:id="l-example-simple">
       <caption>A simple example</caption>
-      <idx><h>example</h><h>unstructured</h><h><pretext/> code</h></idx>
-      <idx><h><pretext/> code</h><h>example</h><h>unstructured</h></idx>
-<program>
+      <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>unstructured</h><h><pretext/> code for</h></idx>
+            <idx><h sortby="example"><tag>example</tag></h><h>unstructured</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>example</h><h>unstructured</h></idx>
+      <idx><h><pretext/> code for</h><h>example-like elements</h></idx>
+      <program>
 <input><xi:include href="example-simple.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-example-simple" /> produces the following output:
+      The code in <xref ref="l-example-simple"/> produces the following output:
     </p>
 
-    <xi:include href="example-simple.ptx" />
+    <xi:include href="example-simple.ptx"/>
 
     <listing xml:id="l-example-structured">
       <caption>A structured example</caption>
-      <idx><h>example</h><h>structured</h><h><pretext/> code</h></idx>
-      <idx><h><pretext/> code</h><h>example</h><h>structured</h></idx>
-<program>
+      <idx><h sortby="example"><tag>example</tag></h><h>structured</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>example</h><h>structured</h></idx>
+      <idx><h><pretext/> code for</h><h>example-like elements</h></idx>
+      <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>structured</h><h><pretext/> code for</h></idx>
+      <program>
 <input><xi:include href="example-structured.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-example-structured" /> produces the following output:
+      The code in <xref ref="l-example-structured"/> produces the following output:
     </p>
 
-    <xi:include href="example-structured.ptx" />
+    <xi:include href="example-structured.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-remark">
@@ -468,7 +479,7 @@
     <idx>remark-like elements</idx>
 
     <p>
-      <pretext /> provides several simple tags that fall into the general category of a <q>remark</q>
+      <pretext/> provides several simple tags that fall into the general category of a <q>remark</q>
       that one would like to be numbered.
       They are <tag>convention</tag>, <tag>insight</tag>, <tag>note</tag>, <tag>observation</tag>, <tag>remark</tag>,
       and <tag>warning</tag>.
@@ -488,17 +499,17 @@
 
     <listing xml:id="l-remark">
       <caption>A remark</caption>
-      <idx><h>remark</h><h><pretext/> code</h></idx>
+      <idx><h>remark</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="remark.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-remark" /> produces the following output:
+      The code in <xref ref="l-remark"/> produces the following output:
     </p>
 
-    <xi:include href="remark.ptx" />
+    <xi:include href="remark.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-project">
@@ -506,28 +517,31 @@
     <idx>project-like elements</idx>
 
     <p>
-      There are four tags that <pretext /> considers to be <q>project-like</q>.
-      They are <tag>activity</tag>, <tag>exploration</tag>, <tag>investigation</tag>, <tag>project</tag>.
-          <idx>project</idx>
+        <idx>project</idx>
           <idx><h>activity</h><see>project</see></idx>
           <idx><h>exploration</h><see>project</see></idx>
-          <idx><h>investigation</h><see>project</see></idx> 			They allow a general, freeform structure similar to the unstructured <tag>example</tag> in <xref ref="l-example-simple" />; a structure analogous to that of the structured <tag>example</tag> in <xref ref="l-example-structured" />; and the highly-stuctured <tag>introduction</tag>, <tag>task</tag>, <tag>conclusion</tag> model shown in <xref ref="l-project" />.
+          <idx><h>investigation</h><see>project</see></idx>
+      There are four tags that <pretext/> considers to be <q>project-like</q>.
+      They are <tag>activity</tag>, <tag>exploration</tag>, <tag>investigation</tag>, <tag>project</tag>.
+      They allow a general, freeform structure similar to the unstructured <tag>example</tag> in <xref ref="l-example-simple"/>;
+      a structure analogous to that of the structured <tag>example</tag> in <xref ref="l-example-structured"/>;
+      and the highly-stuctured <tag>introduction</tag>, <tag>task</tag>, <tag>conclusion</tag> model shown in <xref ref="l-project"/>.
           <idx><h>example</h><h>comparison to project-like elements</h></idx>
     </p>
 
     <listing xml:id="l-project">
       <caption>A project</caption>
-      <idx><h>project</h><h><pretext/> code</h></idx>
+      <idx><h>project</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="project.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-project" /> produces the following output:
+      The code in <xref ref="l-project"/> produces the following output:
     </p>
 
-    <xi:include href="project.ptx" />
+    <xi:include href="project.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-exercise">
@@ -543,7 +557,7 @@
         You can put an <tag>exercise</tag> in the middle of a division,
         intermixed between theorems and paragraphs and figures.
         In this case, it is labeled as a <q>Checkpoint</q>.<fn>
-        See <xref ref="ch-rename" /> for information on how to use something different than
+        See <xref ref="ch-rename"/> for information on how to use something different than
         <q>Checkpoint</q> as the name for these.
         </fn> You can also put a bunch of <tag>exercise</tag>s inside an <tag>exercises</tag> tag within a division,
         which is the typical way for creating a bunch of exercises togther at the end of a section.
@@ -552,19 +566,19 @@
 
       <listing xml:id="l-exercise">
         <caption>An exercise</caption>
-        <idx><h>exercise</h><h><pretext /> code for</h></idx>
-        <idx><h>inline exercise</h><h><pretext /> code for</h></idx>
-        <idx><h><pretext /> code for</h><h>exercise</h><h>inline</h></idx>
+        <idx><h>exercise</h><h><pretext/> code for</h></idx>
+        <idx><h>inline exercise</h><h><pretext/> code for</h></idx>
+        <idx><h><pretext/> code for</h><h>exercise</h><h>inline</h></idx>
 <program>
 <input><xi:include href="exercise.ptx" parse="text"/></input>
 </program>
       </listing>
 
       <p>
-        The code in <xref ref="l-exercise" /> produces the following output:
+        The code in <xref ref="l-exercise"/> produces the following output:
       </p>
 
-      <xi:include href="exercise.ptx" />
+      <xi:include href="exercise.ptx"/>
 
       <p>
         Note that you can have multiple <tag>hint</tag>, <tag>answer</tag>,
@@ -580,7 +594,7 @@
         There are a variety of options for determining where hints,
         answers, and solutions appear
         (at all).
-        Check the <pretext /> documentation for information about <c>stringparam</c>s.
+        Check the <pretext/> documentation for information about <c>stringparam</c>s.
       </p>
     </section>
 
@@ -594,14 +608,14 @@
             <idx><h>exercise group</h><h>instructions</h></idx>
         An <tag>exercisegroup</tag> can only be placed inside an <tag>exercises</tag> element, however!
         The portion of this section headed as
-        <q><xref ref="ch-sample-exercises" text="global" /> Exercises</q>
-        is produced using the code in <xref ref="l-exercisegroup" />.
+        <q><xref ref="ch-sample-exercises" text="global"/> Exercises</q>
+        is produced using the code in <xref ref="l-exercisegroup"/>.
       </p>
 
       <listing xml:id="l-exercisegroup">
         <caption>Using an <tag>exercisegroup</tag>.</caption>
-        <idx><h>exercise group</h><h><pretext /> code for</h></idx>
-        <idx><h><pretext /> code for</h><h>exercise</h><h>group</h></idx>
+        <idx><h>exercise group</h><h><pretext/> code for</h></idx>
+        <idx><h><pretext/> code for</h><h>exercise</h><h>group</h></idx>
 <program>
 <input><xi:include href="exercisegroup.ptx" parse="text"/></input>
 </program>
@@ -623,13 +637,13 @@
       </p>
     </section>
 
-    <xi:include href="exercisegroup.ptx" />
+    <xi:include href="exercisegroup.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-rename">
     <title>Renaming Elements</title>
     <p>
-      The preceding sections have provided a lengthy list of <pretext /> tags that behave interchangeably.
+      The preceding sections have provided a lengthy list of <pretext/> tags that behave interchangeably.
       Perhaps you don't like one of their names.
       If your project will not involve any <tag>algorithm</tag>s, but you need another theorem-like tag whose name you would like to have rendered as <q>Porism</q>.
       To do this, you need to add a <tag>rename</tag> tag to the <tag>docinfo</tag> block of your code.
@@ -654,37 +668,37 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-porism" /> produces the following output:
+      The code in <xref ref="l-porism"/> produces the following output:
     </p>
 
-    <xi:include href="porism.ptx" />
+    <xi:include href="porism.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-webwork">
-    <title><webwork /> Exercises</title>
+    <title><webwork/> Exercises</title>
     <p>
       It is possible to embed
-      <webwork /> exercises into a <pretext /> document.
+      <webwork/> exercises into a <pretext/> document.
       In the <init>HTML</init> version,
       readers can answer these exercises and find out if their answer is correct or incorrect.
       However, results of
-      <webwork /> exercises cannot be recorded to your gradebook.
+      <webwork/> exercises cannot be recorded to your gradebook.
       There's some configuration required use
-      <webwork />.
+      <webwork/>.
       Please see <xref ref="webwork-author"/> and <xref ref="webwork-publisher"/> for more details.
       As soon as you add
-      <webwork /> exercises,
+      <webwork/> exercises,
       compiling to produce any output format becomes a multistep process.
     </p>
 
     <p>
       When a
-      <webwork /> exercise lives on the server, the code takes one form.
+      <webwork/> exercise lives on the server, the code takes one form.
     </p>
 
     <listing xml:id="l-webwork-opl">
       <caption>A
-      <webwork /> exercise living on the server</caption>
+      <webwork/> exercise living on the server</caption>
 
 <program>
 <input><xi:include href="webwork-opl.ptx" parse="text"/></input>
@@ -692,14 +706,14 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-webwork-opl" /> produces the following output:
+      The code in <xref ref="l-webwork-opl"/> produces the following output:
     </p>
 
-    <xi:include href="webwork-opl.ptx" />
+    <xi:include href="webwork-opl.ptx"/>
 
     <p>
       It is also possible to code
-      <webwork /> exercises directly in your <pretext /> source.
+      <webwork/> exercises directly in your <pretext/> source.
       This shows the most primitive sort of such exercise.
       The section of the <pubtitle>Author's Guide</pubtitle> referenced above goes into greater detail
       (<xref ref="webwork-author"/>).
@@ -707,7 +721,7 @@
 
     <listing xml:id="l-webwork-code">
       <caption>A simple
-      <webwork /> exercise coded in <pretext /> source</caption>
+      <webwork/> exercise coded in <pretext/> source</caption>
 
 <program>
 <input><xi:include href="webwork-code.ptx" parse="text"/></input>
@@ -715,10 +729,10 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-webwork-code" /> produces the following output:
+      The code in <xref ref="l-webwork-code"/> produces the following output:
     </p>
 
-    <xi:include href="webwork-code.ptx" />
+    <xi:include href="webwork-code.ptx"/>
   </chapter>
 
   <chapter xml:id="ch-fig">
@@ -726,11 +740,11 @@
     <section xml:id="s-fig">
       <title><tag>figure</tag></title>
       <p>
-        The gold standard for graphics to include in <pretext /> documents is, well,
+        The gold standard for graphics to include in <pretext/> documents is, well,
         complicated.
         If you're only working with <init>HTML</init> output,
         then <init>SVG</init> is what you want.
-        If you're producing <init>PDF</init> by using <latex />,
+        If you're producing <init>PDF</init> by using <latex/>,
         then you'll also want <init>PDF</init> graphics files.
         Fortunately,
         it's not too hard to convert between these formats on the command line.<fn>
@@ -738,7 +752,7 @@
         Since conversion is a rare task,
         it may be easiest to do in a cloud environment like CoCalc.
         </fn> Just be sure to keep track of which file type is your master file and which file type is produced from the other.
-        <init>PNG</init> is also supported by modern web browsers and <latex />,
+        <init>PNG</init> is also supported by modern web browsers and <latex/>,
         so that's a good option when vector graphic formats like <init>SVG</init> and <init>PDF</init> are not available or appropriate.
       </p>
 
@@ -751,10 +765,10 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-figure" /> produces the following output:
+        The code in <xref ref="l-figure"/> produces the following output:
       </p>
 
-      <xi:include href="figure.ptx" />
+      <xi:include href="figure.ptx"/>
 
       <p>
         Note that the path to the image file does not include the file extension.
@@ -764,20 +778,20 @@
         make sure that the <init>SVG</init> file is in the correct location relative to the <init>HTML</init> file.
         Here, we need a directory called <c>images</c> that lives next to our <init>HTML</init> files with a file called <c>small_graph.svg</c> inside that directory.
         If using a <init>PNG</init> file,
-        put the extension in the filename so that the file is used in both <init>HTML</init> and <latex />.
+        put the extension in the filename so that the file is used in both <init>HTML</init> and <latex/>.
       </p>
     </section>
 
     <section xml:id="s-sidebyside">
       <title><tag>sidebyside</tag></title>
       <p>
-        One of the more complex pieces of code in <pretext />,
+        One of the more complex pieces of code in <pretext/>,
         by most accounts, is that used for positioning objects
         (usually figures)
         next to each other.
-        If you've tried to do this in <latex />, you know that it can be challenging on a good day.
+        If you've tried to do this in <latex/>, you know that it can be challenging on a good day.
         Fortunately,
-        <pretext /> does the heavy lifting for us here for both <latex /> and <init>HTML</init>.
+        <pretext/> does the heavy lifting for us here for both <latex/> and <init>HTML</init>.
       </p>
 
       <p>
@@ -797,10 +811,10 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbs" /> produces the following output:
+        The code in <xref ref="l-sbs"/> produces the following output:
       </p>
 
-      <xi:include href="sidebyside.ptx" />
+      <xi:include href="sidebyside.ptx"/>
 
       <listing xml:id="l-sbs2">
         <caption>A few more bells and whistles for <tag>sidebyside</tag></caption>
@@ -811,10 +825,10 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbs2" /> produces the following output:
+        The code in <xref ref="l-sbs2"/> produces the following output:
       </p>
 
-      <xi:include href="sidebyside2.ptx" />
+      <xi:include href="sidebyside2.ptx"/>
 
       <p>
         Another use for <tag>sidebyside</tag> occurs when you want to center a graphc or tabular environment
@@ -835,18 +849,18 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbsgroup" /> produces the following output:
+        The code in <xref ref="l-sbsgroup"/> produces the following output:
       </p>
 
-      <xi:include href="sbsgroup.ptx" />
+      <xi:include href="sbsgroup.ptx"/>
     </section>
 
     <section xml:id="s-latex-fig">
-      <title><latex />-generated images</title>
+      <title><latex/>-generated images</title>
       <p>
-        <pretext /> makes it straightforward to embed <latex /> code that produces images
+        <pretext/> makes it straightforward to embed <latex/> code that produces images
         (such as TikZ)
-        into your source files. <c>xsltproc</c> basically just dumps your code out to your <latex /> file so that it compiles nicely.
+        into your source files. <c>xsltproc</c> basically just dumps your code out to your <latex/> file so that it compiles nicely.
         However, for <init>HTML</init> display,
         you will need <init>SVG</init> graphic files.
         This is where the <c>mbx</c> script comes in.
@@ -866,12 +880,12 @@
           If you're a Windows user who just needs one graphic produced quickly,
           consider going with CoCalc on a temporary basis.
           It is definitely possible to have a fully functional configuration for the <c>mbx</c> script on Windows,
-          and the <pretext /> support email list will provide plenty of assistance when you get stuck.
+          and the <pretext/> support email list will provide plenty of assistance when you get stuck.
         </p>
 
         <p>
           In addition to <c>python</c>,
-          you will need a working <latex /> installation
+          you will need a working <latex/> installation
           (with Ghostscript,
           which can sometimes be the source of configuration headaches for Windows users)
           to make graphics from TikZ
@@ -886,7 +900,7 @@
       <p>
         Our example here just illustrates using TikZ to make a simple figure
         (the Hasse diagram of a poset),
-        but lots of other <latex /> graphics packages can be used.
+        but lots of other <latex/> graphics packages can be used.
         One step required is to put
       </p>
 
@@ -897,7 +911,7 @@
 </pre>
 
       <p>
-        in the <tag>docinfo</tag> tag of your main file. <tag>latex-image-preamble</tag> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext /> source.
+        in the <tag>docinfo</tag> tag of your main file. <tag>latex-image-preamble</tag> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext/> source.
         Macros that you wish to use more broadly should be put inside <tag>macros</tag> inside <tag>docinfo</tag>.
       </p>
 
@@ -910,10 +924,10 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-tikz" /> produces the following output:
+        The code in <xref ref="l-tikz"/> produces the following output:
       </p>
 
-      <xi:include href="tikz.ptx" />
+      <xi:include href="tikz.ptx"/>
 
       <p>
         Well, that's not 100% true for <init>HTML</init>.
@@ -946,15 +960,15 @@
 
     <p>
       After <tag>sidebyside</tag>,
-      getting tables to lay out consistently between <init>HTML</init> and <init>PDF</init> is probably the second biggest headache that <pretext /> takes care of for us behind the scenes.
-      Lots of effort has been taken in order to fix some of the challenges inherent to working with the <tag>tabular</tag> environment in <latex />, and so if you author in <pretext />,
-      you should be able to forget the hacks you had to learn to make nice tables in <latex />.
+      getting tables to lay out consistently between <init>HTML</init> and <init>PDF</init> is probably the second biggest headache that <pretext/> takes care of for us behind the scenes.
+      Lots of effort has been taken in order to fix some of the challenges inherent to working with the <tag>tabular</tag> environment in <latex/>, and so if you author in <pretext/>,
+      you should be able to forget the hacks you had to learn to make nice tables in <latex/>.
     </p>
 
     <p>
           <idx><h>table</h><h>not for visual layout</h></idx>
           <idx><h>table</h><h>not for visual layout</h><seealso>side-by-side group</seealso></idx><alert>Tables should only be used to display data.</alert> Too often in other authoring systems, tables are used as a crutch to facilitate the visual layout of a page.
-      Do <em>not</em> do that when authoring <pretext />.
+      Do <em>not</em> do that when authoring <pretext/>.
       A good question to ask yourself before using a <tag>tabular</tag> is
       <q>Do the <m>xy</m>-coordinates of a cell have semantic meaning in terms of my data?</q>
       If the answer is <q>yes</q>,
@@ -968,8 +982,8 @@
     <listing xml:id="l-table">
       <caption>Code to produce a table</caption>
       <idx>tables</idx>
-      <idx><h>tables</h><h><pretext/> code</h></idx>
-      <idx><h><pretext/> code</h><h>tables</h></idx>
+      <idx><h>tables</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>tables</h></idx>
       <idx><h>caption</h><h>of a table</h></idx>
       <idx><h>tables</h><h>caption</h></idx>
       <idx>tabular</idx>
@@ -982,10 +996,10 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-table" /> produces the following output:
+      The code in <xref ref="l-table"/> produces the following output:
     </p>
 
-    <xi:include href="table.ptx" />
+    <xi:include href="table.ptx"/>
 
     <p>
           <idx><h>column</h><h>of a table</h></idx>
@@ -1012,10 +1026,10 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sage" /> produces the following output:
+        The code in <xref ref="l-sage"/> produces the following output:
       </p>
 
-      <xi:include href="sage.ptx" />
+      <xi:include href="sage.ptx"/>
 
       <p>
         SageMathCells on a single <init>HTML</init> page are automatically linked so that a cell can use the results of computations done in earlier cells on the same page.
@@ -1028,8 +1042,8 @@
         Sometimes you don't want to provide an interactive SageMath environment in the middle of your book
         (or a chunk of code)
         but you would like to produce a figure to include in your project by using SageMath.
-        The cleanest way to do this his to put the SageMath code right in your <pretext /> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats.
-        This is accomplished by using <tag>sageplot</tag> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig" />.
+        The cleanest way to do this his to put the SageMath code right in your <pretext/> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats.
+        This is accomplished by using <tag>sageplot</tag> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig"/>.
         (In particular,
         see the aside in that subsection about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
       </p>
@@ -1044,10 +1058,10 @@
 
       <p>
         We need to run the <c>mbx</c> script to actually make the image files required.
-        If you want to make both <init>HTML</init> and <init>PDF</init> via <latex />, you'll need to run it twice.
+        If you want to make both <init>HTML</init> and <init>PDF</init> via <latex/>, you'll need to run it twice.
         The first command below (again,
         enter on one line) makes the <init>SVG</init> to use on the web,
-        and the second makes what you need for <latex />.
+        and the second makes what you need for <latex/>.
         There is an <c>all</c> option that can be passed after <c>-f</c> instead of <c>svg</c> or <c>pdf</c>,
         but that is more likely to raise errors because some source code cannot produce certain output formats.
         It's best to stay away from error-producing steps until you're comfortable with debugging your system.
@@ -1066,10 +1080,10 @@
       </sidebyside>
 
       <p>
-        The code in <xref ref="l-sageplot" /> produces the following output.
+        The code in <xref ref="l-sageplot"/> produces the following output.
       </p>
 
-      <xi:include href="sageplot.ptx" />
+      <xi:include href="sageplot.ptx"/>
     </section>
   </chapter>
 
@@ -1086,15 +1100,15 @@
     <section xml:id="s-xref">
       <title>Cross references</title>
       <p>
-        <pretext /> provides a robust set of features for internal cross referencing.
-        If you're familiar with <latex />,
+        <pretext/> provides a robust set of features for internal cross referencing.
+        If you're familiar with <latex/>,
         the equivalent of <c>\label</c> is to use an <attr>xml:id</attr>.
         For example,
         the opening tag for this subsection is <tag>subsection xml:id="s-xref"</tag>.
-        Instead of the <c>\ref</c> used by <latex />,
-        we use <tag>xref</tag> in <pretext />.
+        Instead of the <c>\ref</c> used by <latex/>,
+        we use <tag>xref</tag> in <pretext/>.
         So we can type <tage>xref ref="s-xref"</tage> to create a reference to this subsection:
-        <xref ref="s-xref" />.
+        <xref ref="s-xref"/>.
         There are lots of options to control what text and number appear when you use <tag>xref</tag>.
         The default is <attr>text="type-gobal"</attr>,
         which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>.
@@ -1113,7 +1127,7 @@
       <p>
         If you want to provide a link to a resource outside of your project,
         you will want the <tag>url</tag> tag.
-        The code <tage>url href="https://pretextbook.org"</tage> produces <url href="https://pretextbook.org" />.
+        The code <tage>url href="https://pretextbook.org"</tage> produces <url href="https://pretextbook.org"/>.
       </p>
 
       <p>
@@ -1154,24 +1168,24 @@
 
       <listing xml:id="l-aside">
         <caption>A sample <tag>aside</tag></caption>
-        <idx><h>aside</h><h><pretext/> code</h></idx>
+        <idx><h>aside</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="aside.ptx" parse="text"/></input>
 </program>
       </listing>
 
       <p>
-        The code in <xref ref="l-aside" /> produces the aside <q>A Sample Aside</q>.
-        A less contrived example of an aside can be found in <xref ref="s-latex-fig" />.
+        The code in <xref ref="l-aside"/> produces the aside <q>A Sample Aside</q>.
+        A less contrived example of an aside can be found in <xref ref="s-latex-fig"/>.
       </p>
 
-      <xi:include href="aside.ptx" />
+      <xi:include href="aside.ptx"/>
     </section>
 
     <section xml:id="s-idx">
       <title>Index entries</title>
       <p>
-        <pretext /> does a good job of supporting index generation.
+        <pretext/> does a good job of supporting index generation.
         You still need to tag everything that should get an index entry by hand,
         but then the index is produced automatically.
         For a simple index entry for the word <q>group</q>,
@@ -1181,13 +1195,13 @@
         use <c>&lt;idx&gt;&lt;h&gt;subgroup&lt;/h&gt;&lt;h&gt;normal&lt;/h&gt;&lt;idx&gt;</c>.
         It is also possible to use <q>see</q>
         and <q>see also</q> entries for indices.
-        For instance, in <xref ref="ch-basic-formatting" />,
+        For instance, in <xref ref="ch-basic-formatting"/>,
         we use <c>            &lt;idx&gt;&lt;h&gt;font&lt;/h&gt;&lt;see&gt;formatting&lt;/see&gt;&lt;/idx&gt;</c> to create an index entry for <q>font</q>
         that instructs the reader to <q><em>see </em> formatting</q>.
       </p>
 
       <p>
-        If you generate <latex /> output,
+        If you generate <latex/> output,
         the index is generated without any additional passes beyond the usual two required to get references correct.
       </p>
     </section>
@@ -1198,7 +1212,7 @@
 
       <p>
         To ensure that quotation marks are poperly typeset,
-        it is important to use the correct <pretext /> code.
+        it is important to use the correct <pretext/> code.
         To set something off in double quotes,
         use the <tag>q</tag> tag around what should appear in quotes.
         It will supply both the opening and closing quotation marks, as in:
@@ -1218,17 +1232,17 @@
 
       <listing xml:id="l-blockquote">
         <caption>A sample <tag>blockquote</tag></caption>
-        <idx><h>blockquote</h><h><pretext/> code</h></idx>
+        <idx><h>blockquote</h><h><pretext/> code for</h></idx>
 <program>
 <input><xi:include href="blockquote.ptx" parse="text"/></input>
 </program>
       </listing>
 
       <p>
-        The code in <xref ref="l-blockquote" /> produces the quotation below.
+        The code in <xref ref="l-blockquote"/> produces the quotation below.
       </p>
 
-      <xi:include href="blockquote.ptx" />
+      <xi:include href="blockquote.ptx"/>
     </section>
   </chapter>
 

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -2,7 +2,7 @@
 
 <part xml:id="part-basics" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Basics Reference</title>
-  <chapter xml:id="ch-about">
+  <chapter xml:id="basics-ch-about">
     <title>About This Reference</title>
     <p>
       This <pubtitle>Basics Reference</pubtitle> is meant to supplement the more formal documentation in other parts of <pubtitle>The Guide</pubtitle>.
@@ -49,7 +49,7 @@
     </p>
   </chapter>
 
-  <chapter xml:id="ch-basic-formatting">
+  <chapter xml:id="basics-ch-basic-formatting">
     <title>Basic Formatting</title>
     <p>
           <idx><h>bold</h><see>formatting</see></idx>
@@ -80,7 +80,7 @@
       we include the listing and paragraph below.
     </p>
 
-    <listing xml:id="l-p">
+    <listing xml:id="basics-l-p">
       <caption>Some basic content of a paragraph</caption>
 
 <program>
@@ -89,13 +89,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-p"/> produces the following output:
+      The code in <xref ref="basics-l-p"/> produces the following output:
     </p>
 
     <xi:include href="p.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-divisions">
+  <chapter xml:id="basics-ch-divisions">
     <title>Document Structure</title>
     <p>
       Rob Beezer refers to elements such as <tag>chapter</tag>, <tag>section</tag>,
@@ -108,13 +108,14 @@
           <idx><h>chapter</h><see>division</see></idx>
       They are the key organizational elements of the structure of a <pretext/> document and all have (essentially) the same syntax.
       If a division does not contain any other divisions,
-      then its structure looks like what we see in <xref ref="l-section-primitive"/>. (Plenty of other things can go inside other than paragraphs,
+      then its structure looks like what we see in <xref ref="basics-l-section-primitive"/>. (Plenty of other things can go inside other than paragraphs,
       including figures, <etc/>)
     </p>
 
-    <listing xml:id="l-section-primitive">
+    <listing xml:id="basics-l-section-primitive">
       <caption>The general outline of a section as a model division</caption>
       <idx><h>section</h><h><pretext/> code for</h></idx>
+      <idx><h><pretext/> code for</h><h>section</h></idx>
 <program><input><xi:include href="section.ptx" parse="text"/></input> </program>
     </listing>
 
@@ -130,10 +131,10 @@
       In the <q>division with subdivisions</q> model,
       everything <em>must</em> be contained inside <tag>introduction</tag>, <tag>subsection</tag> (or whatever your subdivision type is), <tag>exercises</tag>, <tag>references</tag>,
       or <tag>conclusion</tag>.
-      This is illustrated in <xref ref="l-section-sub"/>.
+      This is illustrated in <xref ref="basics-l-section-sub"/>.
     </p>
 
-    <listing xml:id="l-section-sub">
+    <listing xml:id="basics-l-section-sub">
       <caption>A <tag>section</tag> with <tag>subsection</tag>s.</caption>
 
 <program><input><xi:include href="section-sub.ptx" parse="text"/></input> </program>
@@ -169,7 +170,7 @@
     </paragraphs>
   </chapter>
 
-  <chapter xml:id="ch-math">
+  <chapter xml:id="basics-ch-math">
     <title>Mathematics</title>
     <idx>mathematics</idx>
 
@@ -202,7 +203,7 @@
           <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
     </p>
 
-    <listing xml:id="l-me">
+    <listing xml:id="basics-l-me">
       <caption>Displayed equations</caption>
       <idx><h><pretext/> code for</h><h>displayed equation</h></idx>
       <idx><h>equation</h><h>displayed</h><h><pretext/> code for</h></idx>
@@ -212,7 +213,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-me"/> produces the following output:
+      The code in <xref ref="basics-l-me"/> produces the following output:
     </p>
 
     <xi:include href="me.ptx"/>
@@ -222,7 +223,7 @@
       use <tag>md</tag> and <tag>mrow</tag>. (There's also <tag>mdn</tag> for numbered equations.) <idx><h>mathematics</h><h>environments</h><h>aligned equation</h></idx>
     </p>
 
-    <listing xml:id="l-md">
+    <listing xml:id="basics-l-md">
       <caption>Aligned equations</caption>
       <idx><h><pretext/> code for</h><h>aligned equations</h></idx>
       <idx><h>equation</h><h>aligned</h><h><pretext/> code for</h></idx>
@@ -232,7 +233,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-md"/> produces the following output:
+      The code in <xref ref="basics-l-md"/> produces the following output:
     </p>
 
     <xi:include href="md.ptx"/>
@@ -244,7 +245,7 @@
     </p>
   </chapter>
 
-  <chapter xml:id="ch-lists">
+  <chapter xml:id="basics-ch-lists">
     <title>Lists</title>
     <idx>list</idx>
     <idx><h>enumerate</h><see>list</see></idx>
@@ -273,7 +274,7 @@
       The items of your list are structured inside <tag>li</tag> tags.
     </p>
 
-    <listing xml:id="l-ol">
+    <listing xml:id="basics-l-ol">
       <caption>An ordered list</caption>
       <idx><h>list</h><h>ordered</h><h><pretext/> code for</h></idx>
       <idx><h>ordered list</h><h><pretext/> code for</h></idx>
@@ -284,7 +285,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-ol"/> produces the following output:
+      The code in <xref ref="basics-l-ol"/> produces the following output:
     </p>
 
     <xi:include href="ol.ptx"/>
@@ -301,7 +302,7 @@
           <idx><h>numbering</h><h>list items</h></idx>
     </p>
 
-    <listing xml:id="l-ul">
+    <listing xml:id="basics-l-ul">
       <caption>An unordered list</caption>
       <idx><h>list</h><h>unordered</h><h><pretext/> code for</h></idx>
       <idx><h>unordered list</h><h><pretext/> code for</h></idx>
@@ -312,7 +313,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-ul"/> produces the following output: 
+      The code in <xref ref="basics-l-ul"/> produces the following output: 
           <idx><h>list</h><h>unordered</h></idx>
           <idx><h>unordered list</h></idx>
           <idx><h>itemize</h><see>unordered list</see></idx>
@@ -331,7 +332,7 @@
     </p>
   </chapter>
 
-  <chapter xml:id="ch-thm">
+  <chapter xml:id="basics-ch-thm">
     <title>Theorem-Like Elements</title>
     <idx>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</idx>
 
@@ -340,22 +341,22 @@
       and <tag>proposition</tag> have the same structure in <pretext/>,
       so we will just illustrate <tag>theorem</tag> here.
           <idx>theorem</idx>
-          <idx><h>algorithm</h><see>theorem-like elements</see></idx> 
-          <idx><h>claim</h><see>theorem-like elements</see></idx>
-          <idx><h>corollary</h><see>theorem-like elements</see></idx> 
-          <idx><h>fact</h><see>theorem-like elements</see></idx>
-          <idx><h>identity</h><see>theorem-like elements</see></idx> 
-          <idx><h>lemma</h><see>theorem-like elements</see></idx>
-          <idx><h>proposition</h><see>theorem-like elements</see></idx>
+          <idx><h sortby="algorithm"><tag>algorithm</tag></h><see>theorem-like elements</see></idx> 
+          <idx><h sortby="claim"><tag>claim</tag></h><see>theorem-like elements</see></idx>
+          <idx><h sortby="corollary"><tag>corollary</tag></h><see>theorem-like elements</see></idx> 
+          <idx><h sortby="fact"><tag>fact</tag></h><see>theorem-like elements</see></idx>
+          <idx><h sortby="identity"><tag>identity</tag></h><see>theorem-like elements</see></idx> 
+          <idx><h sortby="lemma"><tag>lemma</tag></h><see>theorem-like elements</see></idx>
+          <idx><h sortby="proposition"><tag>proposition</tag></h><see>theorem-like elements</see></idx>
     </p>
 
-    <listing xml:id="l-theorem">
+    <listing xml:id="basics-l-theorem">
       <caption>A theorem</caption>
       <idx><h sortby="theorem"><tag>theorem</tag></h><h><pretext/> code for</h></idx>
       <idx><h><pretext/> code for</h><h>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</h></idx>
       <idx><h>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</h><h><pretext/> code for</h></idx>
       <idx><h sortby="proof"><tag>proof</tag></h><h><pretext/> code for</h></idx>
-      <idx><h><pretext/> code for</h><h sortby="proof"><tag>proof</tag></h></idx>
+      <idx><h><pretext/> code for</h><h>proof (of theorem-like element)</h></idx>
 
 <program>
 <input><xi:include href="theorem.ptx" parse="text"/></input>
@@ -363,7 +364,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-theorem"/> produces the following output:
+      The code in <xref ref="basics-l-theorem"/> produces the following output:
     </p>
 
     <xi:include href="theorem.ptx"/>
@@ -372,9 +373,16 @@
       The <tag>title</tag> is optional and typically used for theorems with names or to which you wish to give an attribution.
           <idx><h>theorem</h><h>title</h></idx>
           <idx><h>title</h><h>of a theorem-like element</h></idx>
-      Cross references (see <xref ref="s-xref"/> can be made using the name or the number, depending on how the author codes them.
+      Cross references (see <xref ref="basics-s-xref"/> can be made using the name or the number, depending on how the author codes them.
     </p>
 
+    <p>
+        <idx sortby="proof"><tag>proof</tag></idx>
+        <idx><h>theorem-like elements (<tag>algorithm</tag>, <tag>claim</tag>, <tag>corollary</tag>, <tag>fact</tag>, <tag>identity</tag>, <tag>lemma</tag>, <tag>proposition</tag>, <tag>theorem</tag>)</h><h>proofs of</h></idx>
+        A theorem-like element can have multipe <tag>proof</tag> elements contained inside it. In such instances, it would be useful to use the <tag>title</tag> tag within your proof. A <tag>proof</tag> can also be divided into <tag>case</tag>s, each of which can have a title.<idx><h sortby="case"><tag>case</tag></h><h>of proof</h></idx> Although it has not always been so, you can author a <tag>proof</tag> all on its own within a division. The structure of such a detached <tag>proof</tag> is the same as for a <tag>proof</tag> contained within a theorem-like element.<idx><h sortby="proof"><tag>proof</tag></h><h>detached</h></idx>
+        <idx><h sortby="proof"><tag>proof</tag></h><h>outside of theorem-like elements</h><see>proof, detached</see></idx>
+        <idx>detached proof</idx>
+    </p>
     <p>
       You can use <tag>definition</tag> essentially like <tag>theorem</tag>,
       but a <tag>definition</tag> cannot have a proof.
@@ -382,11 +390,11 @@
       You are encouraged to use the <tag>term</tag> tag to set off the word being defined.
           <idx>term (in a definition)</idx>
       If you wish to include a list of notation to an appendix as your document,
-      you might also add a <tag>notation</tag> tag such as shown in <xref ref="l-definition"/>.
+      you might also add a <tag>notation</tag> tag such as shown in <xref ref="basics-l-definition"/>.
           <idx>notation (to be included in a notation list)</idx>
     </p>
 
-    <listing xml:id="l-definition">
+    <listing xml:id="basics-l-definition">
       <caption>A definition with notation</caption>
       <idx><h>definition</h><h><pretext/> code for</h></idx>
       <idx><h>notation (to be included in a notation list)</h><h><pretext/> code for</h></idx>
@@ -396,13 +404,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-definition"/> produces the following output:
+      The code in <xref ref="basics-l-definition"/> produces the following output:
     </p>
 
     <xi:include href="definition.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-examples">
+  <chapter xml:id="basics-ch-examples">
     <title>Example-Like Elements</title>
     <idx>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</idx>
     <idx><h sortby="example"><tag>example</tag></h></idx>
@@ -419,7 +427,7 @@
       The <tag>title</tag> element is optional.
           <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>title</h></idx>
           <idx><h>title</h><h>of example-like elements</h></idx>
-      You may either use a freeform example, as shown in <xref ref="l-example-simple"/>,
+      You may either use a freeform example, as shown in <xref ref="basics-l-example-simple"/>,
             <idx><h sortby="example"><tag>example</tag></h><h>unstructured</h></idx>
       or an example structured with a <tag>statement</tag> and zero or more <tag>hint</tag>s, <tag>answer</tag>s, and <tag>solution</tag>s
       (in that order).
@@ -429,7 +437,7 @@
           <idx><h>hint</h><h>to example-like elements</h></idx> 
           <idx><h>answer</h><h>to example-like elements</h></idx>
           <idx><h>solution</h><h>to example-like elements</h></idx>
-      This is illustrated in <xref ref="l-example-structured"/>.
+      This is illustrated in <xref ref="basics-l-example-structured"/>.
           <idx><h sortby="example"><tag>example</tag></h><h>structured</h></idx>
       Note that for <init>HTML</init> output,
       if your <tag>example</tag> has a <tag>solution</tag>,
@@ -439,28 +447,28 @@
       have the option of not knowling the solution.
     </p>
 
-    <listing xml:id="l-example-simple">
+    <listing xml:id="basics-l-example-simple">
       <caption>A simple example</caption>
       <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>unstructured</h><h><pretext/> code for</h></idx>
             <idx><h sortby="example"><tag>example</tag></h><h>unstructured</h><h><pretext/> code for</h></idx>
       <idx><h><pretext/> code for</h><h>example</h><h>unstructured</h></idx>
-      <idx><h><pretext/> code for</h><h>example-like elements</h></idx>
+      <idx><h><pretext/> code for</h><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h></idx>
       <program>
 <input><xi:include href="example-simple.ptx" parse="text"/></input>
 </program>
     </listing>
 
     <p>
-      The code in <xref ref="l-example-simple"/> produces the following output:
+      The code in <xref ref="basics-l-example-simple"/> produces the following output:
     </p>
 
     <xi:include href="example-simple.ptx"/>
 
-    <listing xml:id="l-example-structured">
+    <listing xml:id="basics-l-example-structured">
       <caption>A structured example</caption>
       <idx><h sortby="example"><tag>example</tag></h><h>structured</h><h><pretext/> code for</h></idx>
       <idx><h><pretext/> code for</h><h>example</h><h>structured</h></idx>
-      <idx><h><pretext/> code for</h><h>example-like elements</h></idx>
+      <idx><h><pretext/> code for</h><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h></idx>
       <idx><h>example-like elements (<tag>example</tag>, <tag>problem</tag>, <tag>question</tag>)</h><h>structured</h><h><pretext/> code for</h></idx>
       <program>
 <input><xi:include href="example-structured.ptx" parse="text"/></input>
@@ -468,13 +476,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-example-structured"/> produces the following output:
+      The code in <xref ref="basics-l-example-structured"/> produces the following output:
     </p>
 
     <xi:include href="example-structured.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-remark">
+  <chapter xml:id="basics-ch-remark">
     <title>Remark-Like Elements</title>
     <idx>remark-like elements</idx>
 
@@ -497,7 +505,7 @@
           <idx><h>title</h><h>of a remark-like element</h></idx>
     </p>
 
-    <listing xml:id="l-remark">
+    <listing xml:id="basics-l-remark">
       <caption>A remark</caption>
       <idx><h>remark</h><h><pretext/> code for</h></idx>
 <program>
@@ -506,13 +514,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-remark"/> produces the following output:
+      The code in <xref ref="basics-l-remark"/> produces the following output:
     </p>
 
     <xi:include href="remark.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-project">
+  <chapter xml:id="basics-ch-project">
     <title>Project-Like Elements</title>
     <idx>project-like elements</idx>
 
@@ -523,13 +531,13 @@
           <idx><h>investigation</h><see>project</see></idx>
       There are four tags that <pretext/> considers to be <q>project-like</q>.
       They are <tag>activity</tag>, <tag>exploration</tag>, <tag>investigation</tag>, <tag>project</tag>.
-      They allow a general, freeform structure similar to the unstructured <tag>example</tag> in <xref ref="l-example-simple"/>;
-      a structure analogous to that of the structured <tag>example</tag> in <xref ref="l-example-structured"/>;
-      and the highly-stuctured <tag>introduction</tag>, <tag>task</tag>, <tag>conclusion</tag> model shown in <xref ref="l-project"/>.
+      They allow a general, freeform structure similar to the unstructured <tag>example</tag> in <xref ref="basics-l-example-simple"/>;
+      a structure analogous to that of the structured <tag>example</tag> in <xref ref="basics-l-example-structured"/>;
+      and the highly-stuctured <tag>introduction</tag>, <tag>task</tag>, <tag>conclusion</tag> model shown in <xref ref="basics-l-project"/>.
           <idx><h>example</h><h>comparison to project-like elements</h></idx>
     </p>
 
-    <listing xml:id="l-project">
+    <listing xml:id="basics-l-project">
       <caption>A project</caption>
       <idx><h>project</h><h><pretext/> code for</h></idx>
 <program>
@@ -538,13 +546,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-project"/> produces the following output:
+      The code in <xref ref="basics-l-project"/> produces the following output:
     </p>
 
     <xi:include href="project.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-exercise">
+  <chapter xml:id="basics-ch-exercise">
     <title>Exercises</title>
     <idx>exercise</idx>
 
@@ -557,14 +565,14 @@
         You can put an <tag>exercise</tag> in the middle of a division,
         intermixed between theorems and paragraphs and figures.
         In this case, it is labeled as a <q>Checkpoint</q>.<fn>
-        See <xref ref="ch-rename"/> for information on how to use something different than
+        See <xref ref="basics-ch-rename"/> for information on how to use something different than
         <q>Checkpoint</q> as the name for these.
         </fn> You can also put a bunch of <tag>exercise</tag>s inside an <tag>exercises</tag> tag within a division,
         which is the typical way for creating a bunch of exercises togther at the end of a section.
             <idx><h>checkpoint</h><see>inline exercise</see></idx>
       </p>
 
-      <listing xml:id="l-exercise">
+      <listing xml:id="basics-l-exercise">
         <caption>An exercise</caption>
         <idx><h>exercise</h><h><pretext/> code for</h></idx>
         <idx><h>inline exercise</h><h><pretext/> code for</h></idx>
@@ -575,7 +583,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-exercise"/> produces the following output:
+        The code in <xref ref="basics-l-exercise"/> produces the following output:
       </p>
 
       <xi:include href="exercise.ptx"/>
@@ -598,7 +606,7 @@
       </p>
     </section>
 
-    <section xml:id="s-exgp">
+    <section xml:id="basics-s-exgp">
       <title><tag>exercisegroup</tag></title>
       <idx>exercise group</idx>
 
@@ -608,11 +616,11 @@
             <idx><h>exercise group</h><h>instructions</h></idx>
         An <tag>exercisegroup</tag> can only be placed inside an <tag>exercises</tag> element, however!
         The portion of this section headed as
-        <q><xref ref="ch-sample-exercises" text="global"/> Exercises</q>
-        is produced using the code in <xref ref="l-exercisegroup"/>.
+        <q><xref ref="basics-s-sample-exercises" text="global"/> Exercises</q>
+        is produced using the code in <xref ref="basics-l-exercisegroup"/>.
       </p>
 
-      <listing xml:id="l-exercisegroup">
+      <listing xml:id="basics-l-exercisegroup">
         <caption>Using an <tag>exercisegroup</tag>.</caption>
         <idx><h>exercise group</h><h><pretext/> code for</h></idx>
         <idx><h><pretext/> code for</h><h>exercise</h><h>group</h></idx>
@@ -632,15 +640,15 @@
 
       <p>
         An <tag>exercisegroup</tag> generates exercises in a separate section or subsection.
-        The code in <xref ref="l-exercisegroup">Listing</xref>
-        produces the output seen in <xref ref="ch-sample-exercises">Exercises</xref>.
+        The code in <xref ref="basics-l-exercisegroup">Listing</xref>
+        produces the output seen in <xref ref="basics-s-sample-exercises">Exercises</xref>.
       </p>
     </section>
 
     <xi:include href="exercisegroup.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-rename">
+  <chapter xml:id="basics-ch-rename">
     <title>Renaming Elements</title>
     <p>
       The preceding sections have provided a lengthy list of <pretext/> tags that behave interchangeably.
@@ -659,7 +667,7 @@
       we can do the following.
     </p>
 
-    <listing xml:id="l-porism">
+    <listing xml:id="basics-l-porism">
       <caption>A porism generated using <tag>algorithm</tag> and <tag>rename</tag></caption>
 
 <program>
@@ -668,13 +676,13 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-porism"/> produces the following output:
+      The code in <xref ref="basics-l-porism"/> produces the following output:
     </p>
 
     <xi:include href="porism.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-webwork">
+  <chapter xml:id="basics-ch-webwork">
     <title><webwork/> Exercises</title>
     <p>
       It is possible to embed
@@ -696,7 +704,7 @@
       <webwork/> exercise lives on the server, the code takes one form.
     </p>
 
-    <listing xml:id="l-webwork-opl">
+    <listing xml:id="basics-l-webwork-opl">
       <caption>A
       <webwork/> exercise living on the server</caption>
 
@@ -706,7 +714,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-webwork-opl"/> produces the following output:
+      The code in <xref ref="basics-l-webwork-opl"/> produces the following output:
     </p>
 
     <xi:include href="webwork-opl.ptx"/>
@@ -719,7 +727,7 @@
       (<xref ref="webwork-author"/>).
     </p>
 
-    <listing xml:id="l-webwork-code">
+    <listing xml:id="basics-l-webwork-code">
       <caption>A simple
       <webwork/> exercise coded in <pretext/> source</caption>
 
@@ -729,15 +737,15 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-webwork-code"/> produces the following output:
+      The code in <xref ref="basics-l-webwork-code"/> produces the following output:
     </p>
 
     <xi:include href="webwork-code.ptx"/>
   </chapter>
 
-  <chapter xml:id="ch-fig">
+  <chapter xml:id="basics-ch-fig">
     <title>Figures and Friends</title>
-    <section xml:id="s-fig">
+    <section xml:id="basics-s-fig">
       <title><tag>figure</tag></title>
       <p>
         The gold standard for graphics to include in <pretext/> documents is, well,
@@ -756,7 +764,7 @@
         so that's a good option when vector graphic formats like <init>SVG</init> and <init>PDF</init> are not available or appropriate.
       </p>
 
-      <listing xml:id="l-figure">
+      <listing xml:id="basics-l-figure">
         <caption>Code to include a figure</caption>
 
 <program>
@@ -765,7 +773,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-figure"/> produces the following output:
+        The code in <xref ref="basics-l-figure"/> produces the following output:
       </p>
 
       <xi:include href="figure.ptx"/>
@@ -782,7 +790,7 @@
       </p>
     </section>
 
-    <section xml:id="s-sidebyside">
+    <section xml:id="basics-s-sidebyside">
       <title><tag>sidebyside</tag></title>
       <p>
         One of the more complex pieces of code in <pretext/>,
@@ -802,7 +810,7 @@
         The sample article demonstrates all the capabilities of <tag>sidebyside</tag>.
       </p>
 
-      <listing xml:id="l-sbs">
+      <listing xml:id="basics-l-sbs">
         <caption>Code to place things side by side</caption>
 
 <program>
@@ -811,12 +819,12 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbs"/> produces the following output:
+        The code in <xref ref="basics-l-sbs"/> produces the following output:
       </p>
 
       <xi:include href="sidebyside.ptx"/>
 
-      <listing xml:id="l-sbs2">
+      <listing xml:id="basics-l-sbs2">
         <caption>A few more bells and whistles for <tag>sidebyside</tag></caption>
 
 <program>
@@ -825,7 +833,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbs2"/> produces the following output:
+        The code in <xref ref="basics-l-sbs2"/> produces the following output:
       </p>
 
       <xi:include href="sidebyside2.ptx"/>
@@ -840,7 +848,7 @@
         It is also possible to create a group of <tag>sidebyside</tag> tags with common <attr>widths</attr> by using the <tag>sbsgroup</tag> tag.
       </p>
 
-      <listing xml:id="l-sbsgroup">
+      <listing xml:id="basics-l-sbsgroup">
         <caption>Use of <tag>sbsgroup</tag></caption>
 
 <program>
@@ -849,13 +857,13 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sbsgroup"/> produces the following output:
+        The code in <xref ref="basics-l-sbsgroup"/> produces the following output:
       </p>
 
       <xi:include href="sbsgroup.ptx"/>
     </section>
 
-    <section xml:id="s-latex-fig">
+    <section xml:id="basics-s-latex-fig">
       <title><latex/>-generated images</title>
       <p>
         <pretext/> makes it straightforward to embed <latex/> code that produces images
@@ -866,7 +874,7 @@
         This is where the <c>mbx</c> script comes in.
         Running the <c>mbx</c> script frequently requires patience,
         particularly on Windows,
-        so settle in with an experienced user before attempting the steps in this subsection.
+        so settle in with an experienced user before attempting the steps in this section.
       </p>
       <aside>
         <title>The <c>mbx</c> script</title>
@@ -915,7 +923,7 @@
         Macros that you wish to use more broadly should be put inside <tag>macros</tag> inside <tag>docinfo</tag>.
       </p>
 
-      <listing xml:id="l-tikz">
+      <listing xml:id="basics-l-tikz">
         <caption>How to use <tag>latex-image</tag> to invoke TikZ</caption>
 
 <program>
@@ -924,7 +932,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-tikz"/> produces the following output:
+        The code in <xref ref="basics-l-tikz"/> produces the following output:
       </p>
 
       <xi:include href="tikz.ptx"/>
@@ -954,7 +962,7 @@
     </section>
   </chapter>
 
-  <chapter xml:id="ch-table">
+  <chapter xml:id="basics-ch-table">
     <title>Tables</title>
     <idx>tables</idx>
 
@@ -979,7 +987,7 @@
       Individuals who use screen readers will find a document that uses tables to do something other than present tabular data very confusing and frustrating.
     </p>
 
-    <listing xml:id="l-table">
+    <listing xml:id="basics-l-table">
       <caption>Code to produce a table</caption>
       <idx>tables</idx>
       <idx><h>tables</h><h><pretext/> code for</h></idx>
@@ -996,7 +1004,7 @@
     </listing>
 
     <p>
-      The code in <xref ref="l-table"/> produces the following output:
+      The code in <xref ref="basics-l-table"/> produces the following output:
     </p>
 
     <xi:include href="table.ptx"/>
@@ -1007,9 +1015,9 @@
     </p>
   </chapter>
 
-  <chapter xml:id="ch-sage">
+  <chapter xml:id="basics-ch-sage">
     <title>SageMath Content</title>
-    <section xml:id="s-sage-cell">
+    <section xml:id="basics-s-sage-cell">
       <title>SageMathCells</title>
       <p>
         Including computational SageMath cells is pretty easy with <tag>sage</tag>, <tag>input</tag>,
@@ -1017,7 +1025,7 @@
         The last tag is useful for producing a <init>PDF</init> that includes the result of the code's execution.
       </p>
 
-      <listing xml:id="l-sage">
+      <listing xml:id="basics-l-sage">
         <caption>SageMath cell</caption>
 
 <program>
@@ -1026,7 +1034,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-sage"/> produces the following output:
+        The code in <xref ref="basics-l-sage"/> produces the following output:
       </p>
 
       <xi:include href="sage.ptx"/>
@@ -1036,19 +1044,19 @@
       </p>
     </section>
 
-    <section xml:id="s-sageplot">
+    <section xml:id="basics-s-sageplot">
       <title><tag>sageplot</tag></title>
       <p>
         Sometimes you don't want to provide an interactive SageMath environment in the middle of your book
         (or a chunk of code)
         but you would like to produce a figure to include in your project by using SageMath.
         The cleanest way to do this his to put the SageMath code right in your <pretext/> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats.
-        This is accomplished by using <tag>sageplot</tag> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig"/>.
+        This is accomplished by using <tag>sageplot</tag> and the <c>mbx</c> script that we discussed in <xref ref="basics-s-latex-fig"/>.
         (In particular,
-        see the aside in that subsection about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
+        see the aside in that section about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
       </p>
 
-      <listing xml:id="l-sageplot">
+      <listing xml:id="basics-l-sageplot">
         <caption><tag>sageplot</tag> to produce a graphic</caption>
 
 <program>
@@ -1080,14 +1088,14 @@
       </sidebyside>
 
       <p>
-        The code in <xref ref="l-sageplot"/> produces the following output.
+        The code in <xref ref="basics-l-sageplot"/> produces the following output.
       </p>
 
       <xi:include href="sageplot.ptx"/>
     </section>
   </chapter>
 
-  <chapter xml:id="ch-small">
+  <chapter xml:id="basics-ch-small">
     <title>Small, But Useful</title>
     <introduction>
       <p>
@@ -1097,18 +1105,18 @@
       </p>
     </introduction>
 
-    <section xml:id="s-xref">
+    <section xml:id="basics-s-xref">
       <title>Cross references</title>
       <p>
         <pretext/> provides a robust set of features for internal cross referencing.
         If you're familiar with <latex/>,
         the equivalent of <c>\label</c> is to use an <attr>xml:id</attr>.
         For example,
-        the opening tag for this subsection is <tag>subsection xml:id="s-xref"</tag>.
+        the opening tag for this section is <tag>section xml:id="basics-s-xref"</tag>.
         Instead of the <c>\ref</c> used by <latex/>,
         we use <tag>xref</tag> in <pretext/>.
-        So we can type <tage>xref ref="s-xref"</tage> to create a reference to this subsection:
-        <xref ref="s-xref"/>.
+        So we can type <tage>xref ref="basics-s-xref"</tage> to create a reference to this subsection:
+        <xref ref="basics-s-xref"/>.
         There are lots of options to control what text and number appear when you use <tag>xref</tag>.
         The default is <attr>text="type-gobal"</attr>,
         which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>.
@@ -1135,7 +1143,7 @@
       </p>
     </section>
 
-    <section xml:id="s-fn">
+    <section xml:id="basics-s-fn">
       <title>Footnotes and asides</title>
       <idx>footnote</idx>
       <idx><tag>fn</tag> tag</idx>
@@ -1166,7 +1174,7 @@
         and <tag>sidebyside</tag> (and many more).
       </p>
 
-      <listing xml:id="l-aside">
+      <listing xml:id="basics-l-aside">
         <caption>A sample <tag>aside</tag></caption>
         <idx><h>aside</h><h><pretext/> code for</h></idx>
 <program>
@@ -1175,14 +1183,14 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-aside"/> produces the aside <q>A Sample Aside</q>.
-        A less contrived example of an aside can be found in <xref ref="s-latex-fig"/>.
+        The code in <xref ref="basics-l-aside"/> produces the aside <q>A Sample Aside</q>.
+        A less contrived example of an aside can be found in <xref ref="basics-s-latex-fig"/>.
       </p>
 
       <xi:include href="aside.ptx"/>
     </section>
 
-    <section xml:id="s-idx">
+    <section xml:id="basics-s-idx">
       <title>Index entries</title>
       <p>
         <pretext/> does a good job of supporting index generation.
@@ -1195,7 +1203,7 @@
         use <c>&lt;idx&gt;&lt;h&gt;subgroup&lt;/h&gt;&lt;h&gt;normal&lt;/h&gt;&lt;idx&gt;</c>.
         It is also possible to use <q>see</q>
         and <q>see also</q> entries for indices.
-        For instance, in <xref ref="ch-basic-formatting"/>,
+        For instance, in <xref ref="basics-ch-basic-formatting"/>,
         we use <c>            &lt;idx&gt;&lt;h&gt;font&lt;/h&gt;&lt;see&gt;formatting&lt;/see&gt;&lt;/idx&gt;</c> to create an index entry for <q>font</q>
         that instructs the reader to <q><em>see </em> formatting</q>.
       </p>
@@ -1230,7 +1238,7 @@
         Longer quotes are best set off using <tag>blockquote</tag>
       </p>
 
-      <listing xml:id="l-blockquote">
+      <listing xml:id="basics-l-blockquote">
         <caption>A sample <tag>blockquote</tag></caption>
         <idx><h>blockquote</h><h><pretext/> code for</h></idx>
 <program>
@@ -1239,7 +1247,7 @@
       </listing>
 
       <p>
-        The code in <xref ref="l-blockquote"/> produces the quotation below.
+        The code in <xref ref="basics-l-blockquote"/> produces the quotation below.
       </p>
 
       <xi:include href="blockquote.ptx"/>
@@ -1251,7 +1259,8 @@
     <p>
       Once a project gets big,
       you may find yourself wishing to break your source into multiple files.
-      This is well documented in the <xref ref="processing-modular"/>, so we refer you there for more details.
+      This is well documented in the <pubtitle>Author's Guide</pubtitle>
+      (<xref ref="processing-modular"/>), so we refer you there for more details.
     </p>
   </chapter>
 </part>

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -1,627 +1,1241 @@
+
+
 <part xml:id="part-basics" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Basics Reference</title>
+  <title>Basics Reference</title>
+  <chapter xml:id="ch-about">
+    <title>About This Reference</title>
+    <p>
+      This <pubtitle>Basics Reference</pubtitle> is meant to supplement the more formal documentation in other parts of <pubtitle>The Guide</pubtitle>.
+      Here you will find the <em>basics</em>
+      of the most important and commonly used <pretext/> elements.
+      In most instances,
+      this will be exhibited by showing a <pretext/> code listing followed immediately by the exact output that code produces.
+      (In some cases, such as with the code that produces a section,
+      it is not practical to do this.)
+      Wherever possible,
+      the sample code and its output are accompanied by cross-references to the <pubtitle>Author's Guide</pubtitle> in <xref ref="part-author"/>.
+    </p>
 
-        <chapter xml:id="ch-about">
-            <title>About This Reference</title>
-            <p>This <pubtitle>Basic Reference</pubtitle> is meant to supplement the more formal documentation in other parts of <pubtitle>The Guide</pubtitle>. Here you will find the <em>basics</em> of the most important and commonly used <pretext/> elements. In most instances, this will be exhibited by showing a <pretext/> code listing followed immediately by the exact output that code produces. (In some cases, such as with the code that produces a section, it is not practical to do this.) Wherever possible, the sample code and its output are accompanied by cross-references to the <pubtitle>Author's Guide</pubtitle> in <xref ref="part-author"/>.
-            </p>
-            <p>There are some things that are considered beyond the scope of this reference:
-            <ul>
-                <li>Many of the possible options that can be used with the different tags. This is a <em>basic</em> reference, and so we want to keep things simple. When you need a more advanced feature not discussed here, follow the link to the appropriate portion of the <pubtitle>Author's Guide</pubtitle> (<xref ref="part-author"/>).</li>
-                <li>Instructions on using <c>xsltproc</c> to convert your <pretext /> <init>XML</init> to another format such as <init>HTML</init> or <latex />.</li>
-                <li>Instructions on using <webwork /> in <pretext />. (This reference does show the most basic of syntax for including a problem from the <webwork /> Open Problem Library. However, it assumes that you already have a project set up to compile correctly with <webwork /> problems, which is a more involved task than just running <c>xsltproc</c>.)</li>
-            </ul></p>
-        </chapter>
-        <chapter xml:id="ch-basic-formatting">
-            <title>Basic Formatting</title>
-            <p><idx><h>bold</h><see>formatting</see></idx>
-            <idx><h>italic</h><see>formatting</see></idx>
-            <idx><h>font</h><see>formatting</see></idx>
-            <idx>term</idx>
-            <idx>formatting</idx>
-            <idx>emphasis</idx>
-                The <pretext /> Principles (<xref ref="list-principles"/>) begin with <q><pretext /> is a markup language that captures the structure of textbooks and research papers</q> (<xref ref="principle-markup"/>). By a <term>markup language</term><idx>markup language</idx>, we mean that the syntax describes the <em>structure</em> of the document and not the presentation of the document. Thus, <pretext /> does not provide, for instance, a way to make text bold or italic or in a larger font.  If an author seeks a specific type of local typesetting, then they need to pause and think about the <em>reason</em> for that typesetting. Is the reason to emphasize a word or phrase? Is the reason to alert the reader to a common mistake? Is it to designate that a word is a new term being defined by the author? There are ways to mark up such structural ideas in <pretext />, and authors should conscientiously ensure that they use this markup.
-            </p>
-            <p>To illustrate some of the key structural markup that leads to formatting, we include the listing and paragraph below.</p>
-            <listing xml:id="l-p">
-                <caption>Some basic content of a paragraph</caption>
-                <program>
-                    <input><xi:include href="p.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-p" /> produces the following output:</p>
-            <xi:include href="p.ptx" />
-        </chapter>
-        <chapter xml:id="ch-divisions">
-            <title>Document Structure</title>
-            <p>Rob Beezer refers to elements such as <c>chapter</c>, <c>section</c>, and <c>subsection</c> as <term>divisions</term>.
-            <idx>division</idx><idx>document structure</idx>
-            <idx>section</idx><idx><h>section</h><seealso>division</seealso></idx>
-            <idx><h>subsection</h><see>division</see></idx>
-            <idx><h>chapter</h><see>division</see></idx>
-            They are the key organizational elements of the structure of a <pretext /> document and all have (essentially) the same syntax. If a division does not contain any other divisions, then its structure looks like what we see in <xref ref="l-section-primitive" />. (Plenty of other things can go inside other than paragraphs, including figures, <etc />)</p>
+    <p>
+      There are some things that are considered beyond the scope of this reference:
 
-            <listing xml:id="l-section-primitive">
-                <caption>The general outline of a section as a model division</caption>
-                <idx><h>section</h><h><pretext/> code</h></idx>
-                <program><input><xi:include href="section.ptx" parse="text"/></input> </program>
-            </listing>
+      <ul>
+        <li>
+          Many of the possible options that can be used with the different tags.
+          This is a <em>basic</em> reference,
+          and so we want to keep things simple.
+          When you need a more advanced feature not discussed here,
+          follow the link to the appropriate portion of the <pubtitle>Author's Guide</pubtitle>
+          (<xref ref="part-author"/>).
+        </li>
 
-            <p>If a division has other divisions inside it, then the structure is a bit more complicated and regimented. In particular, if you want text before your first subdivision (<c>subsection</c> in this example), that text must go inside <c>introduction</c>.<idx><h>introduction</h><h>of chapter, section, etc.</h></idx> If you want to start with the <c>subsection</c>, then the <c>introduction</c> is optional. In the <q>division with subdivisions</q> model, everything <em>must</em> be contained inside <c>introduction</c>, <c>subsection</c> (or whatever your subdivision type is), <c>exercises</c>, <c>references</c>, or <c>conclusion</c>. This is illustrated in <xref ref="l-section-sub" />.</p>
+        <li>
+          Instructions on using <c>xsltproc</c> to convert your <pretext /> <init>XML</init> to another format such as <init>HTML</init> or <latex />.
+        </li>
 
-            <listing xml:id="l-section-sub">
-                <caption>A <c>section</c> with <c>subsection</c>s.</caption>
-                <program><input><xi:include href="section-sub.ptx" parse="text"/></input> </program>
-            </listing>
-            <paragraphs>
-                <title>Limitations on introductions</title>
-                <idx><h>introduction</h><h>of chapter, section, etc.</h><h>limitations</h></idx>
-                <p>
-                    There are a lot of tags that are <em>not</em> allowed in introductions. In general, avoid things that would have numbers. For instance, one should not put an <c>example</c> or an <c>exercise</c> in an introduction. Once the schema is correct, this text should be updated.
-                </p>
-            </paragraphs>
-            <paragraphs>
-                <title>The role of <c>p</c> tags</title>
-                <idx>paragraph</idx>
-                <idx><c>p</c> tag</idx>
-                <p>One of the things you'll need to keep an eye out for is when things must be wrapped in <c>p</c> (paragraph) tags. Notice that <c>title</c> tags do not have their content wrapped in <c>p</c>, which places some limits on the sorts of things that can be contained in a title. If you find text disappearing or displaying strangely, the culprit is likely an unnecessary or or missing <c>p</c> tag. See the part of the documentation on validating your source for information on how to use some additional tools to see if your <pretext /> file is valid in terms of following the structural rules in the schema.</p>
-            </paragraphs>
-        </chapter>
-        <chapter xml:id="ch-math">
-            <title>Mathematics</title>
-            <idx>mathematics</idx>
-            <p>Since <pretext /> was originally called MathBook <init>XML</init>, you will not be surprised to learn that it has robust support for mathematical formulas.
-            <idx><h>mathematics</h><h>formula</h></idx>
-            <idx><h>mathematics</h><seealso>equation</seealso></idx>
-            <idx><h>mathematics</h><h><latex /></h></idx>
-            <idx><h>formula</h><see>equation</see></idx>
-            <idx><h>equation</h></idx>
-            Inside the tags that delimit math environments, your code is basically <latex /> , with the caveat that you must be careful with &lt; and &amp; since they are special symbols for <init>XML</init>.
-            <idx><latex /></idx>
-            <idx><h><latex /></h> <h>exceptions: &lt; and &amp;</h></idx>
-            <idx><h>special symbols</h><see><latex /></see></idx>
-            When typing math in your <pretext /> code, use <c>\lt</c> for &lt;, use <c>\gt</c> for &gt; (not strictly necessary, but good for symmetry), and use <c>\amp</c> for &amp;. In <init>HTML</init>, MathJax is used to render math, so <pretext /> generally supports the things that MathJax does <q>out of the box</q> without the need for too many additional packages to be loaded.
-            <idx>MathJax</idx>
-            </p>
+        <li>
+          Instructions on using
+          <webwork /> in <pretext />.
+          (This reference does show the most basic of syntax for including a problem from the
+          <webwork /> Open Problem Library.
+          However, it assumes that you already have a project set up to compile correctly with
+          <webwork /> problems,
+          which is a more involved task than just running <c>xsltproc</c>.)
+        </li>
+      </ul>
+    </p>
+  </chapter>
 
-            <p> For inline math, just wrap things in the <c>m</c> tag.
-            <idx><h>equation</h><h>in-line</h><h><pretext /> code</h></idx>
-            <idx><h><pretext /> code</h><h>in-line equation</h></idx>
-            For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <c>me</c> and <c>men</c> tags; the latter produces a numbered equation.
-            <idx><h>mathematics</h><h>environments</h><h>displayed equation</h></idx>
-            <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
-            </p>
-            <listing xml:id="l-me">
-                <caption>Displayed equations</caption>
-                <idx><h><pretext /> code</h><h>displayed equation</h></idx>
-                <idx><h>equation</h><h>displayed</h><h><pretext /> code</h></idx>
-                <program>
-                    <input><xi:include href="me.ptx" parse="text"/></input>
-                </program>
-            </listing>
+  <chapter xml:id="ch-basic-formatting">
+    <title>Basic Formatting</title>
+    <p>
+          <idx><h>bold</h><see>formatting</see></idx>
+          <idx><h>italic</h><see>formatting</see></idx>
+          <idx><h>font</h><see>formatting</see></idx> 
+          <idx>term</idx>
+          <idx>formatting</idx>
+          <idx>emphasis</idx>
+      The <pretext /> Principles (<xref ref="list-principles"/>) begin with <q><pretext /> is a markup language that captures the structure of textbooks and research papers</q> (<xref ref="principle-markup"/>).
+      By a <term>markup language</term>,
+          <idx>markup language</idx>
+      we mean that the syntax describes the <em>structure</em>
+      of the document and not the presentation of the document.
+      Thus, <pretext /> does not provide, for instance,
+      a way to make text bold or italic or in a larger font.
+      If an author seeks a specific type of local typesetting,
+      then they need to pause and think about the
+      <em>reason</em> for that typesetting.
+      Is the reason to emphasize a word or phrase?
+      Is the reason to alert the reader to a common mistake?
+      Is it to designate that a word is a new term being defined by the author?
+      There are ways to mark up such structural ideas in <pretext />,
+      and authors should conscientiously ensure that they use this markup.
+    </p>
 
-            <p>The code in <xref ref="l-me" /> produces the following output:</p>
-            <xi:include href="me.ptx" />
-            <p>For a collection of equations all aligned at a designated point, use <c>md</c> and <c>mrow</c>. (There's also <c>mdn</c> for numbered equations.)
-            <idx><h>mathematics</h><h>environments</h><h>aligned equation</h></idx>
-            </p>
-            <listing xml:id="l-md">
-                <caption>Aligned equations</caption>
-                <idx><h><pretext /> code</h><h>aligned equations</h></idx>
-                <idx><h>equation</h><h>aligned</h><h><pretext /> code</h></idx>
-                <program>
-                    <input><xi:include href="md.ptx" parse="text"/></input>
-                </program>
-            </listing>
+    <p>
+      To illustrate some of the key structural markup that leads to formatting,
+      we include the listing and paragraph below.
+    </p>
 
-            <p>The code in <xref ref="l-md" /> produces the following output:</p>
-            <xi:include href="md.ptx" />
-            <p>Because most of the early adopters of <pretext /> have been mathematicians, there are lots of additional features supported in terms of mathematics. See the online documentation for further details.</p>
-        </chapter>
+    <listing xml:id="l-p">
+      <caption>Some basic content of a paragraph</caption>
 
-        <chapter xml:id="ch-lists">
-            <title>Lists</title>
-            <idx>list</idx>
-            <idx><h>enumerate</h><see>list</see></idx>
-            <p>
-                Lists are important in lots of contexts, and the desire to nest lists has led to some very, very complex discussions on the <pretext /> email lists. We'll keep it simple here. There are a variety of places that lists can live, but a good mental model is that a list must be put inside an environment (or tag) that's similar to <c>p</c>. So for example, you can't put your list directly inside a <c>subsection</c>, but instead must wrap the list in a <c>p</c>.
-            </p>
-            <p>There are two common types of lists: ordered and unordered.
-            <idx><h>list</h><h>ordered</h></idx>
-            <idx><h>ordered list</h></idx>
-            (There's also the description list. See the documentation for more information on it.) As in <init>HTML</init>, an ordered list is produced with <c>ol</c> and an unordered list with <c>ul</c>. The items of your list are structured inside <c>li</c> tags.
-            </p>
-            <listing xml:id="l-ol">
-                <caption>An ordered list</caption>
-                <idx><h>list</h><h>ordered</h><h><pretext /> code</h></idx>
-                <idx><h>ordered list</h><h><pretext /> code</h></idx>
-                <idx><h><pretext /> code</h><h>ordered list</h></idx>
-                <program>
-                    <input><xi:include href="ol.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-ol" /> produces the following output:</p>
-            <xi:include href="ol.ptx" />
-            <p>You can use the <c>@label</c> attribute on the <c>ol</c> tag to change the default labeling. For instance, if the opening tag for the list above were <c>&lt;ol label="A"&gt;</c>, then the list items would be labeled as A. and B. Sensible things to use with <c>@label</c> are i, I, A, a, and 1. Nesting of lists is possible, and there are sensible default labels.
-            <idx><h>list</h><h>numbering</h></idx>
-            <idx><h>list</h><h>labeling</h></idx>
-            <idx><h>numbering</h><h>list items</h></idx>
-            </p>
-            <listing xml:id="l-ul">
-                <caption>An unordered list</caption>
-                <idx><h>list</h><h>unordered</h><h><pretext /> code</h></idx>
-                <idx><h>unordered list</h><h><pretext /> code</h></idx>
-                <idx><h><pretext /> code</h><h>unordered list</h></idx>
-                <program>
-                    <input><xi:include href="ul.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-ul" /> produces the following output:
-            <idx><h>list</h><h>unordered</h></idx>
-            <idx><h>unordered list</h></idx>
-            <idx><h>itemize</h><see>unordered list</see></idx>
-            <idx><h>bulleted list</h><see>unordered list</see></idx>
-            </p>
-            <xi:include href="ul.ptx" />
-            <p>You can also use the <c>@cols</c> attribute to split a list (ordered or unordered) across multiple columns if the screen/page is suitably wide.
-            <idx><h>list</h><h>displayed in columns</h></idx>The value of this attribute must be an integer between 2 and 6 (inclusive).</p>
-        </chapter>
-        <chapter xml:id="ch-thm">
-            <title>Theorem-Like Elements</title>
-            <idx>theorem-like elements</idx>
-            <p>
-                The tags <c>theorem</c>, <c>algorithm</c>, <c>claim</c>, <c>corollary</c>, <c>fact</c>, <c>identity</c>, <c>lemma</c>, and <c>proposition</c> have the same structure in <pretext />, so we will just illustrate <c>theorem</c> here.
-                <idx>theorem</idx>
-                <idx><h>algorithm</h><see>theorem</see></idx>
-                <idx><h>claim</h><see>theorem</see></idx>
-                <idx><h>corollary</h><see>theorem</see></idx>
-                <idx><h>fact</h><see>theorem</see></idx>
-                <idx><h>identity</h><see>theorem</see></idx>
-                <idx><h>lemma</h><see>theorem</see></idx>
-                <idx><h>proposition</h><see>theorem</see></idx>
-            </p>
-            <listing xml:id="l-theorem">
-                <caption>A theorem</caption>
-                <idx><h>theorem</h><h><pretext/> code</h></idx>
-                <idx><h>proof</h><h><pretext/> code</h></idx>
-                <program>
-                    <input><xi:include href="theorem.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-theorem" /> produces the following output:</p>
-            <xi:include href="theorem.ptx" />
-            <p>
-            The <c>title</c> is optional and typically used for theorems with names or to which you wish to give an attribution.
-            <idx><h>theorem</h><h>title</h></idx>
-            <idx><h>title</h><h>of a theorem-like element</h></idx>
-            Cross references (see <xref ref="s-xref" /> can be made using the name or the number, depending on how the author codes them. </p>
-            <p>You can use <c>definition</c> essentially like <c>theorem</c>, but a <c>definition</c> cannot have a proof.
-            <idx>definition</idx>
-            You are encouraged to use the <c>term</c> tag to set off the word being defined.
-            <idx>term (in a definition)</idx>
-            If you wish to include a list of notation to an appendix as your document, you might also add a <c>notation</c> tag such as shown in <xref ref="l-definition" />.
-            <idx>notation (to be included in a notation list)</idx>
-            </p>
-            <listing xml:id="l-definition">
-                <caption>A definition with notation</caption>
-                <idx><h>definition</h><h><pretext/> code</h></idx>
-                <idx><h>notation (to be included in a notation list)</h><h><pretext/> code</h></idx>
-                <program>
-                    <input><xi:include href="definition.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-definition" /> produces the following output:</p>
-            <xi:include href="definition.ptx" />
-        </chapter>
+<program>
+<input><xi:include href="p.ptx" parse="text"/></input>
+</program>
+    </listing>
 
-        <chapter xml:id="ch-examples">
-            <title>Example-Like Elements</title>
-            <idx>example</idx>
-            <idx><h>problem</h><see>example</see></idx>
-            <idx><h>question</h><see>example</see></idx>
-            <p>
-                <pretext /> provides three closely-related tags for things that are examples or similar. They are <c>example</c>, <c>problem</c>, and <c>question</c>. They all have the same syntax. The <c>title</c> element is optional.
-                <idx><h>example</h><h>title</h></idx>
-                <idx><h>title</h><h>of example</h></idx>
-                You may either use a freeform example, as shown in <xref ref="l-example-simple" /><idx><h>example</h><h>unstructured</h></idx>, or an example structured with a <c>statement</c> and zero or more <c>hint</c>s, <c>answer</c>s, and <c>solution</c>s (in that order).
-                <idx><h>example</h><h>hint</h></idx>
-                <idx><h>example</h><h>answer</h></idx>
-                <idx><h>example</h><h>solution</h></idx>
-                <idx><h>hint</h><h>to example</h></idx>
-                <idx><h>answer</h><h>to example</h></idx>
-                <idx><h>solution</h><h>to example</h></idx>
-                This is illustrated in <xref ref="l-example-structured" /><idx><h>example</h><h>structured</h></idx>. Note that for <init>HTML</init> output, if your <c>example</c> has a <c>solution</c>, the solution will be hidden in a knowl, and the publisher does not (as of June 2019) have the option of not knowling the solution.
-            </p>
-            <listing xml:id="l-example-simple">
-                <caption>A simple example</caption>
-                <idx><h>example</h><h>unstructured</h><h><pretext/> code</h></idx>
-                <idx><h><pretext/> code</h><h>example</h><h>unstructured</h></idx>
-                <program>
-                    <input><xi:include href="example-simple.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-example-simple" /> produces the following output:</p>
-            <xi:include href="example-simple.ptx" />
-            <listing xml:id="l-example-structured">
-                <caption>A structured example</caption>
-                <idx><h>example</h><h>structured</h><h><pretext/> code</h></idx>
-                <idx><h><pretext/> code</h><h>example</h><h>structured</h></idx>
-                <program>
-                    <input><xi:include href="example-structured.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-example-structured" /> produces the following output:</p>
-            <xi:include href="example-structured.ptx" />
-        </chapter>
+    <p>
+      The code in <xref ref="l-p" /> produces the following output:
+    </p>
 
-        <chapter xml:id="ch-remark">
-            <title>Remark-Like Elements</title>
-			<idx>remark-like elements</idx>
-            <p><pretext /> provides several simple tags that fall into the general category of a <q>remark</q> that one would like to be numbered. They are
-<c>convention</c>, <c>insight</c>, <c>note</c>, <c>observation</c>, <c>remark</c>, and <c>warning</c>. The content of these tags is very simple. They allow an optional title, optional <c>idx</c> tags, and then a mixture of <c>p</c>, <c>blockquote</c>, and <c>pre</c>.
-            <idx>remark</idx>
-            <idx><h>convention</h><see>remark</see></idx>
-            <idx><h>insight</h><see>remark</see></idx>
-            <idx><h>note</h><see>remark</see></idx>
-            <idx><h>observation</h><see>remark</see></idx>
-            <idx><h>warning</h><see>remark</see></idx>
-            <idx><h>title</h><h>of a remark-like element</h></idx>
-            </p>
-            <listing xml:id="l-remark">
-                <caption>A remark</caption>
-                <idx><h>remark</h><h><pretext/> code</h></idx>
-                <program>
-                    <input><xi:include href="remark.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-remark" /> produces the following output:</p>
-            <xi:include href="remark.ptx" />
+    <xi:include href="p.ptx" />
+  </chapter>
 
-        </chapter>
-        <chapter xml:id="ch-project">
-            <title>Project-Like Elements</title>
-            <idx>project-like elements</idx>
-            <p>There are four tags that <pretext /> considers to be <q>project-like</q>. They are <c>activity</c>, <c>exploration</c>, <c>investigation</c>, <c>project</c>.
-            <idx>project</idx>
-            <idx><h>activity</h><see>project</see></idx>
-            <idx><h>exploration</h><see>project</see></idx>
-            <idx><h>investigation</h><see>project</see></idx>
-			They allow a general, freeform structure similar to the unstructured <c>example</c> in <xref ref="l-example-simple" />; a structure analogous to that of the structured <c>example</c> in <xref ref="l-example-structured" />; and the highly-stuctured <c>introduction</c>, <c>task</c>, <c>conclusion</c> model shown in <xref ref="l-project" />.
-			<idx><h>example</h><h>comparison to project-like elements</h></idx>
-            </p>
-            <listing xml:id="l-project">
-                <caption>A project</caption>
-                <idx><h>project</h><h><pretext/> code</h></idx>
-                <program>
-                    <input><xi:include href="project.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-project" /> produces the following output:</p>
-            <xi:include href="project.ptx" />
+  <chapter xml:id="ch-divisions">
+    <title>Document Structure</title>
+    <p>
+      Rob Beezer refers to elements such as <c>chapter</c>, <c>section</c>,
+      and <c>subsection</c> as <term>divisions</term>.
+          <idx>division</idx>
+          <idx>document structure</idx> 
+          <idx>section</idx>
+          <idx><h>section</h><seealso>division</seealso></idx>
+          <idx><h>subsection</h><see>division</see></idx>
+          <idx><h>chapter</h><see>division</see></idx>
+      They are the key organizational elements of the structure of a <pretext /> document and all have (essentially) the same syntax.
+      If a division does not contain any other divisions,
+      then its structure looks like what we see in <xref ref="l-section-primitive" />. (Plenty of other things can go inside other than paragraphs,
+      including figures, <etc />)
+    </p>
 
-        </chapter>
-        <chapter xml:id="ch-exercise">
-            <title>Exercises</title>
-            <idx>exercise</idx>
-            <section>
-                <title>Inline exercises</title>
-                <idx><h>exercise</h><h>inline</h></idx>
-                <idx><h>inline exercise</h></idx>
+    <listing xml:id="l-section-primitive">
+      <caption>The general outline of a section as a model division</caption>
+      <idx><h>section</h><h><pretext/> code</h></idx>
+<program><input><xi:include href="section.ptx" parse="text"/></input> </program>
+    </listing>
 
-            <p>
-                You can put an <c>exercise</c> in the middle of a division, intermixed between theorems and paragraphs and figures. In this case, it is labeled as a <q>Checkpoint</q>.<fn>See <xref ref="ch-rename" /> for information on how to use something different than <q>Checkpoint</q> as the name for these.</fn> You can also put a bunch of <c>exercise</c>s inside an <c>exercises</c> tag within a division, which is the typical way for creating a bunch of exercises togther at the end of a section.
-                <idx><h>checkpoint</h><see>inline exercise</see></idx>
-            </p>
+    <p>
+      If a division has other divisions inside it,
+      then the structure is a bit more complicated and regimented.
+      In particular,
+      if you want text before your first subdivision (<c>subsection</c> in this example),
+      that text must go inside <c>introduction</c>.
+          <idx><h>introduction</h><h>of chapter, section, etc.</h></idx>
+      If you want to start with the <c>subsection</c>,
+      then the <c>introduction</c> is optional.
+      In the <q>division with subdivisions</q> model,
+      everything <em>must</em> be contained inside <c>introduction</c>, <c>subsection</c> (or whatever your subdivision type is), <c>exercises</c>, <c>references</c>,
+      or <c>conclusion</c>.
+      This is illustrated in <xref ref="l-section-sub" />.
+    </p>
 
-            <listing xml:id="l-exercise">
-                <caption>An exercise</caption>
-                <idx><h>exercise</h><h><pretext /> code</h></idx>
-                <idx><h>inline exercise</h><h><pretext /> code</h></idx>
-                <idx><h><pretext /> code</h><h>exercise</h><h>inline</h></idx>
-                <program>
-                    <input><xi:include href="exercise.ptx" parse="text"/></input>
-                </program>
-            </listing>
+    <listing xml:id="l-section-sub">
+      <caption>A <c>section</c> with <c>subsection</c>s.</caption>
 
-            <p>The code in <xref ref="l-exercise" /> produces the following output:</p>
-            <xi:include href="exercise.ptx" />
+<program><input><xi:include href="section-sub.ptx" parse="text"/></input> </program>
+    </listing>
 
-            <p>Note that you can have multiple <c>hint</c>, <c>answer</c>, and <c>solution</c> elements.
+    <paragraphs>
+      <title>Limitations on introductions</title>
+      <idx><h>introduction</h><h>of chapter, section, etc.</h><h>limitations</h></idx>
+
+      <p>
+        There are a lot of tags that are <em>not</em>
+        allowed in introductions.
+        In general, avoid things that would have numbers.
+        For instance,
+        one should not put an <c>example</c> or an <c>exercise</c> in an introduction.
+        Once the schema is correct, this text should be updated.
+      </p>
+    </paragraphs>
+
+    <paragraphs>
+      <title>The role of <c>p</c> tags</title>
+      <idx>paragraph</idx>
+      <idx><c>p</c> tag</idx>
+
+      <p>
+        One of the things you'll need to keep an eye out for is when things must be wrapped in <c>p</c> (paragraph) tags.
+        Notice that <c>title</c> tags do not have their content wrapped in <c>p</c>,
+        which places some limits on the sorts of things that can be contained in a title.
+        If you find text disappearing or displaying strangely,
+        the culprit is likely an unnecessary or or missing <c>p</c> tag.
+        See the part of the documentation on validating your source for information on how to use some additional tools to see if your <pretext /> file is valid in terms of following the structural rules in the schema.
+      </p>
+    </paragraphs>
+  </chapter>
+
+  <chapter xml:id="ch-math">
+    <title>Mathematics</title>
+    <idx>mathematics</idx>
+
+    <p>
+      Since <pretext /> was originally called MathBook <init>XML</init>,
+      you will not be surprised to learn that it has robust support for mathematical formulas.
+          <idx><h>mathematics</h><h>formula</h></idx>
+          <idx><h>mathematics</h><seealso>equation</seealso></idx>
+          <idx><h>mathematics</h><h><latex /></h></idx>
+          <idx><h>formula</h><see>equation</see></idx> 
+          <idx><h>equation</h></idx>
+      Inside the tags that delimit math environments,
+      your code is basically <latex /> , with the caveat that you must be careful with &lt;
+      and &amp;
+      since they are special symbols for <init>XML</init>.
+          <idx><latex /></idx>
+          <idx><h><latex /></h> <h>exceptions: &lt; and &amp;</h></idx>
+          <idx><h>special symbols</h><see><latex /></see></idx>
+      When typing math in your <pretext /> code, use <c>\lt</c> for &lt;, use <c>\gt</c> for &gt; (not strictly necessary, but good for symmetry), and use <c>\amp</c> for &amp;. In <init>HTML</init>, MathJax is used to render math, so <pretext /> generally supports the things that MathJax does <q>out of the box</q> without the need for too many additional packages to be loaded.
+          <idx>MathJax</idx>
+    </p>
+
+    <p>
+      For inline math,
+      just wrap things in the <c>m</c> tag.
+          <idx><h>equation</h><h>in-line</h><h><pretext /> code</h></idx>
+          <idx><h><pretext /> code</h><h>in-line equation</h></idx>
+      For example, <m>a^2 + b^2 = c^2</m> is produced by <c>&lt;m&gt;a^2 + b^2 = c^2&lt;/m&gt;.</c> We get displayed equations via the <c>me</c> and <c>men</c> tags; the latter produces a numbered equation.
+          <idx><h>mathematics</h><h>environments</h><h>displayed equation</h></idx>
+          <idx><h>mathematics</h><h>environments</h><h>in-line equation</h></idx>
+    </p>
+
+    <listing xml:id="l-me">
+      <caption>Displayed equations</caption>
+      <idx><h><pretext /> code</h><h>displayed equation</h></idx>
+      <idx><h>equation</h><h>displayed</h><h><pretext /> code</h></idx>
+<program>
+<input><xi:include href="me.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-me" /> produces the following output:
+    </p>
+
+    <xi:include href="me.ptx" />
+
+    <p>
+      For a collection of equations all aligned at a designated point,
+      use <c>md</c> and <c>mrow</c>. (There's also <c>mdn</c> for numbered equations.) <idx><h>mathematics</h><h>environments</h><h>aligned equation</h></idx>
+    </p>
+
+    <listing xml:id="l-md">
+      <caption>Aligned equations</caption>
+      <idx><h><pretext /> code</h><h>aligned equations</h></idx>
+      <idx><h>equation</h><h>aligned</h><h><pretext /> code</h></idx>
+<program>
+<input><xi:include href="md.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-md" /> produces the following output:
+    </p>
+
+    <xi:include href="md.ptx" />
+
+    <p>
+      Because most of the early adopters of <pretext /> have been mathematicians,
+      there are lots of additional features supported in terms of mathematics.
+      See the online documentation for further details.
+    </p>
+  </chapter>
+
+  <chapter xml:id="ch-lists">
+    <title>Lists</title>
+    <idx>list</idx>
+    <idx><h>enumerate</h><see>list</see></idx>
+
+    <p>
+      Lists are important in lots of contexts,
+      and the desire to nest lists has led to some very,
+      very complex discussions on the <pretext /> email lists.
+      We'll keep it simple here.
+      There are a variety of places that lists can live,
+      but a good mental model is that a list must be put inside an environment
+      (or tag)
+      that's similar to <c>p</c>.
+      So for example,
+      you can't put your list directly inside a <c>subsection</c>,
+      but instead must wrap the list in a <c>p</c>.
+    </p>
+
+    <p>
+      There are two common types of lists:
+      ordered and unordered.
+          <idx><h>list</h><h>ordered</h></idx>
+          <idx><h>ordered list</h></idx> (There's also the description list.
+      See the documentation for more information on it.) As in <init>HTML</init>,
+      an ordered list is produced with <c>ol</c> and an unordered list with <c>ul</c>.
+      The items of your list are structured inside <c>li</c> tags.
+    </p>
+
+    <listing xml:id="l-ol">
+      <caption>An ordered list</caption>
+      <idx><h>list</h><h>ordered</h><h><pretext /> code</h></idx>
+      <idx><h>ordered list</h><h><pretext /> code</h></idx>
+      <idx><h><pretext /> code</h><h>ordered list</h></idx>
+<program>
+<input><xi:include href="ol.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-ol" /> produces the following output:
+    </p>
+
+    <xi:include href="ol.ptx" />
+
+    <p>
+      You can use the <c>@label</c> attribute on the <c>ol</c> tag to change the default labeling.
+      For instance,
+      if the opening tag for the list above were <c>&lt;ol label="A"&gt;</c>,
+      then the list items would be labeled as A. and B. Sensible things to use with <c>@label</c> are i, I, A, a, and 1.
+      Nesting of lists is possible,
+      and there are sensible default labels.
+          <idx><h>list</h><h>numbering</h></idx>
+          <idx><h>list</h><h>labeling</h></idx>
+          <idx><h>numbering</h><h>list items</h></idx>
+    </p>
+
+    <listing xml:id="l-ul">
+      <caption>An unordered list</caption>
+      <idx><h>list</h><h>unordered</h><h><pretext /> code</h></idx>
+      <idx><h>unordered list</h><h><pretext /> code</h></idx>
+      <idx><h><pretext /> code</h><h>unordered list</h></idx>
+<program>
+<input><xi:include href="ul.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-ul" /> produces the following output: 
+          <idx><h>list</h><h>unordered</h></idx>
+          <idx><h>unordered list</h></idx>
+          <idx><h>itemize</h><see>unordered list</see></idx>
+          <idx><h>bulleted list</h><see>unordered list</see></idx>
+    </p>
+
+    <xi:include href="ul.ptx" />
+
+    <p>
+      You can also use the <c>@cols</c> attribute to split a list
+      (ordered or unordered)
+      across multiple columns if the screen/page is suitably wide.
+          <idx><h>list</h><h>displayed in columns</h></idx>
+      The value of this attribute must be an integer between 2 and 6
+      (inclusive).
+    </p>
+  </chapter>
+
+  <chapter xml:id="ch-thm">
+    <title>Theorem-Like Elements</title>
+    <idx>theorem-like elements</idx>
+
+    <p>
+      The tags <c>theorem</c>, <c>algorithm</c>, <c>claim</c>, <c>corollary</c>, <c>fact</c>, <c>identity</c>, <c>lemma</c>,
+      and <c>proposition</c> have the same structure in <pretext />,
+      so we will just illustrate <c>theorem</c> here.
+          <idx>theorem</idx>
+          <idx><h>algorithm</h><see>theorem</see></idx> 
+          <idx><h>claim</h><see>theorem</see></idx>
+          <idx><h>corollary</h><see>theorem</see></idx> 
+          <idx><h>fact</h><see>theorem</see></idx>
+          <idx><h>identity</h><see>theorem</see></idx> 
+          <idx><h>lemma</h><see>theorem</see></idx>
+          <idx><h>proposition</h><see>theorem</see></idx>
+    </p>
+
+    <listing xml:id="l-theorem">
+      <caption>A theorem</caption>
+      <idx><h>theorem</h><h><pretext/> code</h></idx>
+      <idx><h>proof</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="theorem.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-theorem" /> produces the following output:
+    </p>
+
+    <xi:include href="theorem.ptx" />
+
+    <p>
+      The <c>title</c> is optional and typically used for theorems with names or to which you wish to give an attribution.
+          <idx><h>theorem</h><h>title</h></idx>
+          <idx><h>title</h><h>of a theorem-like element</h></idx>
+      Cross references (see <xref ref="s-xref" /> can be made using the name or the number, depending on how the author codes them.
+    </p>
+
+    <p>
+      You can use <c>definition</c> essentially like <c>theorem</c>,
+      but a <c>definition</c> cannot have a proof.
+          <idx>definition</idx>
+      You are encouraged to use the <c>term</c> tag to set off the word being defined.
+          <idx>term (in a definition)</idx>
+      If you wish to include a list of notation to an appendix as your document,
+      you might also add a <c>notation</c> tag such as shown in <xref ref="l-definition" />.
+          <idx>notation (to be included in a notation list)</idx>
+    </p>
+
+    <listing xml:id="l-definition">
+      <caption>A definition with notation</caption>
+      <idx><h>definition</h><h><pretext/> code</h></idx>
+      <idx><h>notation (to be included in a notation list)</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="definition.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-definition" /> produces the following output:
+    </p>
+
+    <xi:include href="definition.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-examples">
+    <title>Example-Like Elements</title>
+    <idx>example</idx>
+    <idx><h>problem</h><see>example</see></idx>
+    <idx><h>question</h><see>example</see></idx>
+
+    <p>
+      <pretext /> provides three closely-related tags for things that are examples or similar.
+      They are <c>example</c>, <c>problem</c>,
+      and <c>question</c>.
+      They all have the same syntax.
+      The <c>title</c> element is optional.
+          <idx><h>example</h><h>title</h></idx>
+          <idx><h>title</h><h>of example</h></idx>
+      You may either use a freeform example, as shown in <xref ref="l-example-simple" />,
+          <idx><h>example</h><h>unstructured</h></idx>
+      or an example structured with a <c>statement</c> and zero or more <c>hint</c>s, <c>answer</c>s, and <c>solution</c>s
+      (in that order).
+          <idx><h>example</h><h>hint</h></idx>
+          <idx><h>example</h><h>answer</h></idx> 
+          <idx><h>example</h><h>solution</h></idx>
+          <idx><h>hint</h><h>to example</h></idx> 
+          <idx><h>answer</h><h>to example</h></idx>
+          <idx><h>solution</h><h>to example</h></idx>
+      This is illustrated in <xref ref="l-example-structured" />.
+          <idx><h>example</h><h>structured</h></idx>
+      Note that for <init>HTML</init> output,
+      if your <c>example</c> has a <c>solution</c>,
+      the solution will be hidden in a knowl,
+      and the publisher does not
+      (as of June 2019)
+      have the option of not knowling the solution.
+    </p>
+
+    <listing xml:id="l-example-simple">
+      <caption>A simple example</caption>
+      <idx><h>example</h><h>unstructured</h><h><pretext/> code</h></idx>
+      <idx><h><pretext/> code</h><h>example</h><h>unstructured</h></idx>
+<program>
+<input><xi:include href="example-simple.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-example-simple" /> produces the following output:
+    </p>
+
+    <xi:include href="example-simple.ptx" />
+
+    <listing xml:id="l-example-structured">
+      <caption>A structured example</caption>
+      <idx><h>example</h><h>structured</h><h><pretext/> code</h></idx>
+      <idx><h><pretext/> code</h><h>example</h><h>structured</h></idx>
+<program>
+<input><xi:include href="example-structured.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-example-structured" /> produces the following output:
+    </p>
+
+    <xi:include href="example-structured.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-remark">
+    <title>Remark-Like Elements</title>
+    <idx>remark-like elements</idx>
+
+    <p>
+      <pretext /> provides several simple tags that fall into the general category of a <q>remark</q>
+      that one would like to be numbered.
+      They are <c>convention</c>, <c>insight</c>, <c>note</c>, <c>observation</c>, <c>remark</c>,
+      and <c>warning</c>.
+      The content of these tags is very simple.
+      They allow an optional title,
+      optional <c>idx</c> tags,
+      and then a mixture of <c>p</c>, <c>blockquote</c>,
+      and <c>pre</c>.
+          <idx>remark</idx>
+          <idx><h>convention</h><see>remark</see></idx>
+          <idx><h>insight</h><see>remark</see></idx> 
+          <idx><h>note</h><see>remark</see></idx>
+          <idx><h>observation</h><see>remark</see></idx>
+          <idx><h>warning</h><see>remark</see></idx>
+          <idx><h>title</h><h>of a remark-like element</h></idx>
+    </p>
+
+    <listing xml:id="l-remark">
+      <caption>A remark</caption>
+      <idx><h>remark</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="remark.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-remark" /> produces the following output:
+    </p>
+
+    <xi:include href="remark.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-project">
+    <title>Project-Like Elements</title>
+    <idx>project-like elements</idx>
+
+    <p>
+      There are four tags that <pretext /> considers to be <q>project-like</q>.
+      They are <c>activity</c>, <c>exploration</c>, <c>investigation</c>, <c>project</c>.
+          <idx>project</idx>
+          <idx><h>activity</h><see>project</see></idx>
+          <idx><h>exploration</h><see>project</see></idx>
+          <idx><h>investigation</h><see>project</see></idx> 			They allow a general, freeform structure similar to the unstructured <c>example</c> in <xref ref="l-example-simple" />; a structure analogous to that of the structured <c>example</c> in <xref ref="l-example-structured" />; and the highly-stuctured <c>introduction</c>, <c>task</c>, <c>conclusion</c> model shown in <xref ref="l-project" />.
+          <idx><h>example</h><h>comparison to project-like elements</h></idx>
+    </p>
+
+    <listing xml:id="l-project">
+      <caption>A project</caption>
+      <idx><h>project</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="project.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-project" /> produces the following output:
+    </p>
+
+    <xi:include href="project.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-exercise">
+    <title>Exercises</title>
+    <idx>exercise</idx>
+
+    <section>
+      <title>Inline exercises</title>
+      <idx><h>exercise</h><h>inline</h></idx>
+      <idx><h>inline exercise</h></idx>
+
+      <p>
+        You can put an <c>exercise</c> in the middle of a division,
+        intermixed between theorems and paragraphs and figures.
+        In this case, it is labeled as a <q>Checkpoint</q>.<fn>
+        See <xref ref="ch-rename" /> for information on how to use something different than
+        <q>Checkpoint</q> as the name for these.
+        </fn> You can also put a bunch of <c>exercise</c>s inside an <c>exercises</c> tag within a division,
+        which is the typical way for creating a bunch of exercises togther at the end of a section.
+            <idx><h>checkpoint</h><see>inline exercise</see></idx>
+      </p>
+
+      <listing xml:id="l-exercise">
+        <caption>An exercise</caption>
+        <idx><h>exercise</h><h><pretext /> code</h></idx>
+        <idx><h>inline exercise</h><h><pretext /> code</h></idx>
+        <idx><h><pretext /> code</h><h>exercise</h><h>inline</h></idx>
+<program>
+<input><xi:include href="exercise.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-exercise" /> produces the following output:
+      </p>
+
+      <xi:include href="exercise.ptx" />
+
+      <p>
+        Note that you can have multiple <c>hint</c>, <c>answer</c>,
+        and <c>solution</c> elements.
             <idx><h>hint</h><h>to exercise</h></idx>
             <idx><h>answer</h><h>to exercise</h></idx>
-            <idx><h>solution</h><h>to exercise</h></idx>
+            <idx><h>solution</h><h>to exercise</h></idx> 
             <idx><h>exercise</h><h>hint</h></idx>
-            <idx><h>exercise</h><h>answer</h></idx>
+            <idx><h>exercise</h><h>answer</h></idx> 
             <idx><h>exercise</h><h>solution</h></idx>
-            But you must put all the <c>hint</c>s first, then all the <c>answer</c>s, and then all the <c>solution</c>s. There are a variety of options for determining where hints, answers, and solutions appear (at all). Check the <pretext /> documentation for information about <c>stringparam</c>s.
-            </p>
-            </section>
+        But you must put all the <c>hint</c>s first,
+        then all the <c>answer</c>s, and then all the <c>solution</c>s.
+        There are a variety of options for determining where hints,
+        answers, and solutions appear
+        (at all).
+        Check the <pretext /> documentation for information about <c>stringparam</c>s.
+      </p>
+    </section>
 
-            <section xml:id="s-exgp">
-                <title><c>exercisegroup</c></title>
-                <idx>exercise group</idx>
-                <p>Sometimes you have several exercises that should all have a common set of instructions, which is when you will use the <c>exercisegroup</c> tag.
-                <idx><h>exercise group</h><h>instructions</h></idx>
-                An <c>exercisegroup</c> can only be placed inside an <c>exercises</c> element, however! The portion of this section headed as <q><xref ref="ch-sample-exercises" text="global" /> Exercises</q> is produced using the code in <xref ref="l-exercisegroup" />.</p>
+    <section xml:id="s-exgp">
+      <title><c>exercisegroup</c></title>
+      <idx>exercise group</idx>
 
-                <listing xml:id="l-exercisegroup">
-                    <caption>Using an <c>exercisegroup</c>.</caption>
-                    <idx><h>exercise group</h><h><pretext /> code</h></idx>
-                    <idx><h><pretext /> code</h><h>exercise</h><h>group</h></idx>
-                    <program>
-                        <input><xi:include href="exercisegroup.ptx" parse="text"/></input>
-                    </program>
-                </listing>
-            <p>
-                If you want the contents of an <c>exercisegroup</c> to be put in multiple columns, you can add a <c>@cols</c> attribute to the <c>exercisegroup</c> of the form <c>cols="3"</c>. The integer value of <c>@cols</c> must be between 2 and 6 (inclusive).
-                <idx><h>exercise group</h><h>columns</h></idx>
-                <idx><h>column</h><h>of an exercise group</h></idx>
-            </p>
+      <p>
+        Sometimes you have several exercises that should all have a common set of instructions,
+        which is when you will use the <c>exercisegroup</c> tag.
+            <idx><h>exercise group</h><h>instructions</h></idx>
+        An <c>exercisegroup</c> can only be placed inside an <c>exercises</c> element, however!
+        The portion of this section headed as
+        <q><xref ref="ch-sample-exercises" text="global" /> Exercises</q>
+        is produced using the code in <xref ref="l-exercisegroup" />.
+      </p>
 
-            <p>
-                An <c>exercisegroup</c> generates exercises in a separate section or subsection.  The code in <xref ref="l-exercisegroup">Listing</xref> produces the output seen in <xref ref="ch-sample-exercises">Exercises</xref>.
-            </p>
-            </section>
-            <xi:include href="exercisegroup.ptx" />
+      <listing xml:id="l-exercisegroup">
+        <caption>Using an <c>exercisegroup</c>.</caption>
+        <idx><h>exercise group</h><h><pretext /> code</h></idx>
+        <idx><h><pretext /> code</h><h>exercise</h><h>group</h></idx>
+<program>
+<input><xi:include href="exercisegroup.ptx" parse="text"/></input>
+</program>
+      </listing>
 
-        </chapter>
-        <chapter xml:id="ch-rename">
-            <title>Renaming Elements</title>
-            <p>The preceding sections have provided a lengthy list of <pretext /> tags that behave interchangeably. Perhaps you don't like one of their names. If your project will not involve any <c>algorithm</c>s, but you need another theorem-like tag whose name you would like to have rendered as <q>Porism</q>. To do this, you need to add a <c>rename</c> tag to the <c>docinfo</c> block of your code. For our example, the necessary code would be <c>&lt;rename element="algorithm"&gt;Porism&lt;/rename&gt;</c>. The <c>rename</c> tag generates a <em>global</em> change; it is not possible to rename a single instance of a tag or to define your own tags (without writings your own <init>XSLT</init> code.</p>
-            <p>
-                We have included this <c>rename</c> code in this project's <c>docinfo</c>, and as such, we can do the following.
-            </p>
-            <listing xml:id="l-porism">
-                <caption>A porism generated using <c>algorithm</c> and <c>rename</c></caption>
-                <program>
-                    <input><xi:include href="porism.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-porism" /> produces the following output:</p>
-            <xi:include href="porism.ptx" />
-        </chapter>
+      <p>
+        If you want the contents of an <c>exercisegroup</c> to be put in multiple columns,
+        you can add a <c>@cols</c> attribute to the <c>exercisegroup</c> of the form <c>cols="3"</c>.
+        The integer value of <c>@cols</c> must be between 2 and 6
+        (inclusive).
+            <idx><h>exercise group</h><h>columns</h></idx>
+            <idx><h>column</h><h>of an exercise group</h></idx>
+      </p>
 
-        <chapter xml:id="ch-webwork">
-            <title><webwork /> Exercises</title>
-            <p>It is possible to embed <webwork /> exercises into a <pretext /> document. In the <init>HTML</init> version, readers can answer these exercises and find out if their answer is correct or incorrect. However, results of <webwork /> exercises cannot be recorded to your gradebook. There's some configuration required use <webwork />. Please see <xref ref="webwork-author"/> and <xref ref="webwork-publisher"/> for more details. As soon as you add <webwork /> exercises, compiling to produce any output format becomes a multistep process.
-            </p>
-            <p>When a <webwork /> exercise lives on the server, the code takes one form.</p>
-            <listing xml:id="l-webwork-opl">
-                <caption>A <webwork /> exercise living on the server</caption>
-                <program>
-                    <input><xi:include href="webwork-opl.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-webwork-opl" /> produces the following output:</p>
-            <xi:include href="webwork-opl.ptx" />
-            <p>It is also possible to code <webwork /> exercises directly in your <pretext /> source. This shows the most primitive sort of such exercise. The section of the <pubtitle>Author's Guide</pubtitle> referenced above goes into greater detail (<xref ref="webwork-author"/>).</p>
-            <listing xml:id="l-webwork-code">
-                <caption>A simple <webwork /> exercise coded in <pretext /> source</caption>
-                <program>
-                    <input><xi:include href="webwork-code.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-webwork-code" /> produces the following output:</p>
-            <xi:include href="webwork-code.ptx" />
-        </chapter>
-        <chapter xml:id="ch-fig">
-            <title>Figures and Friends</title>
-            <section xml:id="s-fig">
-                <title><c>figure</c></title>
-                <p>The gold standard for graphics to include in <pretext /> documents is, well, complicated. If you're only working with <init>HTML</init> output, then <init>SVG</init> is what you want. If you're producing <init>PDF</init> by using <latex />, then you'll also want <init>PDF</init> graphics files. Fortunately, it's not too hard to convert between these formats on the command line.<fn>Windows users have run into some problems in this area. Since conversion is a rare task, it may be easiest to do in a cloud environment like CoCalc.</fn> Just be sure to keep track of which file type is your master file and which file type is produced from the other. <init>PNG</init> is also supported by modern web browsers and <latex />, so that's a good option when vector graphic formats like <init>SVG</init> and <init>PDF</init> are not available or appropriate.
-                </p>
-                <listing xml:id="l-figure">
-                <caption>Code to include a figure</caption>
-                <program>
-                    <input><xi:include href="figure.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-figure" /> produces the following output:</p>
-            <xi:include href="figure.ptx" />
-            <p>Note that the path to the image file does not include the file extension. When you run <c>xsltproc</c>, the output format you're generating will determine what gets added on so that the right file is grabbed. If your browser says it can't find the image file, make sure that the <init>SVG</init> file is in the correct location relative to the <init>HTML</init> file. Here, we need a directory called <c>images</c> that lives next to our <init>HTML</init> files with a file called <c>small_graph.svg</c> inside that directory. If using a <init>PNG</init> file, put the extension in the filename so that the file is used in both <init>HTML</init> and <latex />.</p>
-            </section>
-            <section xml:id="s-sidebyside">
-                <title><c>sidebyside</c></title>
-                <p>One of the more complex pieces of code in <pretext />, by most accounts, is that used for positioning objects (usually figures) next to each other. If you've tried to do this in <latex />, you know that it can be challenging on a good day. Fortunately, <pretext /> does the heavy lifting for us here for both <latex /> and <init>HTML</init>.
-                </p>
-                <p>
-                    We include two examples here. The first places the <c>sidebyside</c> directly in the current division and places a <c>figure</c> with a caption inside the <c>sidebyside</c>. The second puts the <c>sidebyside</c> inside <c>figure</c> and then uses an <c>image</c> not contained in a <c>figure</c> to include the graphic. It's possible to do all sorts of nesting and get nice subnumbering automatically. The sample article demonstrates all the capabilities of <c>sidebyside</c>.
-                </p>
-                <listing xml:id="l-sbs">
-                <caption>Code to place things side by side</caption>
-                <program>
-                    <input><xi:include href="sidebyside.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-sbs" /> produces the following output:</p>
-            <xi:include href="sidebyside.ptx" />
-                <listing xml:id="l-sbs2">
-                <caption>A few more bells and whistles for <c>sidebyside</c></caption>
-                <program>
-                    <input><xi:include href="sidebyside2.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-sbs2" /> produces the following output:</p>
-            <xi:include href="sidebyside2.ptx" />
-            <p>Another use for <c>sidebyside</c> occurs when you want to center a graphc or tabular environment (or a number of other things) on a line by itself but without a <c>caption</c> and number.</p>
-            <p>
-                It is also possible to create a group of <c>sidebyside</c> tags with common <c>@widths</c> by using the <c>sbsgroup</c> tag.
-            </p>
-            <listing xml:id="l-sbsgroup">
-                <caption>Use of <c>sbsgroup</c></caption>
-                <program>
-                    <input><xi:include href="sbsgroup.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-sbsgroup" /> produces the following output:</p>
-            <xi:include href="sbsgroup.ptx" />
-            </section>
-            <section xml:id="s-latex-fig">
-                <title><latex />-generated images</title>
-                <p><pretext /> makes it straightforward to embed <latex /> code that produces images (such as TikZ) into your source files. <c>xsltproc</c> basically just dumps your code out to your <latex /> file so that it compiles nicely. However, for <init>HTML</init> display, you will need <init>SVG</init> graphic files. This is where the <c>mbx</c> script comes in. Running the <c>mbx</c> script frequently requires patience, particularly on Windows, so settle in with an experienced user before attempting the steps in this subsection.
-                </p>
-                <aside>
-                    <title>The <c>mbx</c> script</title>
-                    <p>
-                        The <c>mbx</c> script has a number of prerequisites to use its full power. As a baseline, <c>python</c> is required. (Both version 2 and version 3 are generally supported.) This comes pretty much by default with Mac, Linux, and CoCalc/cloud environments, and so they tend to work better than Windows. If you're a Windows user who just needs one graphic produced quickly, consider going with CoCalc on a temporary basis. It is definitely possible to have a fully functional configuration for the <c>mbx</c> script on Windows, and the <pretext /> support email list will provide plenty of assistance when you get stuck.
-                    </p>
-                    <p>
-                        In addition to <c>python</c>, you will need a working <latex /> installation (with Ghostscript, which can sometimes be the source of configuration headaches for Windows users) to make graphics from TikZ (or similar) code to include in your <c>HTML</c> pages. <c>pdf2svg</c> is also a piece of the toolchain that may need to be installed separately, including on macOS. To generate graphics using SageMath, you'll need a working installation of it with a proper configuration of its path in the <c>mbx.cfg</c> file. Linux and CoCalc can probably get away without extra configuration here, but it will likely be required on macOS and Windows unless you've set up your SageMath install so you can run it from the command line by simply executing <c>sage</c>.
-                    </p>
-                </aside>
-                <p>Our example here just illustrates using TikZ to make a simple figure (the Hasse diagram of a poset), but lots of other <latex /> graphics packages can be used. One step required is to put
-                </p>
-                <pre>
+      <p>
+        An <c>exercisegroup</c> generates exercises in a separate section or subsection.
+        The code in <xref ref="l-exercisegroup">Listing</xref>
+        produces the output seen in <xref ref="ch-sample-exercises">Exercises</xref>.
+      </p>
+    </section>
+
+    <xi:include href="exercisegroup.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-rename">
+    <title>Renaming Elements</title>
+    <p>
+      The preceding sections have provided a lengthy list of <pretext /> tags that behave interchangeably.
+      Perhaps you don't like one of their names.
+      If your project will not involve any <c>algorithm</c>s, but you need another theorem-like tag whose name you would like to have rendered as <q>Porism</q>.
+      To do this, you need to add a <c>rename</c> tag to the <c>docinfo</c> block of your code.
+      For our example,
+      the necessary code would be <c>&lt;rename element="algorithm"&gt;Porism&lt;/rename&gt;</c>.
+      The <c>rename</c> tag generates a <em>global</em> change;
+      it is not possible to rename a single instance of a tag or to define your own tags (without writings your own <init>XSLT</init> code.
+    </p>
+
+    <p>
+      We have included this <c>rename</c> code in this project's <c>docinfo</c>,
+      and as such,
+      we can do the following.
+    </p>
+
+    <listing xml:id="l-porism">
+      <caption>A porism generated using <c>algorithm</c> and <c>rename</c></caption>
+
+<program>
+<input><xi:include href="porism.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-porism" /> produces the following output:
+    </p>
+
+    <xi:include href="porism.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-webwork">
+    <title><webwork /> Exercises</title>
+    <p>
+      It is possible to embed
+      <webwork /> exercises into a <pretext /> document.
+      In the <init>HTML</init> version,
+      readers can answer these exercises and find out if their answer is correct or incorrect.
+      However, results of
+      <webwork /> exercises cannot be recorded to your gradebook.
+      There's some configuration required use
+      <webwork />.
+      Please see <xref ref="webwork-author"/> and <xref ref="webwork-publisher"/> for more details.
+      As soon as you add
+      <webwork /> exercises,
+      compiling to produce any output format becomes a multistep process.
+    </p>
+
+    <p>
+      When a
+      <webwork /> exercise lives on the server, the code takes one form.
+    </p>
+
+    <listing xml:id="l-webwork-opl">
+      <caption>A
+      <webwork /> exercise living on the server</caption>
+
+<program>
+<input><xi:include href="webwork-opl.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-webwork-opl" /> produces the following output:
+    </p>
+
+    <xi:include href="webwork-opl.ptx" />
+
+    <p>
+      It is also possible to code
+      <webwork /> exercises directly in your <pretext /> source.
+      This shows the most primitive sort of such exercise.
+      The section of the <pubtitle>Author's Guide</pubtitle> referenced above goes into greater detail
+      (<xref ref="webwork-author"/>).
+    </p>
+
+    <listing xml:id="l-webwork-code">
+      <caption>A simple
+      <webwork /> exercise coded in <pretext /> source</caption>
+
+<program>
+<input><xi:include href="webwork-code.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-webwork-code" /> produces the following output:
+    </p>
+
+    <xi:include href="webwork-code.ptx" />
+  </chapter>
+
+  <chapter xml:id="ch-fig">
+    <title>Figures and Friends</title>
+    <section xml:id="s-fig">
+      <title><c>figure</c></title>
+      <p>
+        The gold standard for graphics to include in <pretext /> documents is, well,
+        complicated.
+        If you're only working with <init>HTML</init> output,
+        then <init>SVG</init> is what you want.
+        If you're producing <init>PDF</init> by using <latex />,
+        then you'll also want <init>PDF</init> graphics files.
+        Fortunately,
+        it's not too hard to convert between these formats on the command line.<fn>
+        Windows users have run into some problems in this area.
+        Since conversion is a rare task,
+        it may be easiest to do in a cloud environment like CoCalc.
+        </fn> Just be sure to keep track of which file type is your master file and which file type is produced from the other.
+        <init>PNG</init> is also supported by modern web browsers and <latex />,
+        so that's a good option when vector graphic formats like <init>SVG</init> and <init>PDF</init> are not available or appropriate.
+      </p>
+
+      <listing xml:id="l-figure">
+        <caption>Code to include a figure</caption>
+
+<program>
+<input><xi:include href="figure.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-figure" /> produces the following output:
+      </p>
+
+      <xi:include href="figure.ptx" />
+
+      <p>
+        Note that the path to the image file does not include the file extension.
+        When you run <c>xsltproc</c>,
+        the output format you're generating will determine what gets added on so that the right file is grabbed.
+        If your browser says it can't find the image file,
+        make sure that the <init>SVG</init> file is in the correct location relative to the <init>HTML</init> file.
+        Here, we need a directory called <c>images</c> that lives next to our <init>HTML</init> files with a file called <c>small_graph.svg</c> inside that directory.
+        If using a <init>PNG</init> file,
+        put the extension in the filename so that the file is used in both <init>HTML</init> and <latex />.
+      </p>
+    </section>
+
+    <section xml:id="s-sidebyside">
+      <title><c>sidebyside</c></title>
+      <p>
+        One of the more complex pieces of code in <pretext />,
+        by most accounts, is that used for positioning objects
+        (usually figures)
+        next to each other.
+        If you've tried to do this in <latex />, you know that it can be challenging on a good day.
+        Fortunately,
+        <pretext /> does the heavy lifting for us here for both <latex /> and <init>HTML</init>.
+      </p>
+
+      <p>
+        We include two examples here.
+        The first places the <c>sidebyside</c> directly in the current division and places a <c>figure</c> with a caption inside the <c>sidebyside</c>.
+        The second puts the <c>sidebyside</c> inside <c>figure</c> and then uses an <c>image</c> not contained in a <c>figure</c> to include the graphic.
+        It's possible to do all sorts of nesting and get nice subnumbering automatically.
+        The sample article demonstrates all the capabilities of <c>sidebyside</c>.
+      </p>
+
+      <listing xml:id="l-sbs">
+        <caption>Code to place things side by side</caption>
+
+<program>
+<input><xi:include href="sidebyside.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-sbs" /> produces the following output:
+      </p>
+
+      <xi:include href="sidebyside.ptx" />
+
+      <listing xml:id="l-sbs2">
+        <caption>A few more bells and whistles for <c>sidebyside</c></caption>
+
+<program>
+<input><xi:include href="sidebyside2.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-sbs2" /> produces the following output:
+      </p>
+
+      <xi:include href="sidebyside2.ptx" />
+
+      <p>
+        Another use for <c>sidebyside</c> occurs when you want to center a graphc or tabular environment
+        (or a number of other things)
+        on a line by itself but without a <c>caption</c> and number.
+      </p>
+
+      <p>
+        It is also possible to create a group of <c>sidebyside</c> tags with common <c>@widths</c> by using the <c>sbsgroup</c> tag.
+      </p>
+
+      <listing xml:id="l-sbsgroup">
+        <caption>Use of <c>sbsgroup</c></caption>
+
+<program>
+<input><xi:include href="sbsgroup.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-sbsgroup" /> produces the following output:
+      </p>
+
+      <xi:include href="sbsgroup.ptx" />
+    </section>
+
+    <section xml:id="s-latex-fig">
+      <title><latex />-generated images</title>
+      <p>
+        <pretext /> makes it straightforward to embed <latex /> code that produces images
+        (such as TikZ)
+        into your source files. <c>xsltproc</c> basically just dumps your code out to your <latex /> file so that it compiles nicely.
+        However, for <init>HTML</init> display,
+        you will need <init>SVG</init> graphic files.
+        This is where the <c>mbx</c> script comes in.
+        Running the <c>mbx</c> script frequently requires patience,
+        particularly on Windows,
+        so settle in with an experienced user before attempting the steps in this subsection.
+      </p>
+      <aside>
+        <title>The <c>mbx</c> script</title>
+        <p>
+          The <c>mbx</c> script has a number of prerequisites to use its full power.
+          As a baseline, <c>python</c> is required.
+          (Both version 2 and version 3 are generally supported.)
+          This comes pretty much by default with Mac, Linux,
+          and CoCalc/cloud environments,
+          and so they tend to work better than Windows.
+          If you're a Windows user who just needs one graphic produced quickly,
+          consider going with CoCalc on a temporary basis.
+          It is definitely possible to have a fully functional configuration for the <c>mbx</c> script on Windows,
+          and the <pretext /> support email list will provide plenty of assistance when you get stuck.
+        </p>
+
+        <p>
+          In addition to <c>python</c>,
+          you will need a working <latex /> installation
+          (with Ghostscript,
+          which can sometimes be the source of configuration headaches for Windows users)
+          to make graphics from TikZ
+          (or similar)
+          code to include in your <c>HTML</c> pages. <c>pdf2svg</c> is also a piece of the toolchain that may need to be installed separately,
+          including on macOS. To generate graphics using SageMath,
+          you'll need a working installation of it with a proper configuration of its path in the <c>mbx.cfg</c> file.
+          Linux and CoCalc can probably get away without extra configuration here,
+          but it will likely be required on macOS and Windows unless you've set up your SageMath install so you can run it from the command line by simply executing <c>sage</c>.
+        </p>
+      </aside>
+      <p>
+        Our example here just illustrates using TikZ to make a simple figure
+        (the Hasse diagram of a poset),
+        but lots of other <latex /> graphics packages can be used.
+        One step required is to put
+      </p>
+
+<pre>
 &lt;latex-image-preamble&gt;
-    \usepackage{tikz}
+\usepackage{tikz}
 &lt;/latex-image-preamble&gt;
-                </pre>
-                <p>
-                    in the <c>docinfo</c> tag of your main file. <c>latex-image-preamble</c> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext /> source. Macros that you wish to use more broadly should be put inside <c>macros</c> inside <c>docinfo</c>.
-                </p>
-                <listing xml:id="l-tikz">
-                <caption>How to use <c>latex-image</c> to invoke TikZ</caption>
-                <program>
-                    <input><xi:include href="tikz.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-tikz" /> produces the following output:</p>
-            <xi:include href="tikz.ptx" />
-            <p>Well, that's not 100% true for <init>HTML</init>. If you just run <c>xsltproc</c>, your browser will display an error message about not being able to find the graphic file, since it doesn't exist. To generate the image, we have to run the <c>mbx</c> script.<fn>Will the script someday be renamed the <c>ptx</c> script? Tune in again next time to find out!</fn> To do this, on the command line we run the following command (on a single line). </p>
-            <sidebyside widths="80%" margins="10% 10%">
-                <pre>[path to mathbook]/script/mbx -c latex-image -f svg
-                -d ./images [path to PTX source file]</pre>
-            </sidebyside>
-            <p>This command assumes that we're in the directory where we usually run <c>xsltproc</c> to produce our <init>HTML</init> and that we want to put the images in a directory called <c>images</c> inside that directory.</p>
-            </section>
-        </chapter>
-        <chapter xml:id="ch-table">
-            <title>Tables</title>
-            <idx>tables</idx>
-            <p>After <c>sidebyside</c>, getting tables to lay out consistently between <init>HTML</init> and <init>PDF</init> is probably the second biggest headache that <pretext /> takes care of for us behind the scenes. Lots of effort has been taken in order to fix some of the challenges inherent to working with the <c>tabular</c> environment in <latex />, and so if you author in <pretext />, you should be able to forget the hacks you had to learn to make nice tables in <latex />.
-            </p>
-            <p><idx><h>table</h><h>not for visual layout</h></idx><idx><h>table</h><h>not for visual layout</h><seealso>side-by-side group</seealso></idx><alert>Tables should only be used to display data.</alert> Too often in other authoring systems, tables are used as a crutch to facilitate the visual layout of a page. Do <em>not</em> do that when authoring <pretext />. A good question to ask yourself before using a <c>tabular</c> is <q>Do the <m>xy</m>-coordinates of a cell have semantic meaning in terms of my data?</q> If the answer is <q>yes</q>, then make a table with <c>tabular</c>. If not, find a more suitable tag. (Perhaps <c>sidebyside</c> and/or <c>sbsgroup</c>.) One of the many reasons for this is that screen readers used by individuals with visual impairments read tables in a very specific way that assumes the <m>xy</m>-coordinates of each cell are contributing to the meaning. Individuals who use screen readers will find a document that uses tables to do something other than present tabular data very confusing and frustrating.</p>
-            <listing xml:id="l-table">
-                <caption>Code to produce a table</caption>
-                <idx>tables</idx>
-                <idx><h>tables</h><h><pretext/> code</h></idx>
-                <idx><h><pretext/> code</h><h>tables</h></idx>
-                <idx><h>caption</h><h>of a table</h></idx>
-                <idx><h>tables</h><h>caption</h></idx>
-                <idx>tabular</idx>
-                <idx><h>row</h><h>of a table</h></idx>
-                <idx><h>cell</h><h>of a table</h></idx>
-                <idx><h>entry of a table</h><see>cell</see></idx>
-                <program>
-                    <input><xi:include href="table.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-table" /> produces the following output:</p>
-            <xi:include href="table.ptx" />
-            <p>
-                <idx><h>column</h><h>of a table</h></idx>
-            See <xref ref="topic-tabular"/> for more information about how to make more complicated tables including formatting columns and vertical and horizontal rules.</p>
-        </chapter>
-        <chapter xml:id="ch-sage">
-            <title>SageMath Content</title>
-            <section xml:id="s-sage-cell">
-                <title>SageMathCells</title>
-                <p>Including computational SageMath cells is pretty easy with <c>sage</c>, <c>input</c>, and <c>output</c>. The last tag is useful for producing a <init>PDF</init> that includes the result of the code's execution.</p>
-                <listing xml:id="l-sage">
-                <caption>SageMath cell</caption>
-                <program>
-                    <input><xi:include href="sage.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>The code in <xref ref="l-sage" /> produces the following output:</p>
-            <xi:include href="sage.ptx" />
-            <p>SageMathCells on a single <init>HTML</init> page are automatically linked so that a cell can use the results of computations done in earlier cells on the same page. </p>
-            </section>
-            <section xml:id="s-sageplot">
-                <title><c>sageplot</c></title>
-                <p>
-                    Sometimes you don't want to provide an interactive SageMath environment in the middle of your book (or a chunk of code) but you would like to produce a figure to include in your project by using SageMath. The cleanest way to do this his to put the SageMath code right in your <pretext /> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats. This is accomplished by using <c>sageplot</c> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig" />. (In particular, see the aside in that subsection about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
-                </p>
-                <listing xml:id="l-sageplot">
-                <caption><c>sageplot</c> to produce a graphic</caption>
-                <program>
-                    <input><xi:include href="sageplot.ptx" parse="text"/></input>
-                </program>
-            </listing>
-            <p>We need to run the <c>mbx</c> script to actually make the image files required. If you want to make both <init>HTML</init> and <init>PDF</init> via <latex />, you'll need to run it twice. The first command below (again, enter on one line) makes the <init>SVG</init> to use on the web, and the second makes what you need for <latex />. There is an <c>all</c> option that can be passed after <c>-f</c> instead of <c>svg</c> or <c>pdf</c>, but that is more likely to raise errors because some source code cannot produce certain output formats. It's best to stay away from error-producing steps until you're comfortable with debugging your system.</p>
-            <sidebyside widths="80%" margins="10% 10%">
-                <pre>[path to mathbook]/script/mbx -c sageplot -f svg
-                -d ./images [path to PTX source file]</pre>
-            </sidebyside>
-            <sidebyside widths="80%" margins="10% 10%">
-                <pre>[path to mathbook]/script/mbx -c sageplot -f pdf
-                -d ./images [path to PTX source file]</pre>
-            </sidebyside>
-            <p>The code in <xref ref="l-sageplot" /> produces the following output.</p>
-            <xi:include href="sageplot.ptx" />
-            </section>
-        </chapter>
-        <chapter xml:id="ch-small">
-            <title>Small, But Useful</title>
-            <introduction>
-                <p>The topics in this section are not terribly structural or critical, but they fall in the category of <q>little things you want to do right from the outset</q>.</p>
-            </introduction>
-            <section xml:id="s-xref">
-                <title>Cross references</title>
-                <p><pretext /> provides a robust set of features for internal cross referencing. If you're familiar with <latex />, the equivalent of <c>\label</c> is to use an <c>xml:id</c>. For example, the opening tag for this subsection is <c>&lt;subsection xml:id="s-xref"&gt;</c>. Instead of the <c>\ref</c> used by <latex />, we use <c>xref</c> in <pretext />. So we can type <c>&lt;xref ref="s-xref" /&gt;</c> to create a reference to this subsection: <xref ref="s-xref" />. There are lots of options to control what text and number appear when you use <c>xref</c>. The default is the <c>type-gobal</c> option, which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>. The type is <q>Subsection</q> or <q>Theorem</q>, and the <em>global</em> number is 3.3 or 3.1.4. (Global is in contrast to local, which would be just 3 or 4, reespectively, for these examples.) The <pubtitle>Author's Guide</pubtitle> (<xref ref="topic-cross-referencing"/>) goes into greater detail about how to change settings for how cross references appear, which you can do for your entire document as well as for individual cross references that require different treatment.</p>
-            </section>
-            <section>
-                <title>External links</title>
-                <p>
-                    If you want to provide a link to a resource outside of your project, you will want the <c>url</c> tag. The code <c>&lt;url href="https://pretextbook.org" /&gt;</c> produces <url href="https://pretextbook.org" />.</p>
-                <p>Extensive details are provided in <xref ref="topic-url"/>.
-                </p>
-            </section>
-            <section xml:id="s-fn">
-                <title>Footnotes and asides</title>
-                <idx>footnote</idx>
-                <idx><c>fn</c> tag</idx>
-                <p>Footnotes are not too hard, just use <c>fn</c>, but note that for the time being, what can go inside a footnote is very, very restricted.<fn>This is a sample footnote, just so you can see how one looks.</fn> For instance, you can't put a <c>p</c> (and thus you can't put lists) inside a footnote. Also, no displayed math via <c>me</c>. This might change, but there's a lot of care being taken because of the prospect of footnotes inside footnotes inside footnotes.<idx><h>footnote</h><h>restrictions</h></idx></p>
-                <p>Because of the restrictions on footnotes, it is important to keep them short. A good alternative for longer things that are somewhat digressional is the <term>aside</term><idx>aside</idx>, which comes in three flavors: <c>aside</c>, <c>biographical</c>, <c>historical</c><idx><h>historical</h><see>aside</see></idx><idx><h>biographical</h><see>aside</see></idx>. Each of these allows an optional title and then a variety of tags such as <c>p</c>, <c>figure</c>, and <c>sidebyside</c> (and many more).
-                </p>
-                <listing xml:id="l-aside">
-                    <caption>A sample <c>aside</c></caption>
-                    <idx><h>aside</h><h><pretext/> code</h></idx>
-                    <program>
-                        <input><xi:include href="aside.ptx" parse="text"/></input>
-                    </program>
-                </listing>
-                <p>The code in <xref ref="l-aside" /> produces the aside <q>A Sample Aside</q>. A less contrived example of an aside can be found in <xref ref="s-latex-fig" />.
-                </p>
-                <xi:include href="aside.ptx" />
-            </section>
-            <section xml:id="s-idx">
-                <title>Index entries</title>
-                <p><pretext /> does a good job of supporting index generation. You still need to tag everything that should get an index entry by hand, but then the index is produced automatically. For a simple index entry for the word <q>group</q>, you just use <c>&lt;idx&gt;group&lt;idx&gt;</c>. If you need an index entry involving subheadings, such as <q>normal</q> under <q>subgroup</q>, use <c>&lt;idx&gt;&lt;h&gt;subgroup&lt;/h&gt;&lt;h&gt;normal&lt;/h&gt;&lt;idx&gt;</c>. It is also possible to use <q>see</q> and <q>see also</q> entries for indices. For instance, in <xref ref="ch-basic-formatting" />, we use <c>            &lt;idx&gt;&lt;h&gt;font&lt;/h&gt;&lt;see&gt;formatting&lt;/see&gt;&lt;/idx&gt;</c> to create an index entry for <q>font</q> that instructs the reader to <q><em>see </em> formatting</q>.</p>
-                <p>If you generate <latex /> output, the index is generated without any additional passes beyond the usual two required to get references correct.</p>
-            </section>
-            <section>
-                <title>Quotations</title>
-                <idx>quotations</idx>
-                <p>To ensure that quotation marks are poperly typeset, it is important to use the correct <pretext /> code. To set something off in double quotes, use the <c>q</c> tag around what should appear in quotes. It will supply both the opening and closing quotation marks, as in: <q>This is a quotation.</q> If you need single quotes, use <c>sq</c>. Because the content of <c>q</c> and <c>sq</c> is quite restricted, you may find yourself needing to explicitly access the left and right single and double quotation marks. They are, quite sensibly, <c>lq</c>, <c>rq</c>, <c>lsq</c>, and <c>rsq</c>.
-                <idx><h>quote</h><h>single</h></idx>
-                <idx><h>quote</h><h>double</h></idx>
-                </p>
-                <p>Longer quotes are best set off using <c>blockquote</c></p>
-                <listing xml:id="l-blockquote">
-                    <caption>A sample <c>blockquote</c></caption>
-                    <idx><h>blockquote</h><h><pretext/> code</h></idx>
-                    <program>
-                        <input><xi:include href="blockquote.ptx" parse="text"/></input>
-                    </program>
-                </listing>
-                <p>The code in <xref ref="l-blockquote" /> produces the quotation below.
-                </p>
-                <xi:include href="blockquote.ptx" />
-            </section>
-        </chapter>
-        <chapter>
-            <title>Modular Source</title>
-            <p>Once a project gets big, you may find yourself wishing to break your source into multiple files. This is well documented in the <xref ref="processing-modular"/>, so we refer you there for more details.</p>
-        </chapter>
+</pre>
+
+      <p>
+        in the <c>docinfo</c> tag of your main file. <c>latex-image-preamble</c> is used to set up the preamble that should be used for making <init>SVG</init> images from your <pretext /> source.
+        Macros that you wish to use more broadly should be put inside <c>macros</c> inside <c>docinfo</c>.
+      </p>
+
+      <listing xml:id="l-tikz">
+        <caption>How to use <c>latex-image</c> to invoke TikZ</caption>
+
+<program>
+<input><xi:include href="tikz.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-tikz" /> produces the following output:
+      </p>
+
+      <xi:include href="tikz.ptx" />
+
+      <p>
+        Well, that's not 100% true for <init>HTML</init>.
+        If you just run <c>xsltproc</c>,
+        your browser will display an error message about not being able to find the graphic file,
+        since it doesn't exist.
+        To generate the image,
+        we have to run the <c>mbx</c> script.<fn>
+        Will the script someday be renamed the <c>ptx</c> script?
+        Tune in again next time to find out!
+        </fn> To do this, on the command line we run the following command
+        (on a single line).
+      </p>
+
+      <sidebyside widths="80%" margins="10% 10%">
+
+<pre>[path to mathbook]/script/mbx -c latex-image -f svg
+-d ./images [path to PTX source file]</pre>
+      </sidebyside>
+
+      <p>
+        This command assumes that we're in the directory where we usually run <c>xsltproc</c> to produce our <init>HTML</init> and that we want to put the images in a directory called <c>images</c> inside that directory.
+      </p>
+    </section>
+  </chapter>
+
+  <chapter xml:id="ch-table">
+    <title>Tables</title>
+    <idx>tables</idx>
+
+    <p>
+      After <c>sidebyside</c>,
+      getting tables to lay out consistently between <init>HTML</init> and <init>PDF</init> is probably the second biggest headache that <pretext /> takes care of for us behind the scenes.
+      Lots of effort has been taken in order to fix some of the challenges inherent to working with the <c>tabular</c> environment in <latex />, and so if you author in <pretext />,
+      you should be able to forget the hacks you had to learn to make nice tables in <latex />.
+    </p>
+
+    <p>
+          <idx><h>table</h><h>not for visual layout</h></idx>
+          <idx><h>table</h><h>not for visual layout</h><seealso>side-by-side group</seealso></idx><alert>Tables should only be used to display data.</alert> Too often in other authoring systems, tables are used as a crutch to facilitate the visual layout of a page.
+      Do <em>not</em> do that when authoring <pretext />.
+      A good question to ask yourself before using a <c>tabular</c> is
+      <q>Do the <m>xy</m>-coordinates of a cell have semantic meaning in terms of my data?</q>
+      If the answer is <q>yes</q>,
+      then make a table with <c>tabular</c>.
+      If not, find a more suitable tag.
+      (Perhaps <c>sidebyside</c> and/or <c>sbsgroup</c>.)
+      One of the many reasons for this is that screen readers used by individuals with visual impairments read tables in a very specific way that assumes the <m>xy</m>-coordinates of each cell are contributing to the meaning.
+      Individuals who use screen readers will find a document that uses tables to do something other than present tabular data very confusing and frustrating.
+    </p>
+
+    <listing xml:id="l-table">
+      <caption>Code to produce a table</caption>
+      <idx>tables</idx>
+      <idx><h>tables</h><h><pretext/> code</h></idx>
+      <idx><h><pretext/> code</h><h>tables</h></idx>
+      <idx><h>caption</h><h>of a table</h></idx>
+      <idx><h>tables</h><h>caption</h></idx>
+      <idx>tabular</idx>
+      <idx><h>row</h><h>of a table</h></idx>
+      <idx><h>cell</h><h>of a table</h></idx>
+      <idx><h>entry of a table</h><see>cell</see></idx>
+<program>
+<input><xi:include href="table.ptx" parse="text"/></input>
+</program>
+    </listing>
+
+    <p>
+      The code in <xref ref="l-table" /> produces the following output:
+    </p>
+
+    <xi:include href="table.ptx" />
+
+    <p>
+          <idx><h>column</h><h>of a table</h></idx>
+      See <xref ref="topic-tabular"/> for more information about how to make more complicated tables including formatting columns and vertical and horizontal rules.
+    </p>
+  </chapter>
+
+  <chapter xml:id="ch-sage">
+    <title>SageMath Content</title>
+    <section xml:id="s-sage-cell">
+      <title>SageMathCells</title>
+      <p>
+        Including computational SageMath cells is pretty easy with <c>sage</c>, <c>input</c>,
+        and <c>output</c>.
+        The last tag is useful for producing a <init>PDF</init> that includes the result of the code's execution.
+      </p>
+
+      <listing xml:id="l-sage">
+        <caption>SageMath cell</caption>
+
+<program>
+<input><xi:include href="sage.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-sage" /> produces the following output:
+      </p>
+
+      <xi:include href="sage.ptx" />
+
+      <p>
+        SageMathCells on a single <init>HTML</init> page are automatically linked so that a cell can use the results of computations done in earlier cells on the same page.
+      </p>
+    </section>
+
+    <section xml:id="s-sageplot">
+      <title><c>sageplot</c></title>
+      <p>
+        Sometimes you don't want to provide an interactive SageMath environment in the middle of your book
+        (or a chunk of code)
+        but you would like to produce a figure to include in your project by using SageMath.
+        The cleanest way to do this his to put the SageMath code right in your <pretext /> project and use the <c>mbx</c> script to produce the image files required for your chosen output formats.
+        This is accomplished by using <c>sageplot</c> and the <c>mbx</c> script that we discussed in <xref ref="s-latex-fig" />.
+        (In particular,
+        see the aside in that subsection about the additional packages that must be installed and configured to use the <c>mbx</c> script.)
+      </p>
+
+      <listing xml:id="l-sageplot">
+        <caption><c>sageplot</c> to produce a graphic</caption>
+
+<program>
+<input><xi:include href="sageplot.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        We need to run the <c>mbx</c> script to actually make the image files required.
+        If you want to make both <init>HTML</init> and <init>PDF</init> via <latex />, you'll need to run it twice.
+        The first command below (again,
+        enter on one line) makes the <init>SVG</init> to use on the web,
+        and the second makes what you need for <latex />.
+        There is an <c>all</c> option that can be passed after <c>-f</c> instead of <c>svg</c> or <c>pdf</c>,
+        but that is more likely to raise errors because some source code cannot produce certain output formats.
+        It's best to stay away from error-producing steps until you're comfortable with debugging your system.
+      </p>
+
+      <sidebyside widths="80%" margins="10% 10%">
+
+<pre>[path to mathbook]/script/mbx -c sageplot -f svg
+-d ./images [path to PTX source file]</pre>
+      </sidebyside>
+
+      <sidebyside widths="80%" margins="10% 10%">
+
+<pre>[path to mathbook]/script/mbx -c sageplot -f pdf
+-d ./images [path to PTX source file]</pre>
+      </sidebyside>
+
+      <p>
+        The code in <xref ref="l-sageplot" /> produces the following output.
+      </p>
+
+      <xi:include href="sageplot.ptx" />
+    </section>
+  </chapter>
+
+  <chapter xml:id="ch-small">
+    <title>Small, But Useful</title>
+    <introduction>
+      <p>
+        The topics in this section are not terribly structural or critical,
+        but they fall in the category of
+        <q>little things you want to do right from the outset</q>.
+      </p>
+    </introduction>
+
+    <section xml:id="s-xref">
+      <title>Cross references</title>
+      <p>
+        <pretext /> provides a robust set of features for internal cross referencing.
+        If you're familiar with <latex />,
+        the equivalent of <c>\label</c> is to use an <c>xml:id</c>.
+        For example,
+        the opening tag for this subsection is <c>&lt;subsection xml:id="s-xref"&gt;</c>.
+        Instead of the <c>\ref</c> used by <latex />,
+        we use <c>xref</c> in <pretext />.
+        So we can type <c>&lt;xref ref="s-xref" /&gt;</c> to create a reference to this subsection:
+        <xref ref="s-xref" />.
+        There are lots of options to control what text and number appear when you use <c>xref</c>.
+        The default is the <c>type-gobal</c> option,
+        which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>.
+        The type is <q>Subsection</q> or <q>Theorem</q>,
+        and the <em>global</em> number is 3.3 or 3.1.4. (Global is in contrast to local,
+        which would be just 3 or 4, reespectively,
+        for these examples.) The <pubtitle>Author's Guide</pubtitle>
+        (<xref ref="topic-cross-referencing"/>)
+        goes into greater detail about how to change settings for how cross references appear,
+        which you can do for your entire document as well as for individual cross references that require different treatment.
+      </p>
+    </section>
+
+    <section>
+      <title>External links</title>
+      <p>
+        If you want to provide a link to a resource outside of your project,
+        you will want the <c>url</c> tag.
+        The code <c>&lt;url href="https://pretextbook.org" /&gt;</c> produces <url href="https://pretextbook.org" />.
+      </p>
+
+      <p>
+        Extensive details are provided in <xref ref="topic-url"/>.
+      </p>
+    </section>
+
+    <section xml:id="s-fn">
+      <title>Footnotes and asides</title>
+      <idx>footnote</idx>
+      <idx><c>fn</c> tag</idx>
+
+      <p>
+        Footnotes are not too hard,
+        just use <c>fn</c>,
+        but note that for the time being,
+        what can go inside a footnote is very, very restricted.<fn>
+        This is a sample footnote, just so you can see how one looks.
+        </fn> For instance,
+        you can't put a <c>p</c> (and thus you can't put lists) inside a footnote.
+        Also, no displayed math via <c>me</c>.
+        This might change,
+        but there's a lot of care being taken because of the prospect of footnotes inside footnotes inside footnotes.
+            <idx><h>footnote</h><h>restrictions</h></idx>
+      </p>
+
+      <p>
+        Because of the restrictions on footnotes,
+        it is important to keep them short.
+        A good alternative for longer things that are somewhat digressional is the <term>aside</term>,
+            <idx>aside</idx>
+        which comes in three flavors: <c>aside</c>, <c>biographical</c>, <c>historical</c>.
+            <idx><h>historical</h><see>aside</see></idx>
+            <idx><h>biographical</h><see>aside</see></idx>
+        Each of these allows an optional title and then a variety of tags such as <c>p</c>, <c>figure</c>,
+        and <c>sidebyside</c> (and many more).
+      </p>
+
+      <listing xml:id="l-aside">
+        <caption>A sample <c>aside</c></caption>
+        <idx><h>aside</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="aside.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-aside" /> produces the aside <q>A Sample Aside</q>.
+        A less contrived example of an aside can be found in <xref ref="s-latex-fig" />.
+      </p>
+
+      <xi:include href="aside.ptx" />
+    </section>
+
+    <section xml:id="s-idx">
+      <title>Index entries</title>
+      <p>
+        <pretext /> does a good job of supporting index generation.
+        You still need to tag everything that should get an index entry by hand,
+        but then the index is produced automatically.
+        For a simple index entry for the word <q>group</q>,
+        you just use <c>&lt;idx&gt;group&lt;idx&gt;</c>.
+        If you need an index entry involving subheadings,
+        such as <q>normal</q> under <q>subgroup</q>,
+        use <c>&lt;idx&gt;&lt;h&gt;subgroup&lt;/h&gt;&lt;h&gt;normal&lt;/h&gt;&lt;idx&gt;</c>.
+        It is also possible to use <q>see</q>
+        and <q>see also</q> entries for indices.
+        For instance, in <xref ref="ch-basic-formatting" />,
+        we use <c>            &lt;idx&gt;&lt;h&gt;font&lt;/h&gt;&lt;see&gt;formatting&lt;/see&gt;&lt;/idx&gt;</c> to create an index entry for <q>font</q>
+        that instructs the reader to <q><em>see </em> formatting</q>.
+      </p>
+
+      <p>
+        If you generate <latex /> output,
+        the index is generated without any additional passes beyond the usual two required to get references correct.
+      </p>
+    </section>
+
+    <section>
+      <title>Quotations</title>
+      <idx>quotations</idx>
+
+      <p>
+        To ensure that quotation marks are poperly typeset,
+        it is important to use the correct <pretext /> code.
+        To set something off in double quotes,
+        use the <c>q</c> tag around what should appear in quotes.
+        It will supply both the opening and closing quotation marks, as in:
+        <q>This is a quotation.</q> If you need single quotes,
+        use <c>sq</c>.
+        Because the content of <c>q</c> and <c>sq</c> is quite restricted,
+        you may find yourself needing to explicitly access the left and right single and double quotation marks.
+        They are, quite sensibly, <c>lq</c>, <c>rq</c>, <c>lsq</c>,
+        and <c>rsq</c>.
+            <idx><h>quote</h><h>single</h></idx>
+            <idx><h>quote</h><h>double</h></idx>
+      </p>
+
+      <p>
+        Longer quotes are best set off using <c>blockquote</c>
+      </p>
+
+      <listing xml:id="l-blockquote">
+        <caption>A sample <c>blockquote</c></caption>
+        <idx><h>blockquote</h><h><pretext/> code</h></idx>
+<program>
+<input><xi:include href="blockquote.ptx" parse="text"/></input>
+</program>
+      </listing>
+
+      <p>
+        The code in <xref ref="l-blockquote" /> produces the quotation below.
+      </p>
+
+      <xi:include href="blockquote.ptx" />
+    </section>
+  </chapter>
+
+  <chapter>
+    <title>Modular Source</title>
+    <p>
+      Once a project gets big,
+      you may find yourself wishing to break your source into multiple files.
+      This is well documented in the <xref ref="processing-modular"/>, so we refer you there for more details.
+    </p>
+  </chapter>
 </part>
+

--- a/doc/guide/basics/blockquote.ptx
+++ b/doc/guide/basics/blockquote.ptx
@@ -1,18 +1,17 @@
+
+
 <blockquote>
-    <title>Lorem ipsum</title>
-    <p>
-        <q>Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad
-        minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur.
-        Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id
-        est laborum.</q>
-    </p>
-    <attribution>
-        Anonymous
-    </attribution>
+  <title>Lorem ipsum</title>
+  <p>
+    <q>Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit,
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident,
+    sunt in culpa qui officia deserunt mollit anim id est laborum.</q>
+  </p>
+  <attribution>Anonymous</attribution>
 </blockquote>
+

--- a/doc/guide/basics/definition.ptx
+++ b/doc/guide/basics/definition.ptx
@@ -1,11 +1,17 @@
+
+
 <definition>
-    <notation>
-        <usage>\binom{n}{k}</usage>
-        <description>binomial coefficient</description>
-    </notation>
-    <statement>
-        <p>The <term>binomial coefficient</term> <m>\binom{n}{k}</m>
-        is the number of <m>k</m>-element subsets of an
-        <m>n</m>-element set.</p>
-    </statement>
+
+  <notation>
+    <usage>\binom{n}{k}</usage>
+    <description>binomial coefficient</description>
+  </notation>
+
+  <statement>
+    <p>
+      The <term>binomial coefficient</term>
+      <m>\binom{n}{k}</m> is the number of <m>k</m>-element subsets of an <m>n</m>-element set.
+    </p>
+  </statement>
 </definition>
+

--- a/doc/guide/basics/example-simple.ptx
+++ b/doc/guide/basics/example-simple.ptx
@@ -1,8 +1,10 @@
+
+
 <example>
-    <title>Differentiating a polynomial</title>
-    <p>
-        The derivative of the function
-        <m>f(x) = 3x^5-7x+5</m> is
-        <m>f'(x) = 15x^4-7</m>.
-    </p>
+  <title>Differentiating a polynomial</title>
+  <p>
+    The derivative of the function
+    <m>f(x) = 3x^5-7x+5</m> is <m>f'(x) = 15x^4-7</m>.
+  </p>
 </example>
+

--- a/doc/guide/basics/example-structured.ptx
+++ b/doc/guide/basics/example-structured.ptx
@@ -1,20 +1,22 @@
+
+
 <example>
-    <title>Differentiating a polynomial</title>
-    <statement>
-        <p>
-            Differentiate the function
-            <m>f(x) = 3x^5-7x+5</m>.
-        </p>
-    </statement>
-    <answer>
-        <p>
-            <m>f'(x) = 15x^4-7</m>
-        </p>
-    </answer>
-    <solution>
-        <p>We use the power, sum, and constant multiple
-        rules and find that the derivative is
-        <m>f'(x) = 15x^4-7</m>.
-        </p>
-    </solution>
+  <title>Differentiating a polynomial</title>
+  <statement>
+    <p>
+      Differentiate the function <m>f(x) = 3x^5-7x+5</m>.
+    </p>
+  </statement>
+  <answer>
+    <p>
+      <m>f'(x) = 15x^4-7</m>
+    </p>
+  </answer>
+  <solution>
+    <p>
+      We use the power, sum,
+      and constant multiple rules and find that the derivative is <m>f'(x) = 15x^4-7</m>.
+    </p>
+  </solution>
 </example>
+

--- a/doc/guide/basics/exercise.ptx
+++ b/doc/guide/basics/exercise.ptx
@@ -1,16 +1,28 @@
+
+
 <exercise>
-    <statement>
-        <p>
-            The <c>statement</c> is mandatory.
-        </p>
-    </statement>
-    <hint>
-        <p>Optional. Just an suggestion of what to try.</p>
-    </hint>
-    <answer>
-        <p>Optional. Just the <q>final answer</q>.</p>
-    </answer>
-    <solution>
-        <p>Optional. All the gory details.</p>
-    </solution>
+  <statement>
+    <p>
+      The <c>statement</c> is mandatory.
+    </p>
+  </statement>
+  <hint>
+    <p>
+      Optional.
+      Just an suggestion of what to try.
+    </p>
+  </hint>
+  <answer>
+    <p>
+      Optional.
+      Just the <q>final answer</q>.
+    </p>
+  </answer>
+  <solution>
+    <p>
+      Optional.
+      All the gory details.
+    </p>
+  </solution>
 </exercise>
+

--- a/doc/guide/basics/exercisegroup.ptx
+++ b/doc/guide/basics/exercisegroup.ptx
@@ -1,38 +1,48 @@
+
 <exercises xml:id="ch-sample-exercises">
-    <exercisegroup>
-        <introduction>
-            <p>Here's where you put the common instructions.
-            </p>
-        </introduction>
-        <exercise>
-            <statement>
-                <p>First exercise. The <c>statement</c> is
-                mandatory. You can add all the usual bells and
-                whistles after, but we'll keep it short here.
-                </p>
-            </statement>
-        </exercise>
-        <exercise>
-            <statement>
-                <p>
-                    Second exercise.
-                </p>
-            </statement>
-        </exercise>
-        <exercise>
-            <statement>
-                <p>
-                    Third exercise.
-                </p>
-            </statement>
-        </exercise>
-    </exercisegroup>
+  <exercisegroup>
+
+    <introduction>
+      <p>
+        Here's where you put the common instructions.
+      </p>
+    </introduction>
+
     <exercise>
-        <statement>
-            <p>
-                This <c>exercise</c> is not inside the
-                <c>exercisegroup</c>.
-            </p>
-        </statement>
+      <statement>
+        <p>
+          First exercise.
+          The <c>statement</c> is mandatory.
+          You can add all the usual bells and whistles after,
+          but we'll keep it short here.
+        </p>
+      </statement>
     </exercise>
+
+    <exercise>
+      <statement>
+        <p>
+          Second exercise.
+        </p>
+      </statement>
+    </exercise>
+
+    <exercise>
+      <statement>
+        <p>
+          Third exercise.
+        </p>
+      </statement>
+    </exercise>
+
+  </exercisegroup>
+
+  <exercise>
+    <statement>
+      <p>
+        This <c>exercise</c> is not inside the <c>exercisegroup</c>.
+      </p>
+    </statement>
+  </exercise>
+
 </exercises>

--- a/doc/guide/basics/exercisegroup.ptx
+++ b/doc/guide/basics/exercisegroup.ptx
@@ -1,5 +1,5 @@
 
-<exercises xml:id="ch-sample-exercises">
+<exercises xml:id="basics-s-sample-exercises">
   <exercisegroup>
 
     <introduction>

--- a/doc/guide/basics/figure.ptx
+++ b/doc/guide/basics/figure.ptx
@@ -1,6 +1,9 @@
+
+
 <figure xml:id="fig-graph">
-    <caption>A small graph (from <pubtitle>Applied
-    Combinatorics</pubtitle> by Keller and
-    Trotter)</caption>
-    <image source="images/small_graph" width="20%"/>
+  <caption>A small graph (from <pubtitle>Applied
+  Combinatorics</pubtitle> by Keller and
+  Trotter)</caption>
+  <image source="images/small_graph" width="20%"/>
 </figure>
+

--- a/doc/guide/basics/md.ptx
+++ b/doc/guide/basics/md.ptx
@@ -1,6 +1,9 @@
+
+
 <p>
-    <md>
-        <mrow>x \amp = r\cos\theta</mrow>
-        <mrow>y \amp = r\sin\theta</mrow>
-    </md>
+  <md>
+    <mrow>x \amp = r\cos\theta</mrow>
+    <mrow>y \amp = r\sin\theta</mrow>
+  </md>
 </p>
+

--- a/doc/guide/basics/me.ptx
+++ b/doc/guide/basics/me.ptx
@@ -1,4 +1,11 @@
+
+
 <p>
-    <me>\frac{d}{dx} \int_1^x \frac{1}{t}\, dt = \frac{1}{x}</me>
-    <men xml:id="eqn-ftc">\int_a^b f(x)\, dx = F(b) - F(a)</men>
+  <me>
+    \frac{d}{dx} \int_1^x \frac{1}{t}\, dt = \frac{1}{x}
+  </me>
+  <men xml:id="eqn-ftc">
+    \int_a^b f(x)\, dx = F(b) - F(a)
+  </men>
 </p>
+

--- a/doc/guide/basics/ol.ptx
+++ b/doc/guide/basics/ol.ptx
@@ -1,6 +1,15 @@
+
+
 <p>
-    <ol>
-        <li>First item.</li>
-        <li><p>Second item, showing can wrap content with <c>p</c>.</p></li>
-    </ol>
+  <ol>
+    <li>First item.</li>
+
+    <li>
+      <p>
+        Second item,
+        showing can wrap content with <c>p</c>.
+      </p>
+    </li>
+  </ol>
 </p>
+

--- a/doc/guide/basics/p.ptx
+++ b/doc/guide/basics/p.ptx
@@ -1,6 +1,8 @@
+
+
 <p>
-    This is a new <term>piece of terminology</term>. Here
-    is a word we have chosen to <em>emphasize</em>.
-    <alert>This is an alert to the reader!</alert> This is a
-    piece of <c>code</c>.
+  This is a new <term>piece of terminology</term>.
+  Here is a word we have chosen to <em>emphasize</em>.
+  <alert>This is an alert to the reader!</alert> This is a piece of <c>code</c>.
 </p>
+

--- a/doc/guide/basics/porism.ptx
+++ b/doc/guide/basics/porism.ptx
@@ -1,9 +1,16 @@
+
+
 <algorithm>
-    <statement>
-        <p>This is a short little ditty that follows
-        immediately from the previous proof.</p>
-    </statement>
-    <proof>
-        <p>We'll still include a proof though.</p>
-    </proof>
+  <statement>
+    <p>
+      This is a short little ditty that follows immediately from the previous proof.
+    </p>
+  </statement>
+
+  <proof>
+    <p>
+      We'll still include a proof though.
+    </p>
+  </proof>
 </algorithm>
+

--- a/doc/guide/basics/project.ptx
+++ b/doc/guide/basics/project.ptx
@@ -1,34 +1,55 @@
+
+
 <project>
-    <title>A structured project</title>
-    <introduction>
-        <p>Here is where we describe what the reader will
-        accomplish in the project.</p>
-    </introduction>
-    <task>
-        <statement>
-            <p>The first step to do.</p>
-        </statement>
-        <hint>
-            <p>A little hint.</p>
-        </hint>
-        <answer>
-            <p>Just the answer.</p>
-        </answer>
-        <solution>
-            <p>All the glorious details about how to do the
-            first step.</p>
-        </solution>
-    </task>
-    <task>
-        <statement>
-            <p>The second step to do. We'll be lazy and
-            just include an answer.</p>
-        </statement>
-        <answer>
-            <p>Just the answer.</p>
-        </answer>
-    </task>
-    <conclusion>
-        <p>A little wrap up.</p>
-    </conclusion>
+  <title>A structured project</title>
+  <introduction>
+    <p>
+      Here is where we describe what the reader will accomplish in the project.
+    </p>
+  </introduction>
+
+  <task>
+    <statement>
+      <p>
+        The first step to do.
+      </p>
+    </statement>
+    <hint>
+      <p>
+        A little hint.
+      </p>
+    </hint>
+    <answer>
+      <p>
+        Just the answer.
+      </p>
+    </answer>
+    <solution>
+      <p>
+        All the glorious details about how to do the first step.
+      </p>
+    </solution>
+  </task>
+
+  <task>
+    <statement>
+      <p>
+        The second step to do.
+        We'll be lazy and just include an answer.
+      </p>
+    </statement>
+    <answer>
+      <p>
+        Just the answer.
+      </p>
+    </answer>
+  </task>
+
+  <conclusion>
+    <p>
+      A little wrap up.
+    </p>
+  </conclusion>
+
 </project>
+

--- a/doc/guide/basics/remark.ptx
+++ b/doc/guide/basics/remark.ptx
@@ -1,7 +1,10 @@
+
+
 <remark>
-    <title>A little remark</title>
-    <p>
-        Remarks have restricted content, but they can be
-        used to call out lots of important things for your readers.
-    </p>
+  <title>A little remark</title>
+  <p>
+    Remarks have restricted content,
+    but they can be used to call out lots of important things for your readers.
+  </p>
 </remark>
+

--- a/doc/guide/basics/sage.ptx
+++ b/doc/guide/basics/sage.ptx
@@ -1,8 +1,8 @@
 <sage>
-    <input>
-        2+2
-    </input>
-    <output>
-        4
-    </output>
+<input>
+2+2
+</input>
+<output>
+4
+</output>
 </sage>

--- a/doc/guide/basics/sageplot.ptx
+++ b/doc/guide/basics/sageplot.ptx
@@ -1,12 +1,17 @@
+
+
 <figure xml:id="fig-sage-cubic">
-    <caption>A cubic plotted by SageMath on
-    <m>[-3,2]</m></caption>
-    <image xml:id="sageplot-cubic" width="50%">
-        <description>A cubic function on the interval
-        [-3,2]</description>
-        <sageplot>
-            f(x) = (x-1)*(x+1)*(x-2)
-            plot(f, (x, -3, 2), color='blue', thickness=3)
-        </sageplot>
-    </image>
+  <caption>A cubic plotted by SageMath on
+  <m>[-3,2]</m></caption>
+  <image xml:id="sageplot-cubic" width="50%">
+    <description>A cubic function on the interval
+    [-3,2]</description>
+
+<sageplot>
+f(x) = (x-1)*(x+1)*(x-2)
+plot(f, (x, -3, 2), color='blue', thickness=3)
+</sageplot>
+  </image>
+
 </figure>
+

--- a/doc/guide/basics/sbsgroup.ptx
+++ b/doc/guide/basics/sbsgroup.ptx
@@ -1,13 +1,29 @@
+
+
 <sbsgroup widths = "25% 50%" margins="5% 10%">
-    <sidebyside>
-        <p>A short piece of text.</p>
-        <p>A longer piece of text. It goes on and on and on.
-        And on and on and on. And eventually we will let it
-        end, but we want to show the width.</p>
-    </sidebyside>
-    <sidebyside>
-        <p>Another little snippet of text. This time a bit
-        longer so that it will wrap.</p>
-        <p>We're going to keep this paragraph shorter.</p>
-    </sidebyside>
+  <sidebyside>
+    <p>
+      A short piece of text.
+    </p>
+
+    <p>
+      A longer piece of text.
+      It goes on and on and on.
+      And on and on and on.
+      And eventually we will let it end,
+      but we want to show the width.
+    </p>
+  </sidebyside>
+
+  <sidebyside>
+    <p>
+      Another little snippet of text.
+      This time a bit longer so that it will wrap.
+    </p>
+
+    <p>
+      We're going to keep this paragraph shorter.
+    </p>
+  </sidebyside>
 </sbsgroup>
+

--- a/doc/guide/basics/section-sub.ptx
+++ b/doc/guide/basics/section-sub.ptx
@@ -1,17 +1,33 @@
+
+
 <section>
+  <title>Mandatory</title>
+  <introduction>
+    <p>
+      Introductory text.
+      (Optional.)
+    </p>
+  </introduction>
+
+  <subsection>
     <title>Mandatory</title>
-    <introduction>
-        <p>Introductory text. (Optional.)</p>
-    </introduction>
-    <subsection>
-        <title>Mandatory</title>
-        <p>Subsection content.</p>
-    </subsection>
-    <subsection>
-        <title>Mandatory</title>
-        <p>Subsection content.</p>
-    </subsection>
-    <conclusion>
-        <p>Concluding text. (Optional.)</p>
-    </conclusion>
+    <p>
+      Subsection content.
+    </p>
+  </subsection>
+
+  <subsection>
+    <title>Mandatory</title>
+    <p>
+      Subsection content.
+    </p>
+  </subsection>
+
+  <conclusion>
+    <p>
+      Concluding text.
+      (Optional.)
+    </p>
+  </conclusion>
 </section>
+

--- a/doc/guide/basics/section.ptx
+++ b/doc/guide/basics/section.ptx
@@ -1,5 +1,13 @@
+
+
 <section>
-    <title>Mandatory</title>
-    <p>First paragraph.</p>
-    <p>Second paragraph.</p>
+  <title>Mandatory</title>
+  <p>
+    First paragraph.
+  </p>
+
+  <p>
+    Second paragraph.
+  </p>
 </section>
+

--- a/doc/guide/basics/sidebyside.ptx
+++ b/doc/guide/basics/sidebyside.ptx
@@ -1,11 +1,18 @@
+
+
 <sidebyside widths="25% 25%" valign="middle">
-    <figure>
-        <caption>Small graph</caption>
-        <image source="images/small_graph" />
-    </figure>
-    <p>We can put a paragraph here. Yes, a paragraph.
-    Isn't this the most exciting paragraph that you've
-    ever seen? It goes on and on and on and on and on
-    and on. We want to put enough here to make it
-    wrap, really, is all. Let's hope that this is enough.</p>
+  <figure>
+    <caption>Small graph</caption>
+    <image source="images/small_graph" />
+  </figure>
+
+  <p>
+    We can put a paragraph here.
+    Yes, a paragraph.
+    Isn't this the most exciting paragraph that you've ever seen?
+    It goes on and on and on and on and on and on.
+    We want to put enough here to make it wrap, really, is all.
+    Let's hope that this is enough.
+  </p>
 </sidebyside>
+

--- a/doc/guide/basics/sidebyside2.ptx
+++ b/doc/guide/basics/sidebyside2.ptx
@@ -1,13 +1,21 @@
+
+
 <figure>
-    <caption>A graphic next to a paragraph of
-    text.</caption>
-    <sidebyside widths="25% 35%" margins="0% 0%"
-                valigns="bottom top">
-        <image source="images/small_graph" />
-        <p>We can put a paragraph here. Yes, a paragraph.
-        Isn't this the most exciting paragraph that you've
-        ever seen? It goes on and on and on and on and on
-        and on. We want to put enough here to make it
-        wrap, really, is all. Let's hope that this is enough.</p>
-    </sidebyside>
+  <caption>A graphic next to a paragraph of
+  text.</caption>
+  <sidebyside widths="25% 35%" margins="0% 0%"
+    valigns="bottom top">
+    <image source="images/small_graph" />
+
+    <p>
+      We can put a paragraph here.
+      Yes, a paragraph.
+      Isn't this the most exciting paragraph that you've ever seen?
+      It goes on and on and on and on and on and on.
+      We want to put enough here to make it wrap, really, is all.
+      Let's hope that this is enough.
+    </p>
+  </sidebyside>
+
 </figure>
+

--- a/doc/guide/basics/table.ptx
+++ b/doc/guide/basics/table.ptx
@@ -1,35 +1,39 @@
+
+
 <table>
-    <title>A simple table</title>
-    <tabular halign="center">
-        <row bottom="minor" >
-            <cell><m>x</m></cell>
-            <cell><m>y</m></cell>
-            <cell><m>x\wedge y</m></cell>
-            <cell><m>x\vee y</m></cell>
-        </row>
-        <row>
-            <cell>T</cell>
-            <cell>T</cell>
-            <cell>T</cell>
-            <cell>T</cell>
-        </row>
-        <row>
-            <cell>T</cell>
-            <cell>F</cell>
-            <cell>F</cell>
-            <cell>T</cell>
-        </row>
-        <row>
-            <cell>F</cell>
-            <cell>T</cell>
-            <cell>F</cell>
-            <cell>T</cell>
-        </row>
-        <row>
-            <cell>F</cell>
-            <cell>F</cell>
-            <cell>F</cell>
-            <cell>F</cell>
-        </row>
-    </tabular>
+  <title>A simple table</title>
+  <tabular halign="center">
+    <row bottom="minor" >
+      <cell><m>x</m></cell>
+      <cell><m>y</m></cell>
+      <cell><m>x\wedge y</m></cell>
+      <cell><m>x\vee y</m></cell>
+    </row>
+    <row>
+      <cell>T</cell>
+      <cell>T</cell>
+      <cell>T</cell>
+      <cell>T</cell>
+    </row>
+    <row>
+      <cell>T</cell>
+      <cell>F</cell>
+      <cell>F</cell>
+      <cell>T</cell>
+    </row>
+    <row>
+      <cell>F</cell>
+      <cell>T</cell>
+      <cell>F</cell>
+      <cell>T</cell>
+    </row>
+    <row>
+      <cell>F</cell>
+      <cell>F</cell>
+      <cell>F</cell>
+      <cell>F</cell>
+    </row>
+  </tabular>
+
 </table>
+

--- a/doc/guide/basics/theorem.ptx
+++ b/doc/guide/basics/theorem.ptx
@@ -1,14 +1,19 @@
+
+
 <theorem>
-    <title>Optional</title>
-    <statement>
-        <p>Here's the statement of the theorem.</p>
-    </statement>
-    <proof>
-        <p>
-            You don't actually need a proof, but put it
-            inside the <c>theorem</c>. You can actually
-            put another <c>proof</c> right after this
-            one if you want to.
-        </p>
-    </proof>
+  <title>Optional</title>
+  <statement>
+    <p>
+      Here's the statement of the theorem.
+    </p>
+  </statement>
+
+  <proof>
+    <p>
+      You don't actually need a proof,
+      but put it inside the <c>theorem</c>.
+      You can actually put another <c>proof</c> right after this one if you want to.
+    </p>
+  </proof>
 </theorem>
+

--- a/doc/guide/basics/tikz.ptx
+++ b/doc/guide/basics/tikz.ptx
@@ -1,26 +1,31 @@
+
+
 <figure xml:id="fig-tikz">
-    <caption>A figure generated with TikZ in
-    <latex /></caption>
-    <image width="15%" xml:id="poset">
-        <latex-image >
-            \begin{tikzpicture}
-            \draw (0,0) -- (0,1);
-            \draw (1,0) -- (1,1) -- (1,2) -- (1,3);
-            \draw (0,0) -- (1,2);
-            \draw (0,1) -- (1,0);
-            \draw [fill] (0,0) circle [radius=0.1];
-            \draw [fill] (0,1) circle [radius=0.1];
-            \draw [fill] (1,0) circle [radius=0.1];
-            \draw [fill] (1,1) circle [radius=0.1];
-            \draw [fill] (1,2) circle [radius=0.1];
-            \draw [fill] (1,3) circle [radius=0.1];
-            \node [left] at (0,0) {$x$};
-            \node [left] at (0,1) {$b$};
-            \node [right] at (1,0) {$a$};
-            \node [right] at (1,1) {$y$};
-            \node [right] at (1,2) {$c$};
-            \node [right] at (1,3) {$d$};
-            \end{tikzpicture}
-        </latex-image>
-    </image>
+  <caption>A figure generated with TikZ in
+  <latex /></caption>
+  <image width="15%" xml:id="poset">
+
+<latex-image >
+\begin{tikzpicture}
+\draw (0,0) -- (0,1);
+\draw (1,0) -- (1,1) -- (1,2) -- (1,3);
+\draw (0,0) -- (1,2);
+\draw (0,1) -- (1,0);
+\draw [fill] (0,0) circle [radius=0.1];
+\draw [fill] (0,1) circle [radius=0.1];
+\draw [fill] (1,0) circle [radius=0.1];
+\draw [fill] (1,1) circle [radius=0.1];
+\draw [fill] (1,2) circle [radius=0.1];
+\draw [fill] (1,3) circle [radius=0.1];
+\node [left] at (0,0) {$x$};
+\node [left] at (0,1) {$b$};
+\node [right] at (1,0) {$a$};
+\node [right] at (1,1) {$y$};
+\node [right] at (1,2) {$c$};
+\node [right] at (1,3) {$d$};
+\end{tikzpicture}
+</latex-image>
+  </image>
+
 </figure>
+

--- a/doc/guide/basics/ul.ptx
+++ b/doc/guide/basics/ul.ptx
@@ -1,6 +1,10 @@
+
+
 <p>
-    <ul>
-        <li>First item.</li>
-        <li>Another item.</li>
-    </ul>
+  <ul>
+    <li>First item.</li>
+
+    <li>Another item.</li>
+  </ul>
 </p>
+

--- a/doc/guide/basics/webwork-code.ptx
+++ b/doc/guide/basics/webwork-code.ptx
@@ -1,7 +1,12 @@
+
+
 <exercise>
-    <webwork>
-        <statement>
-            <p><m>1+2=</m><var name="3" width="5" /></p>
-        </statement>
-    </webwork>
+  <webwork>
+      <statement>
+        <p>
+          <m>1+2=</m><var name="3" width="5" />
+        </p>
+      </statement>
+  </webwork>
 </exercise>
+

--- a/doc/guide/basics/webwork-opl.ptx
+++ b/doc/guide/basics/webwork-opl.ptx
@@ -1,11 +1,20 @@
+
+
 <exercise>
-    <introduction>
-        <p>Optional introduction</p>
-    </introduction>
 
-    <webwork source="Library/ma122DB/set12/s5_4_26.pg" />
+  <introduction>
+    <p>
+      Optional introduction
+    </p>
+  </introduction>
 
-    <conclusion>
-        <p>Optional conclusion</p>
-     </conclusion>
+  <webwork source="Library/ma122DB/set12/s5_4_26.pg" />
+
+  <conclusion>
+    <p>
+      Optional conclusion
+    </p>
+  </conclusion>
+
 </exercise>
+

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -7,7 +7,7 @@
 <!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
-<chapter xml:id="starting">
+<chapter xml:id="start-here">
     <title>Starting</title>
 
     <introduction>

--- a/doc/guide/preface.xml
+++ b/doc/guide/preface.xml
@@ -12,7 +12,7 @@
     <paragraphs>
         <title>Introduction</title>
 
-        <p>This part is the place to begin if you are new to <pretext/>.  <xref ref="starting"/> is the introduction, overview, and philosophy.  Then <xref ref="quickstart-example"/> intends to get you started quickly by authoring a simple example and converting it to <init>HTML</init> and <init>PDF</init> output formats.</p>
+        <p>This part is the place to begin if you are new to <pretext/>.  <xref ref="start-here"/> is the introduction, overview, and philosophy.  Then <xref ref="quickstart-example"/> intends to get you started quickly by authoring a simple example and converting it to <init>HTML</init> and <init>PDF</init> output formats.</p>
     </paragraphs>
 
     <paragraphs>

--- a/doc/guide/publisher/publisher-faq.xml
+++ b/doc/guide/publisher/publisher-faq.xml
@@ -7,7 +7,7 @@
 <!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
-<chapter xml:id="faq">
+<chapter xml:id="publisher-faq">
     <title>Publisher FAQ: Frequently Asked Questions</title>
 
      <p>This is a list of answers to frequent questions, in no particular order.</p>


### PR DESCRIPTION
This is the pretty-printing of the Basics Reference plus taking care of the index cleanup based on the discussions in Portland. I also fixed some `xref` issues in other parts of The Guide.