### PR TITLE
Read developer.css file at end of HTML

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -7851,6 +7851,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="login-footer">
     <div class="login-link"><span id="loginlogout" class="login">login</span></div>
     <script src="{$html.js.server}/js/{$html.js.version}/login.js"></script>
+    <!-- A CSS file that is read in last, for development only, possibly temporary. -->
+    <link href="developer.css" rel="stylesheet" type="text/css"/>
 </xsl:template>
 
 <!-- Console Session -->


### PR DESCRIPTION
Add a link to a local "developer.css" file.  This is useful for development and it
allows the use of the same CSS selectors as the main CSS, because it occurs at
the end of the HTML file.

A developer has to create the developer.css file before using it.