### PR TITLE
EPUB: More simple test elements in sampler, small CSS edit, and TOC change for backmatter

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -46,18 +46,31 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <chapter>
             <title>Two</title>
-
+            <introduction><p>This is the introduction to the chapter.</p></introduction>
+            <section>
+                <title>A silly section.</title>
+                <p>This section just exists so that we can add <tag>introduction</tag> and <tag>conclusion</tag> tags to this chapter.
+                </p>
             <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ultricies purus sit amet rutrum dictum. Donec sit amet ligula quis orci vestibulum tempor id in erat. Ut ut placerat lacus, sit amet feugiat lorem. Pellentesque sodales risus at eros malesuada, eget ultrices est consectetur. Praesent fermentum, ligula sit amet fermentum varius, elit eros imperdiet lectus, tempus condimentum quam elit in elit. Sed molestie mauris sem, sed laoreet elit iaculis ut. In mattis blandit ex, nec rutrum purus ullamcorper eget. Nullam maximus magna non elit euismod, non ornare nisl porttitor. Pellentesque commodo tempus viverra.</p>
 
             <p>Curabitur ac hendrerit ligula. Aenean vitae nunc id elit convallis efficitur. Sed ultricies ut justo quis elementum. Sed eget eros venenatis, pellentesque risus sed, fermentum mi. Proin ipsum arcu, porta nec sem sit amet, sollicitudin faucibus erat. Quisque lacus lectus, pellentesque ut imperdiet sed, euismod vitae nibh. Donec dolor diam, elementum ac pharetra vitae, volutpat mollis augue.</p>
+            <aside>
+                <title>Look at this!</title>
+                <p>This is an aside. Please don't let it distract you.</p>
+            </aside>
 
             <p>Maecenas ex enim, lobortis et blandit sit amet, pretium in ante. Sed mollis sollicitudin nibh non consectetur. Vestibulum eget tortor sit amet felis iaculis fermentum. Sed eu nisl a urna cursus congue at nec nulla. Mauris lacinia molestie tristique. Maecenas aliquet rutrum venenatis. Vivamus quis metus sit amet est feugiat facilisis quis et massa. Aenean dui sem, dapibus at imperdiet ac, auctor sit amet arcu. Vestibulum eget porttitor est. Aliquam id pellentesque quam, vitae rhoncus metus. In congue condimentum malesuada. Mauris in condimentum eros, eget mattis nibh. Praesent et ex porttitor, lobortis nibh sed, cursus ante. Suspendisse dapibus vel risus eu pellentesque. </p>
+            </section>
+            <conclusion>
+                <title>Wrapping up</title>
+                <p>This is the conclusion.</p>
+            </conclusion>
         </chapter>
 
         <chapter>
             <title>A Bit of Math</title>
 
-            <p>This paragraph has some inline math, a Diophantine equation, <m>x^2 + \doubler{y^2} = z^2</m>.  And some display math about infinite series: <me>\sum_{n=1}^\infty\,\frac{1}{n^2} = \frac{\pi^2}{6}.</me>  Look at the XML source to see how <latex /> macros are employed.</p>
+            <p><idx>Diophantine equation</idx>This paragraph has some inline math, a Diophantine equation, <m>x^2 + \doubler{y^2} = z^2</m>.  And some display math about infinite series: <me>\sum_{n=1}^\infty\,\frac{1}{n^2} = \frac{\pi^2}{6}.</me>  Look at the XML source to see how <latex /> macros are employed.</p>
 
             <p>Nice.</p>
         </chapter>
@@ -65,7 +78,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <chapter>
             <title>Some Images</title>
 
-            <p>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
+            <p><idx>Portable Network Graphics (PNG)</idx><idx><h>PNG</h><see>Portable Network Graphics</see></idx>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
 
             <figure>
                 <caption>A cubic polynomial and its derivative</caption>
@@ -201,6 +214,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </exercise>
 
         </chapter>
-
+        <backmatter>
+            <appendix>
+                <title>Maybe the license</title>
+                <p>Lots of books written in <pretext/> include the terms of their license in an appendix, so let's use this as a test.</p>
+            </appendix>
+            <index>
+                <title>Index</title>
+                <index-list/>
+            </index>
+        </backmatter>
+        
     </book>
 </pretext>

--- a/examples/epub/pretext-epub.css
+++ b/examples/epub/pretext-epub.css
@@ -1725,7 +1725,8 @@ ul.circle {
     list-style-type: circle;
 }
 ol.no-marker,
