### PR TITLE
add test to only show 'chapter' in heading when it gets a number

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -773,7 +773,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:element name="{$html-heading}">
         <xsl:attribute name="class">
             <xsl:choose>
-                <xsl:when test="self::chapter">
+                <xsl:when test="self::chapter and $numbering.maximum.level!='0'">
                     <xsl:text>heading</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>


### PR DESCRIPTION
This fixes the following bug: 

If numbering.maximum.level is set to 0, not even chapters get numbers.  In HTML this results in the heading for the chapter still having the word "Chapter" followed by the title of the chapter.  

Fix adds $numbering.maximum.level!=0 to the test for applying "heading" as the class of the title.