### PR TITLE
Add description list for revealjs

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -276,6 +276,13 @@ Reveal.initialize({
   </ol>
 </xsl:template>
 
+<xsl:template match="dl">
+  <dl>
+    <xsl:apply-templates select="li"/>
+  </dl>
+</xsl:template>
+
+
 <xsl:template match="li">
   <li>
     <xsl:if test="parent::*/@slide-step = 'true'">
@@ -287,6 +294,14 @@ Reveal.initialize({
   </li>
 </xsl:template>
 
+<xsl:template match="dl/li">
+  <dt>
+    <xsl:apply-templates select="." mode="title-full"/>
+  </dt>
+  <dd>
+    <xsl:apply-templates select="*[not(title)]"/>
+  </dd>
+</xsl:template>
 
 <xsl:template match="p">
   <p>


### PR DESCRIPTION
Here's a simple `dl` implementation. For example, it made [slide 2](https://spot.pcc.edu/~ajordan/AMATYC2019ORCCA/#/2).