### PR TITLE
Add FontAwesome media control icons

### DIFF
--- a/doc/guide/appendices/mac-os.xml
+++ b/doc/guide/appendices/mac-os.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--      PreTeXt Author's Guide                              -->
+<!--                                                          -->
+<!-- Copyright (C) 2013-2019  Robert A. Beezer                -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<appendix xml:id="mac-os-install-notes">
+    <title>MacOS Installation Notes</title>
+
+    <introduction>
+       <p>This appendix explains how to install necessary software on Apple's Mac.</p>
+    </introduction>
+
+    <section xml:id="mac-os-java">
+        <title>Java</title>
+
+        <p>The <c>jing</c> and <c>trang</c> schema tools (<xref ref="schema-install"/>) require the Java Development Kit (<init>JDK</init>).  These instructions come from Mitch Keller and Jane Butterfield on 2019-07-23.  You may need to change some version numbers over time.</p>
+
+        <list>
+            <title>Install Java on MacOS</title>
+
+            <ol>
+                <li><p>From <url href="https://jdk.java.net/12/"/> get an open source <init>JDK</init>.  In other words, not the proprietary version from Oracle.</p></li>
+
+                <li><p>Unzip the file you download until you have a directory called <c>jdk-12.0.1.jdk</c>. Put that directory somewhere useful. We will pretend that you put it in your home directory and that your user is called <c>jane</c>, which means that the directory is now at <c>/Users/jane/jdk-12.0.1.jdk</c>.</p></li>
+
+                <li><p>In a Terminal, run<cd>export JAVA_HOME=/Users/jane/jdk-12.0.2.jdk/Contents/Home</cd>adjusted appropriately.  A good check is to get this same directory back from the command<cd><cline>echo $(/usr/libexec/java_home)</cline></cd></p></li>
+
+                <li><p>If you are doing this to install <c>jing</c> and <c>trang</c>, then, <em>in the same Terminal window</em>, <c>cd</c> into the <c>jing-trang</c> directory and run <c>./ant</c>.</p></li>
+            </ol>
+        </list>
+  </section>
+</appendix>

--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -37,11 +37,11 @@
                     <p>Follow the instructions in the <c>readme.md</c> found at the top level of the <c>jing-trang</c> distribution, observing the following notes keyed to the four steps.  These helpful notes come courtesy of the experiences of Jahrme Risner, Mitch Keller, Bruce Yoshiwara, Ken Levasseur, and Jessica Sklar on a variety of operating systems.</p>
                     <p><ol>
                         <li>
-                            <p>It is necesssary to have a developer's version of <c>java</c> on your machine.  Try <c>which java</c> to see if one is already available.  Any output here might help in the next step.  References here to the <init>JDK</init> is the Java Development Kit.</p>
+                            <p>It is necesssary to have a developer's version of <c>java</c> on your machine.  Try <c>which java</c> to see if one is already available.  Any output here might help in the next step.  References here to the <init>JDK</init> is the Java Development Kit.  There are specific directions for MacOS (<xref ref="mac-os-java"/>) and Windows (<xref ref="section-jing"/>).</p>
                         </li>
 
                         <li>
-                            <p>You will need to have the <c>JAVA_HOME</c> environment variable set correctly.  You can try <c>echo ${JAVA_HOME}</c> in a console to see if it produces anything sensible and/or consistent with Step 1.  Ken Levasseur notes that on OSX you can go<cd>
+                            <p>You will need to have the <c>JAVA_HOME</c> environment variable set correctly.  You can try <c>echo ${JAVA_HOME}</c> in a Linux console to see if it produces anything sensible and/or consistent with Step 1.  Ken Levasseur notes that on MacOS you can go<cd>
                                 <cline>echo $(/usr/libexec/java_home)</cline>
                             </cd>and the output is what you set to the <c>JAVA_HOME</c> variable.</p>
                             <p>On Windows you may need to set Environmental Variables in the Windows System Properties GUI, both here and in Step 4.</p>

--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -202,35 +202,160 @@
 
         <p>If you consistently follow the prescription in the previous paragraph you will avoid a descent into escape-character hell and avoid a lot of head-scratching.  In particular, you should have no need of the <c>&lt;![CDATA[</c><nbsp /><c>]]&gt;</c> mechanism of XML, so just forget we even mentioned it.</p>
 
