### PR TITLE
Slide documentation

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -499,4 +499,21 @@
 
         <p>Since we are interested in helping authors produce documents with open licenses, and we concentrate on employing open standards for the <init>HTML</init> output we create, we are ideally positioned to help you easily create highly-accessible documents.  There are many technical features which happen automatically, and there are some features which we make available for your use as an author and which only an author can provide.  See <xref ref="topic-accessibility" /> for full details and ways you can make the <init>HTML</init> version of your document more accessible, and more useful for a wider audience.</p>
     </section>
+    <section xml:id="overview-slides">
+      <title>Slides</title>
+      <idx>slides</idx>
+      <p>
+In addition to articles and books, support for authoring slideshows is also available,
+but is experimental (so tags and attributes are subject to change).
+      </p>
+      <p>
+Currently, support for producing <url href="https://revealjs.com">Reveal.js</url>
+and <url href="https://en.wikipedia.org/wiki/Beamer_(LaTeX)">Beamer <m>\LaTeX{}</m></url>
+slideshows is available. Details on authoring may be found in <xref ref="topic-slides" />.
+      </p>
+      <p>
+Also, future support for annotating PreTeXt books and articles to export PreTeXt slides
+is in the works, but not yet available.
+      </p>
+    </section>
 </chapter>

--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -509,7 +509,8 @@ but is experimental (so tags and attributes are subject to change).
       <p>
 Currently, support for producing <url href="https://revealjs.com">Reveal.js</url>
 and <url href="https://en.wikipedia.org/wiki/Beamer_(LaTeX)">Beamer <m>\LaTeX{}</m></url>
-slideshows is available. Details on authoring may be found in <xref ref="topic-slides" />.
+slideshows is available. Details on authoring may be found in <xref ref="topic-slides" />,
+and publishing details are in <xref ref="publisher-slides" />.
       </p>
       <p>
 Also, future support for annotating PreTeXt books and articles to export PreTeXt slides

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2331,6 +2331,7 @@ Following is a somewhat minimal working example.
       &lt;/titlepage&gt;
     &lt;/frontmatter&gt;
     &lt;section&gt;
+      &lt;title&gt;Title of Section&lt;/title&gt;
       &lt;slide&gt;
         &lt;title&gt;PDX &lt;m&gt;\iff&lt;/m&gt; PTX&lt;/title&gt;
         &lt;ul&gt;

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2307,7 +2307,9 @@ Similar to articles, your content should be organized into several
           <li>
 And within each section, a <c>slide</c> represents a full screen of information.
 Within a slide, you may author PreTeXt content as usual, such as paragraphs
-(<c>p</c>), lists (<c>ul</c>), and so on. 
+(<c>p</c>), lists (<c>ul</c>), and so on. The <c>@slide-step="true"</c> attribute
+is supported on several elements to allow stepping through slides
+(e.g. it inserts a Beamer <c>\pause</c>).
           </li>
         </ul>
         <p>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2288,4 +2288,77 @@
             </li>
         </dl></p>
     </section>
+    <section xml:id="topic-slides">
+        <title>Slides</title>
+        <idx>slides</idx>
+        <p>
+Slideshows may be authored in PreTeXt by using the following tags.
+        </p>
+        <ul>
+          <li>
+<c>slideshow</c> replaces the usual <c>article</c> or <c>book</c> tag to
+let PreTeXt know you are authoring a set of slides. As usual, you may then
+define your <c>title</c>, <c>subtitle</c>, and <c>frontmatter</c>.
+          </li>
+          <li>
+Similar to articles, your content should be organized into several
+<c>section</c>s.
+          </li>
+          <li>
+And within each section, a <c>slide</c> represents a full screen of information.
+Within a slide, you may author PreTeXt content as usual, such as paragraphs
+(<c>p</c>), lists (<c>ul</c>), and so on. 
+          </li>
+        </ul>
+        <p>
+Following is a somewhat minimal working example.
+        </p>
+      <pre>
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;pretext&gt;
+  &lt;slideshow&gt;
+    &lt;title&gt;Hello World!&lt;/title&gt;
+    &lt;subtitle&gt;Sample PreTeXt slides&lt;/subtitle&gt;
+    &lt;frontmatter&gt;
+      &lt;titlepage&gt;
+        &lt;author&gt;
+          &lt;personname&gt;Your Name&lt;/personname&gt;
+          &lt;affiliation&gt;Your School&lt;/affiliation&gt;
+          &lt;logo&gt;&lt;image source="path/to/your/image.png"/&gt;&lt;/logo&gt;
+        &lt;/author&gt;
+        &lt;event&gt;PreTeXt Workshop 20XX&lt;/event&gt;
+        &lt;date&gt;Month 20XX&lt;/date&gt;
+      &lt;/titlepage&gt;
+    &lt;/frontmatter&gt;
+    &lt;section&gt;
+      &lt;slide&gt;
+        &lt;title&gt;PDX &lt;m&gt;\iff&lt;/m&gt; PTX&lt;/title&gt;
+        &lt;ul&gt;
+          &lt;li&gt;&lt;p&gt;One item&lt;/p&gt;&lt;/li&gt;
+          &lt;li&gt;&lt;p&gt;Another item&lt;/p&gt;&lt;/li&gt;
+          &lt;li&gt;&lt;p&gt;
+            A really long item which is really far too long to be an 
+            item in a talk. Points should really be only a single line 
+            unless they are really important.
+          &lt;/p&gt;&lt;/li&gt;
+        &lt;/ul&gt;
+      &lt;/slide&gt;
+      &lt;slide&gt;
+        &lt;title&gt;A second slide here&lt;/title&gt;
+        &lt;p&gt;
+          Words and stuff
+        &lt;/p&gt;
+        &lt;p&gt;
+          &lt;ul slide-step="true"&gt;
+            &lt;li&gt;&lt;p&gt;First thing&lt;/p&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;p&gt;Second thing&lt;/p&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;p&gt;Third thing&lt;/p&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/p&gt;
+      &lt;/slide&gt;
+    &lt;/section&gt;
+  &lt;/slideshow&gt;
+&lt;/pretext&gt;
+      </pre>
+    </section>
 </chapter>

