### PR TITLE
LaTeX: include index entries from exercises

### DIFF
--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -5036,6 +5036,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\begin{inlineexercise}</xsl:text>
     <xsl:apply-templates select="." mode="block-options"/>
     <xsl:text>%&#xa;</xsl:text>
+    <xsl:apply-templates select="idx"/>
     <!-- Allow a webwork or myopenmath exercise to introduce/connect    -->
     <!-- a problem (especially from server) to the text in various ways -->
     <xsl:if test="webwork-reps|myopenmath">


### PR DESCRIPTION
An `idx` inside an `exercise` currently doesn't do anything for LaTeX output. Index entries simply go missing from print. This is one way to address that, although I'm not sure if it's the right way.