-      <table>
-        <title>Special Characters</title>
-        <tabular halign="left">
-          <row bottom="medium">
-               <cell>To get this:</cell>       <cell>Type this:</cell></row>
-          <row><cell>&amp;</cell>              <cell><c>&amp;amp;</c></cell></row>
-          <row><cell><copyright/></cell>       <cell><tage>copyright</tage></cell></row>
-          <row><cell><ellipsis/></cell>        <cell><tage>ellipsis</tage></cell></row>
-          <row><cell><fillin/></cell>          <cell><tage>fillin</tage></cell></row>
-          <row><cell><icon name="gear"/></cell><cell><c>&lt;icon name="gear"/&gt;</c></cell></row>
-          <row><cell>&lt;</cell>               <cell><c>&amp;lt;</c></cell></row>
-          <row><cell><lq/></cell>              <cell><tage>lq</tage></cell></row>
-          <row><cell><lsq/></cell>             <cell><tage>lsq</tage></cell></row>
-          <row><cell><mdash/></cell>           <cell><tage>mdash</tage></cell></row>
-          <row><cell><midpoint/></cell>        <cell><tage>midpoint</tage></cell></row>
-          <row><cell><nbsp/></cell>            <cell><tage>nbsp</tage></cell></row>
-          <row><cell><ndash/></cell>           <cell><tage>ndash</tage></cell></row>
-          <row><cell><permille/></cell>        <cell><tage>permille</tage></cell></row>
-          <row><cell><pilcrow/></cell>         <cell><tage>pilcrow</tage></cell></row>
-          <row><cell><registered/></cell>      <cell><tage>registered</tage></cell></row>
-          <row><cell><rq/></cell>              <cell><tage>rq</tage></cell></row>
-          <row><cell><rsq/></cell>             <cell><tage>rsq</tage></cell></row>
-          <row><cell><section-mark/></cell>    <cell><tage>section-mark</tage></cell></row>
-          <row><cell><solidus/></cell>         <cell><tage>solidus</tage></cell></row>
-          <row><cell><swungdash/></cell>       <cell><tage>swungdash</tage></cell></row>
-          <row><cell><times/></cell>           <cell><tage>times</tage></cell></row>
-          <row><cell><trademark/></cell>       <cell><tage>trademark</tage></cell> </row>
-        </tabular>
-      </table>
+ <table>
+  <title>Special Characters</title>
+  <tabular halign="left">
+   <col halign="center"/>
+   <col halign="left" right="medium"/>
+   <col halign="center"/>
+   <col halign="left"/>
+   <row bottom="medium">
+    <cell>To get this:</cell>
+    <cell>Type this:</cell>
+    <cell>To get this:</cell>
+    <cell>Type this</cell>
+   </row>
+
+   <row>
+    <cell>&amp;</cell>
+    <cell><c>&amp;amp;</c></cell>
+    <cell><copyright/></cell>
+    <cell><tage>copyright</tage></cell>
+   </row>
+   <row>
+    <cell><ellipsis/></cell>
+    <cell><tage>ellipsis</tage></cell>
+    <cell><fillin/></cell>
+    <cell><tage>fillin</tage></cell>
+   </row>
+   <row>
+    <cell><icon name="gear"/></cell>
+    <cell><c>&lt;icon name="gear"/&gt;</c></cell>
+    <cell>&lt;</cell>
+    <cell><c>&amp;lt;</c></cell>
+   </row>
+   <row>
+    <cell><lq/></cell>
+    <cell><tage>lq</tage></cell>
+    <cell><lsq/></cell>
+    <cell><tage>lsq</tage></cell>
+   </row>
+   <row>
+    <cell><mdash/></cell>
+    <cell><tage>mdash</tage></cell>
+    <cell><midpoint/></cell>
+    <cell><tage>midpoint</tage></cell>
+   </row>
+   <row>
+    <cell><nbsp/></cell>
+    <cell><tage>nbsp</tage></cell>
+    <cell><ndash/></cell>
+    <cell><tage>ndash</tage></cell>
+   </row>
+   <row>
+    <cell><permille/></cell>
+    <cell><tage>permille</tage></cell>
+    <cell><pilcrow/></cell>
+    <cell><tage>pilcrow</tage></cell>
+   </row>
+   <row>
+    <cell><registered/></cell>
+    <cell><tage>registered</tage></cell>
+    <cell><rq/></cell>
+    <cell><tage>rq</tage></cell>
+   </row>
+   <row>
+    <cell><rsq/></cell>
+    <cell><tage>rsq</tage></cell>
+    <cell><section-mark/></cell>
+    <cell><tage>section-mark</tage></cell>
+   </row>
+   <row>
+    <cell><solidus/></cell>
+    <cell><tage>solidus</tage></cell>
+    <cell><swungdash/></cell>
+    <cell><tage>swungdash</tage></cell>
+   </row>
+   <row>
+    <cell><times/></cell>
+    <cell><tage>times</tage></cell>
+    <cell><trademark/></cell>
+    <cell><tage>trademark</tage></cell>
+   </row>
+  </tabular>
+ </table>
+
+
+ <table>
+  <title>User-Interface Icons available with <tage>icon</tage></title>
+  <tabular>
+
+   <col/>
+   <col halign="center" right="medium"/>
+   <col/>
+   <col halign="center" right="medium"/>
+   <col/>
+   <col halign="center"/>
+   <row bottom="medium">
+    <cell>Name</cell>
+    <cell>Icon</cell>
+    <cell>Name</cell>
+    <cell>Icon</cell>
+    <cell>Name</cell>
+    <cell>Icon</cell>
+   </row>
+   <row>
+    <cell><c>arrow-down</c></cell>
+    <cell><icon name="arrow-down"/></cell>
+    <cell><c>arrow-left</c></cell>
+    <cell><icon name="arrow-left"/></cell>
+    <cell><c>arrow-right</c></cell>
+    <cell><icon name="arrow-right"/></cell>
+   </row>
+   <row>
+    <cell><c>arrow-up</c></cell>
+    <cell><icon name="arrow-up"/></cell>
+    <cell><c>file-save</c></cell>
+    <cell><icon name="file-save"/></cell>
+    <cell><c>gear</c></cell>
+    <cell><icon name="gear"/></cell>
+   </row>
+   <row>
+    <cell><c>menu</c></cell>
+    <cell><icon name="menu"/></cell>
+    <cell><c>wrench</c></cell>
+    <cell><icon name="wrench"/></cell>
+    <cell><c>power</c></cell>
+    <cell><icon name="power"/></cell>
+   </row>
+   <row>
+    <cell><c>media-play</c></cell>
+    <cell><icon name="media-play"/></cell>
+    <cell><c>media-pause</c></cell>
+    <cell><icon name="media-pause"/></cell>
+    <cell><c>media-stop</c></cell>
+    <cell><icon name="media-stop"/></cell>
+   </row>
+   <row>
+    <cell><c>media-fast-forward</c></cell>
+    <cell><icon name="media-fast-forward"/></cell>
+    <cell><c>media-rewind</c></cell>
+    <cell><icon name="media-rewind"/></cell>
+    <cell><c>media-skip-to-end</c></cell>
+    <cell><icon name="media-skip-to-end"/></cell>
+   </row>
+   <row>
+    <cell><c>media-skip-to-start</c></cell>
+    <cell><icon name="media-skip-to-start"/></cell>
+    <cell/>
+    <cell/>
+    <cell/>
+    <cell/>
+   </row>
+   <!-- <cell><c></c></cell><cell><icon name=""/></cell> -->
+   <!-- Keep rows full (w/ empty cells) to please HTML validator -->
+  </tabular>
+ </table>
 
     </section>
 

