### PR TITLE
Add option to use custom css style

### DIFF
--- a/examples/sample-book/publication.xml
+++ b/examples/sample-book/publication.xml
@@ -28,6 +28,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- default behavior, but we do this as a test and as an  -->
         <!-- illustration                                          -->
         <index-page ref="sample-book"/>
+        <!-- specify the style of the html by giving names to      -->
+        <!-- override defaults.  Ex: to use "style_oscarlevin.css" -->
+        <!-- put <css style="oscarlevin"/>                         -->
+        <!-- @colors currently unimplementd.                       -->
+        <css style="default" colors="blue_red"/>
     </html>
 
 </publication>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -217,6 +217,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.js.server" select="'https://pretextbook.org'" />
 <xsl:param name="html.js.version" select="'0.12'" />
 <xsl:param name="html.css.colorfile" select="''" />
+<xsl:param name="html.css.stylefile" select="''" />
 <!-- A temporary variable for testing -->
 <xsl:param name="debug.colors" select="''"/>
 
@@ -243,6 +244,29 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
+
+<!-- 2019-11-24: this selects the style_default            -->
+<!-- unless there is a style specified in a publisher.xml  -->
+<!-- file or as a string-param. (OL)                       -->
+<xsl:variable name="html-css-stylefile">
+    <xsl:choose>
+        <!-- if string-param is set, use it (highest priority) -->
+        <xsl:when test="not($html.css.stylefile = '')">
+            <xsl:value-of select="$html.css.stylefile"/>
+        </xsl:when>
+        <!-- if publisher.xml file has style value, use it -->
+        <xsl:when test="$publication/html/css/@style">
+            <xsl:text>style_</xsl:text>
+            <xsl:value-of select="$publication/html/css/@style"/>
+            <xsl:text>.css</xsl:text>
+        </xsl:when>
+        <!-- otherwise use the dafault -->
+        <xsl:otherwise>
+            <xsl:text>style_default.css</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- A space-separated list of CSS URLs (points to servers or local files) -->
 <xsl:param name="html.css.extra"  select="''" />
 
@@ -10296,7 +10320,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <link href="{$html.css.server}/css/{$html.css.version}/banner_default.css" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/toc_default.css" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/knowls_default.css" rel="stylesheet" type="text/css" />
-    <link href="{$html.css.server}/css/{$html.css.version}/style_default.css" rel="stylesheet" type="text/css" />
+    <link href="{$html.css.server}/css/{$html.css.version}/{$html-css-stylefile}" rel="stylesheet" type="text/css" />
+    <!-- <link href="{$html.css.server}/css/{$html.css.version}/style_default.css" rel="stylesheet" type="text/css" /> -->
     <link href="{$html.css.server}/css/{$html.css.version}/{$html-css-colorfile}" rel="stylesheet" type="text/css" />
     <link href="{$html.css.server}/css/{$html.css.version}/setcolors.css" rel="stylesheet" type="text/css" />
     <!-- If extra CSS is specified, then unpack multiple CSS files -->


### PR DESCRIPTION
Implemented as both a stringparam and element of publisher.xml options file.  String param is given preference (this might not be needed, but was good practice to make backwards compatible publisher.xml file options in the future).

I opted to include a new child of `publication/html` called `css` rather than including `@css-style` as an attribute of `publication/html`.  This seemed natural, but is certainly open to debate.  See publication.xml in sample-book.  As an example, I put `@colors` as another attribute of the `css` element, but this is not yet implemented (I could easily add this to the pull request, but it would take a small refactor of the html-css-colorfile xsl variable code).