--- a/doc/guide/guide.xml
+++ b/doc/guide/guide.xml
@@ -53,6 +53,7 @@
             <xi:include href="publisher/online-html.xml"/>
             <xi:include href="publisher/pdf-print.xml"/>
             <xi:include href="publisher/epub.xml"/>
+            <xi:include href="publisher/slides.xml"/>
             <xi:include href="publisher/jupyter-notebook.xml"/>
             <xi:include href="publisher/instructor-version.xml"/>
             <xi:include href="publisher/ancillaries.xml"/>

--- a/doc/guide/publisher/slides.xml
+++ b/doc/guide/publisher/slides.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<chapter xml:id="publisher-slides">
+    <idx>slides</idx>
+    <title>Conversion to Slides</title>
+    <introduction>
+        <p>
+As discussed in <xref ref="overview-slides"/> and <xref ref="topic-slides"/>,
+support is available for authoring slideshows in PreTeXt. Currently, slideshows
+must be authored explicitly, but we hope to eventually support annotating
+books and articles to export appropriate content as slides.
+        </p>
+    </introduction>
+    <section xml:id="publisher-revealjs">
+        <title>Reveal.js</title>
+        <p>
+Run this to produce a Reveal.js slideshow:
+        </p>
+        <pre>
+xsltproc -o path/to/output/slides.html --xinclude path/to/pretext/xsl/pretext-revealjs.xsl path/to/source/slides.xml 
+        </pre>
+        <p>
+Two string parameters (see <xref ref="processing-parameters"/>) are available.
+        </p>
+        <ul>
+            <li>
+Insert <c>-stringparam local yes</c> to have the resulting HTML use a local
+installation of Reveal.js rather than the CDN installation used by default.
+In particular, you will need to make sure Reveal.js's <c>css</c> and
+<c>js</c> folders are located in the same folder that the resulting HTML
+is served from.
+            </li>
+            <li>
+Insert <c>-stringparam theme {theme-name}</c> to choose a theme besides
+the default of <c>simple</c>. For example, to use the theme located at
+<c>css/theme/solarized.css</c>, replace <c>{theme name}</c> with <c>solarized</c>.
+            </li>
+        </ul>
+    </section>
+    <section xml:id="publisher-beamer">
+        <title>Beamer <m>\LaTeX{}</m></title>
+        <p>
+Run this to produce a Beamer <m>\LaTeX{}</m> slideshow:
+        </p>
+        <pre>
+xsltproc -o path/to/output/slides.tex --xinclude path/to/pretext/xsl/pretext-beamer.xsl path/to/source/slides.xml 
+        </pre>
+        <p>
+Of course, you should then run e.g. <c>pdflatex slides.tex</c> to produce a PDF.
+        </p>
+    </section>
+</chapter>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -183,12 +183,14 @@ Reveal.initialize({
 <!-- but first we make a special slide announcing the "section" -->
 <xsl:template match="section">
     <section>
-        <h1>
-          <xsl:apply-templates select="." mode="title-full"/>
-        </h1>
+        <section>
+            <h1>
+                <xsl:apply-templates select="." mode="title-full"/>
+            </h1>
+        </section>
+        <xsl:apply-templates select="slide"/>
     </section>
     <!--  -->
-    <xsl:apply-templates select="slide"/>
 </xsl:template>
 
 <xsl:template match="titlepage" mode="title-slide">


### PR DESCRIPTION
This PR adds documentation for the experimental slide authoring features of PreTeXt. I've also snuck in a fix to #1184 to vertically organize slides within each section in Reveal.js output.