--- a/doc/guide/backmatter.xml
+++ b/doc/guide/backmatter.xml
@@ -21,6 +21,7 @@
     <xi:include href="appendices/schema-install.xml"/>
     <xi:include href="appendices/git.xml"/>
     <xi:include href="appendices/latex-conversion.xml"/>
+    <xi:include href="appendices/mac-os.xml"/>
     <xi:include href="appendices/windows.xml"/>
     <xi:include href="appendices/windows-wsl.xml"/>
     <xi:include href="appendices/vagrant.xml"/>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2179,7 +2179,7 @@ the xsltproc executable.
                     <p>Nested <c>tcolorbox</c> (in <latex/> conversion) need special care when footnotes are interior.</p>
 
                     <sidebyside margins="20% 30%">
-                        <p>A paragraph interior to a <c>sidebyside</c> with a footnote<fn>Interior footnote.</fn> buried inside the footnote.</p>
+                        <p>A paragraph interior to a <c>sidebyside</c> with a footnote<fn>Interior footnote.</fn> buried inside the paragraph.</p>
                     </sidebyside>
 
                     <p>The final paragraph of this remark, randomly placed, to test footnotes in <latex/> conversions.</p>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2172,6 +2172,18 @@ the xsltproc executable.
                     <caption>Complete graph on <m>16</m> vertices, from <c>www.texample.net</c></caption>
                     <image source="images/complete-graph" width="65%"/>
                 </figure>
