### PR TITLE
Fix "missing number treated as zero" bug

### DIFF
--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -2160,7 +2160,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>%% tcolorbox styles for sidebyside layout&#xa;</xsl:text>
                 <!-- "frame empty" is needed to counteract very faint outlines in some PDF viewers -->
                 <!-- framecol=white is inadvisable, "frame hidden" is ineffective for default skin -->
-                <xsl:text>\tcbset{ sbsstyle/.style={raster before skip={2.0ex plus 0.5ex}, raster equal height=rows, raster force size=false} }&#xa;</xsl:text>
+                <xsl:text>\tcbset{ sbsstyle/.style={raster before skip=2.0ex, raster equal height=rows, raster force size=false} }&#xa;</xsl:text>
                 <xsl:text>\tcbset{ sbspanelstyle/.style={bwminimalstyle} }&#xa;</xsl:text>
             </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
When a `sidebyside` is not in a figure, and latex is compiled using TeXLive 2019, an error "missing number treated as zero" is thrown.  Changing the value of `raster before skip` to a single number instead of `{2.0ex plus 0.5ex}` resolves this issue.  

Still works with TeXLive 2018 compile.  Limited testing does not reveal any noticeable differences. 