### PR TITLE
Upgrade Javascript to version 0.12

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -215,7 +215,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.css.server" select="'https://pretextbook.org'" />
 <xsl:param name="html.css.version" select="'0.2'" />
 <xsl:param name="html.js.server" select="'https://pretextbook.org'" />
-<xsl:param name="html.js.version" select="'0.11'" />
+<xsl:param name="html.js.version" select="'0.12'" />
 <xsl:param name="html.css.colorfile" select="''" />
 <!-- A temporary variable for testing -->
 <xsl:param name="debug.colors" select="''"/>


### PR DESCRIPTION
Changes to interactive reading questions required incompatible changes to
the Javascript.  Only difference for PreTeXt is changing Javascript version from
0.11 to 0.12.