### PR TITLE
Extend statement search in extracted WW

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -474,7 +474,7 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
         except:
             bad_xml = True
         if not bad_xml:
-            if problem_root.find('statement') is None:
+            if problem_root.find('.//statement') is None:
                 no_statement = True
 
         file_empty_msg = "PTX:ERROR:  WeBWorK problem {} was empty\n"


### PR DESCRIPTION
This addresses #1120. Enrique ran up against this and reported it to me, so with an affected user  it floated to the top of my to-do list. Super easy. Thanks @mitchkeller .

@rbeezer, should your build script for the sample chapter use `-a`? It would have aborted on the problem there with a `stage` and we would have seen this a long time ago. I must not have been testing with the sample chapter when I made the commit to look for `statement`.