+
+                <remark>
+                    <title>Footnote Buried</title>
+
+                    <p>Nested <c>tcolorbox</c> (in <latex/> conversion) need special care when footnotes are interior.</p>
+
+                    <sidebyside margins="20% 30%">
+                        <p>A paragraph interior to a <c>sidebyside</c> with a footnote<fn>Interior footnote.</fn> buried inside the footnote.</p>
+                    </sidebyside>
+
+                    <p>The final paragraph of this remark, randomly placed, to test footnotes in <latex/> conversions.</p>
+                </remark>
             </subsection>
 
             <subsection>

--- a/script/braille/mjpage-sre.js
+++ b/script/braille/mjpage-sre.js
@@ -6,6 +6,9 @@
 // Modified render(node) method to produce cleaner output
 // and remove extraneous spaces.
 
+// Rob Beezer: 2019-07-24
+// Minor updates to accomodate SRE 3.0.0-beta.5
+
 const fs = require('fs');
 const mjnode = require('mathjax-node-sre');
 const jsdom = require('jsdom');
@@ -25,14 +28,13 @@ const render = async (node) => {
     math: mathinput, // This is the MathML expression that will be converted
     format: "MathML",
     mml:true, // I think it does not matter which we pick, mml or svg; we are not using it anyway
-    sre: ['domain', 'default', 'locale', 'nemeth'], // This is important!
+    sre: ['domain', 'default', 'locale', 'nemeth', 'modality', 'braille'], // This is important!
     });
 
   // result.speech contains Nemeth Braille code for mathinput
