### PR TITLE
Add support for amsmath and 3d pdf

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -106,7 +106,7 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)
             asypng = "{}_*.png".format(filebase)
-            asy_cmd = [asy_executable, '-offscreen', '-batchMask', '-outformat', outformat, asydiagram]
+            asy_cmd = [asy_executable, '-noprc', '-offscreen', '-batchMask', '-outformat', outformat, asydiagram]
             _verbose("converting {} to {}".format(asydiagram, asyout))
             _debug("asymptote conversion {}".format(asy_cmd))
             subprocess.call(asy_cmd, stdout=devnull, stderr=subprocess.STDOUT)

--- a/xsl/extract-asymptote.xsl
+++ b/xsl/extract-asymptote.xsl
@@ -48,6 +48,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select=".." mode="visible-id" />
     </xsl:variable>
     <exsl:document href="{$scratch}/{$filebase}.asy" method="text">
+        <xsl:text>usepackage("amsmath"):</xsl:text>
         <xsl:text>texpreamble("&#xa;</xsl:text>
         <xsl:value-of select="$latex-macros" />
         <xsl:text>");&#xa;&#xa;</xsl:text>


### PR DESCRIPTION
Add -noprc option to asy build command in mbx script.
Add line in extract-asymptote.xsl to put `usepackage("amsmath");` as first line in each .asy file.
Otherwise, any instances of `\DeclareMathOperator` in the texpreamble will cause build to fail.
I did not bother to also add the line to the deprecated template.