### PR TITLE
add info about atom and vscode to guide

### DIFF
--- a/doc/guide/appendices/editors.xml
+++ b/doc/guide/appendices/editors.xml
@@ -11,7 +11,7 @@
     <title>Text Editors, Spell Check</title>
 
     <introduction>
-        <p>This appendix has information about using various text editors efficiently with <pretext/> source, along with suggestions for spell-checking.  The choice of an editor that suits you is a big part of being a productive author.  Despite not being open source, we are partial to Sublime Text, due to its unlimited trial period, reasonable licensing (cost and terms), range of features, community support (plug-ins), and cross-platform support (Linux, Mac, and Windows).  So we lead with Sublime Text, but also include Emacs and XML Copy Editor.  A summary table of schema-aware editors can be found at <xref ref="editors-supporting-schema" />.</p>
+        <p>This appendix has information about using various text editors efficiently with <pretext/> source, along with suggestions for spell-checking.  The choice of an editor that suits you is a big part of being a productive author.  Despite not being open source, we are partial to Sublime Text, due to its unlimited trial period, reasonable licensing (cost and terms), range of features, community support (plug-ins), and cross-platform support (Linux, Mac, and Windows).  So we lead with Sublime Text, but also include Emacs, XML Copy Editor, Atom, Visual Studio Code, and vi/vim.  A summary table of schema-aware editors can be found at <xref ref="editors-supporting-schema" />.</p>
     </introduction>
 
     <section xml:id="section-sublime-text">
@@ -324,6 +324,30 @@
         <title>XML Copy Editor</title>
 
         <p>Michael Doob reports on 2017-02-03 that <url href="http://xml-copy-editor.sourceforge.net/">XML Copy Editor</url><fn><c>xml-copy-editor.sourceforge.net</c></fn> works well, in particular on Windows.  This is an open source program, for Windows and a variety of popular Linux distributions, that supports both <init>DTD</init> and <acro>RELAX-NG</acro> schemas.  It is less of a general programmer's editor and more like dedicated tools for working strictly with <init>XML</init> documents.</p>
+    </section>
+
+    <section xml:id="atom">
+        <title>Atom</title>
+        <author>Oscar Levin</author>
+        <p>
+            An open source alternative to Sublime Text, with many of the same features, is <url href="https://atom.io">Atom</url>, made by the folks at GitHub.  Much of the advise given in <xref ref="section-sublime-text"/> also applies to Atom, although the shortcuts and packages might be slightly different.  Atom is available for Windows, Mac, and Linux.
+        </p>
+
+        <p>
+            There are two packages specifically for <pretext /> that can speed up writing.  First, <url href="https://atom.io/packages/language-pretext">language-pretext</url> provides syntax highlighting and <em>snippets</em> for <pretext /> documents.  This should highlight math enclosed in <tag>m</tag> tags and in fact allow you to use <latex /> snippets there.  The <pretext /> snippets allow you to, for example, start typing <c>example</c> and upon hitting return or tab, expand to the tags needed to write an example.  Particularly helpful are the snippets for <tag>p</tag>, <tag>li</tag>, and <tag>m</tag>, as these put your curser in the right spot (hitting tab again should pop you out of the <tag>m</tag> tags).  
+        </p>
+
+        <p>
+            Second, <url href="https://atom.io/packages/linter-spell-pretext">linter-spell-pretext</url> provides spell checking that is <pretext /> aware (so it should only check your text, not tags for spelling errors).  This requires the linter-spell package, which in turn requires that you have aspell or hunspell installed.
+        </p>
+    </section>
+
+    <section xml:id="vscode">
+        <title>Visual Studio Code</title>
+        <author>Oscar Levin</author>
+        <p>
+            VS Code is a free and open source, cross platform text editor from Microsoft, with many of the same features as Sublime Text and Atom.  The package <url href="https://marketplace.visualstudio.com/items?itemName=oscarlevin.pretext-tools">PreTeXt-tools</url> provides highlighting and snippets for <pretext /> by extending the XML language support of VS Code.
+        </p>
     </section>
 
     <section xml:id="vi">


### PR DESCRIPTION
Added two new sections to the "editors" appendix providing info about the plugins available for atom and vs code.  Adjusted the intro to this section to reflect these additions (and to mention the sections on the other editors now with sections).