### PR TITLE
Give sample book frontmatter new xml:id

### DIFF
--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -25,7 +25,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!-- Copyright (C) 1997-2014  Thomas W. Judson     -->
 
-<frontmatter xml:id="sample-book" xmlns:xi="http://www.w3.org/2001/XInclude">
+<frontmatter xml:id="frontmatter" xmlns:xi="http://www.w3.org/2001/XInclude">
 
     <titlepage>
 


### PR DESCRIPTION
In the sample-book, both the `book` and `frontmatter` elements have xml:id "sample-book". I was seeing a duplicate xml:id error. This changes the `frontmatter` id to "frontmatter".