### PR TITLE
Fix filename error

### DIFF
--- a/doc/guide/appendices/windows.xml
+++ b/doc/guide/appendices/windows.xml
@@ -382,7 +382,7 @@
       <cd>
         <cline>if [ -f ~/.bashrc ]; then . ~/.bashrc; fi</cline>
       </cd>
-      to <c>.bashrc</c>
+      to <c>.bash-profile</c>
     </p>
 
     <p>


### PR DESCRIPTION
Fixing a file reference to .bashrc that should have pointed to .bash-profile.