### PR TITLE
Bug Fix: Generate solutions to projects in paragraphs

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -7177,7 +7177,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
             <xsl:with-param name="b-has-heading" select="$b-has-heading"/>
             <xsl:with-param name="content">
 
-                <xsl:for-each select="exercise|exercisegroup|&PROJECT-LIKE;|paragraphs/exercise|self::worksheet//exercise">
+                <xsl:for-each select="exercise|exercisegroup|&PROJECT-LIKE;|paragraphs/exercise|paragraphs/*[&PROJECT-FILTER;]|self::worksheet//exercise">
                      <xsl:choose>
                         <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;)">
                             <xsl:apply-templates select="." mode="solutions">


### PR DESCRIPTION
The solution generator template did not pull hints/answers/solutions from PROJECT-LIKE when they were contained in a `<paragraphs>`.  Added `paragraphs/*[&PROJECT-FILTER;]` as one of the "for-each" parts of the template.

Tested on my project successfully.  Not sure if sample article has this case yet.