-  // with extra spaces that we kill now. This also needs to be
-  // enclosed in some tags. I picked 'title'; we may want to
-  // come up with something like <nemeth>.
-  node.innerHTML = '<title>'+result.speech.replace(/ /g,'')+'</title>';
+  // This needs to be enclosed in some tags. I picked 'title';
+  // we may want to come up with something like <nemeth>.
+  node.innerHTML = '<title>'+result.speech+'</title>';
 };
 
 const main = async argv => {

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -4385,6 +4385,30 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <iconinfo name="wrench"
               font-awesome="wrench"
               unicode="&#x1f527;"/> <!-- WRENCH -->
+    <iconinfo name="power"
+              font-awesome="power-off"
+              unicode="&#x23FB;"/> <!-- POWER SYMBOL -->
+    <iconinfo name="media-play"
+              font-awesome="play"
+              unicode="&#x25B6;"/> <!--BLACK RIGHT-POINTING TRIANGLE-->
+    <iconinfo name="media-pause"
+              font-awesome="pause"
+              unicode="&#x23F8;"/> <!-- DOUBLE VERTICAL BAR -->
+    <iconinfo name="media-stop"
+              font-awesome="stop"
+              unicode="&#x23F9;"/> <!-- BLACK SQUARE FOR STOP-->
+    <iconinfo name="media-fast-forward"
+              font-awesome="forward"
+              unicode="&#x23E9;"/> <!-- BLACK RIGHT-POINTING DOUBLE TRIANGLE -->
+    <iconinfo name="media-rewind"
+              font-awesome="backward"
+              unicode="&#x23EA;"/> <!-- BLACK LEFT-POINTING DOUBLE TRIANGLE--> 
+    <iconinfo name="media-skip-to-end"
+              font-awesome="fast-forward"
+              unicode="&#x23ED;"/> <!-- BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR--> 
+    <iconinfo name="media-skip-to-start"
+              font-awesome="fast-backward"
+              unicode="&#x23EE;"/> <!-- BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR-->
 </xsl:variable>
 
 <!-- If read from a file via "document()" then   -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -10211,16 +10211,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- by an intervening "tcolorbox".  The template should be placed -->
 <!-- immediately after the "\end{}" of affected environments.      -->
 <!-- It will format as one footnote text per output line.          -->
+<!--                                                               -->
+<!-- We need to pop all interior footnotes iff we are free of      -->
+<!-- enclosing blocks implemented with tcolorbox.  So this         -->
+<!-- template is called at the end of a template for a block,      -->
+<!-- but after the tcolorbox closes.  So we are in the clear when  -->
+<!-- no ancestors are implmented by tcolorbox.  Otherwise, we      -->
+<!-- "wait" and pop all interior footnotes later.                  -->
+<!-- NB: these templates could be improved with an entity          -->
 <xsl:template match="&ASIDE-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&DEFINITION-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|&FIGURE-LIKE;|list|sidebyside|defined-term|objectives|outcomes|backmatter/colophon|assemblage|exercise" mode="pop-footnote-text">
-    <xsl:for-each select=".//fn">
-        <xsl:text>\footnotetext[</xsl:text>
-        <xsl:apply-templates select="." mode="serial-number"/>
-        <xsl:text>]</xsl:text>
-        <xsl:text>{</xsl:text>
-        <xsl:apply-templates />
-        <xsl:apply-templates select="." mode="label" />
-        <xsl:text>}%&#xa;</xsl:text>
-    </xsl:for-each>
+    <xsl:if test="count(ancestor::*[&ASIDE-FILTER; or &THEOREM-FILTER; or &AXIOM-FILTER;  or &DEFINITION-FILTER; or &REMARK-FILTER; or &COMPUTATION-FILTER; or &EXAMPLE-FILTER; or &PROJECT-FILTER; or &FIGURE-FILTER; or self::list or self::sidebyside or self::defined-term or self::objectives or self::outcomes or self::colophon/parent::backmatter or self::assemblage or self::exercise]) = 0">
+        <xsl:for-each select=".//fn">
+            <xsl:text>\footnotetext[</xsl:text>
+            <xsl:apply-templates select="." mode="serial-number"/>
+            <xsl:text>]</xsl:text>
+            <xsl:text>{</xsl:text>
+            <xsl:apply-templates />
+            <xsl:apply-templates select="." mode="label" />
+            <xsl:text>}%&#xa;</xsl:text>
+        </xsl:for-each>
+    </xsl:if>
 </xsl:template>
 
 <!-- Very nearly a no-op, but necessary for HTML -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1859,6 +1859,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\lst@CCPutMacro\lst@ProcessOther {"2D}{\lst@ttfamily{-{}}{-{}}}&#xa;</xsl:text>
         <xsl:text>\@empty\z@\@empty&#xa;</xsl:text>
         <xsl:text>\makeatother&#xa;</xsl:text>
+        <xsl:text>%% We define a null language, free of any formatting or style&#xa;</xsl:text>
+        <xsl:text>%% for use when a language is not supported, or pseudo-code, or consoles&#xa;</xsl:text>
+        <xsl:text>%% Not necessary for Sage code, so in limited cases included unnecessarily&#xa;</xsl:text>
+        <xsl:text>\lstdefinelanguage{none}{identifierstyle=,commentstyle=,stringstyle=,keywordstyle=}&#xa;</xsl:text>
         <xsl:text>\ifthenelse{\boolean{xetex}}{}{%&#xa;</xsl:text>
         <xsl:text>%% begin: pdflatex-specific listings configuration&#xa;</xsl:text>
         <xsl:text>%% translate U+0080 - U+00F0 to their textmode LaTeX equivalents&#xa;</xsl:text>
@@ -1988,9 +1992,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>\definecolor{strings}{rgb}{0,0,0}&#xa;</xsl:text>
                 <xsl:text>\definecolor{keywords}{rgb}{0,0,0}&#xa;</xsl:text>
             </xsl:if>
-            <xsl:text>%% We define a null language, free of any formatting or style&#xa;</xsl:text>
-            <xsl:text>%% for use when a language is not supported, or pseudo-code&#xa;</xsl:text>
-            <xsl:text>\lstdefinelanguage{none}{identifierstyle=,commentstyle=,stringstyle=,keywordstyle=}&#xa;</xsl:text>
             <xsl:text>%% Options passed to the listings package via tcolorbox&#xa;</xsl:text>
             <xsl:text>\lstdefinestyle{programcodestyle}{identifierstyle=\color{identifiers},commentstyle=\color{comments},stringstyle=\color{strings},keywordstyle=\color{keywords}, breaklines=true, breakatwhitespace=true, columns=fixed, extendedchars=true, aboveskip=0pt, belowskip=0pt}&#xa;</xsl:text>
             <!-- NB: rules "at break" need to come after "boxrule"                 -->


### PR DESCRIPTION
I needed an icon for fast-forward which wasn't available, so I have added the suite of icons for the media control and I updated the corresponding section in the author's guide.

```
<icon name='power'/>
<icon name="media-play" />
<icon name="media-pause" />
<icon name="media-stop" />
<icon name="media-fast-forward" />
<icon name="media-rewind" />
<icon name="media-skip-to-end" />
<icon name="media-skip-to-start" />
```

**Important note**

When I was testing this, Latex reported that FontAwesome was not installed as a system font, which was true.  However when I went to the fontawesome.com and downloaded and installed them I continued to get the same error.  Apparently the issue is that in the latest version 5, the fonts are called **Font Awesome 5 Free-Regular-400.otf** and **Font Awesome 5 Free-Solid-900.otf** but  PreTeXt was looking for the previous version called **FontAwesome.otf**

I was able to scrounge this file from another site, but it doesn't seem to be available on the official FontAwesome site.