-ul.no-marker {
+ul.no-marker,
+li.no-marker {
     list-style-type: none;
 }
 

--- a/xsl/mathbook-epub.xsl
+++ b/xsl/mathbook-epub.xsl
@@ -305,7 +305,6 @@
     <manifest xmlns="http://www.idpf.org/2007/opf">
         <item id="css" href="{$css-dir}/pretext-epub.css" media-type="text/css"/>
         <item id="cover-page" href="{$xhtml-dir}/cover-page.xhtml" media-type="application/xhtml+xml"/>
-        <item id="title-page" href="{$xhtml-dir}/title-page.xhtml" media-type="application/xhtml+xml"/>
         <item id="table-contents" href="{$xhtml-dir}/table-contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
         <item id="cover-image" href="{$xhtml-dir}/images/cover.png" properties="cover-image" media-type="image/png"/>
         <!-- <item id="cover-image" href="{$xhtml-dir}/images/cover.jpg" properties="cover-image" media-type="image/jpeg"/> -->
@@ -375,9 +374,8 @@
 <!-- Each must reference an id in the manifest   -->
 <xsl:template name="package-spine">
     <spine xmlns="http://www.idpf.org/2007/opf">
-        <itemref idref="cover-page" linear="yes" />
-        <itemref idref="title-page" linear="yes"/>
         <itemref idref="table-contents" linear="yes"/>
+        <itemref idref="cover-page" linear="yes" />
         <xsl:apply-templates select="$document-root" mode="spine" />
     </spine>
 </xsl:template>
@@ -424,42 +422,45 @@
             </body>
         </html>
     </exsl:document>
-    <exsl:document href="{$content-dir}/{$xhtml-dir}/title-page.xhtml" method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="yes">
-        <html xmlns="http://www.w3.org/1999/xhtml">
-            <!-- head element should not be empty -->
-            <head>
-                <meta charset="utf-8"/>
-                <title>
-                    <xsl:apply-templates select="$document-root" mode="title-full"/>
-                </title>
-            </head>
-            <body>
-                <h1>
-                    <xsl:apply-templates select="$document-root" mode="title-full" />
-                    <xsl:if test="$document-root/subtitle">
-                        <br />
-                        <xsl:apply-templates select="$document-root" mode="subtitle" />
-                    </xsl:if>
-                </h1>
-                <h3>
-                    <xsl:apply-templates select="titlepage/author/personname" />
-                    <br />
-                    <xsl:apply-templates select="titlepage/author/institution" />
-                </h3>
-            </body>
-        </html>
-    </exsl:document>
     <exsl:document href="{$content-dir}/{$xhtml-dir}/table-contents.xhtml" method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="yes">
         <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
             <head>
                 <meta charset="utf-8"/>
+                <link href="../{$css-dir}/pretext-epub.css" rel="stylesheet" type="text/css" />
             </head>
             <body epub:type="frontmatter">
                 <nav epub:type="toc" id="toc">
                     <h1>Table of Contents</h1>
                     <ol>
-                        <xsl:for-each select="$document-root/chapter|$document-root/backmatter/appendix|$document-root/backmatter/index">
+                        <xsl:for-each select="$document-root/chapter">
                             <li>
+                                <xsl:element name="a">
+                                    <xsl:attribute name="href">
+                                        <xsl:apply-templates select="." mode="containing-filename" />
+                                    </xsl:attribute>
+                                    <xsl:apply-templates select="." mode="title-simple" />
+                                </xsl:element>
+                            </li>
+                        </xsl:for-each>
+                        <xsl:if test="$document-root/backmatter/appendix">
+                            <li class="no-marker">
+                                <span>Appendices</span>
+                                <ol type="A">
+                                    <xsl:for-each select="$document-root/backmatter/appendix">
+                                        <li>
+                                            <xsl:element name="a">
+                                                <xsl:attribute name="href">
+                                                    <xsl:apply-templates select="." mode="containing-filename" />
+                                                </xsl:attribute>
+                                                <xsl:apply-templates select="." mode="title-simple" />
+                                            </xsl:element>
+                                        </li>
+                                    </xsl:for-each>
+                                </ol>
+                            </li>
+                        </xsl:if>
+                        <xsl:for-each select="$document-root/backmatter/index">
+                            <li class="no-marker">
                                 <xsl:element name="a">
                                     <xsl:attribute name="href">
                                         <xsl:apply-templates select="." mode="containing-filename" />


### PR DESCRIPTION
* Add an `aside`, a couple of `idx`, an `appendix`, an `index`, an `introduction`, and a `conclusion` to the EPUB sampler for better testing.
* Rearrange the TOC slightly so that it comes where eBook stores prefer on the spine, remove the half-title, and treat backmatter items more correctly for the TOC. This involved adding a new CSS selector so that some `li` in the TOC could be unnumbered.