### PR TITLE
WeBWorK: remove title from samples, mbx script

### DIFF
--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -37,7 +37,6 @@
       <title><webwork /> Minimal Section</title>
       <exercise>
         <webwork>
-          <title>Integer Addition</title>
           <setup>
             <pg-code>
               $a = Compute(random(1, 9, 1));

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -129,8 +129,6 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition">
-                    <title>Integer Addition</title>
-
                     <setup>
                         <pg-code>
                             $a = Compute(random(1, 9, 1));
@@ -164,8 +162,6 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition-with-seed" seed="510">
-                    <title>Integer Addition</title>
-
                     <setup>
                         <pg-code>
                             $a = Compute(random(1, 9, 1));
@@ -193,8 +189,6 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition-with-control-seed" seed="1">
-                    <title>Integer Addition</title>
-
                     <setup>
                         <pg-code>
                             $a = Compute(random(1, 9, 1));
@@ -228,7 +222,6 @@
                 </introduction>
 
                 <webwork>
-                    <title>Multiplication with Exponents</title>
                     <pg-macros>
                         <macro-file>contextLimitedPolynomial.pl</macro-file>
                     </pg-macros>
@@ -278,7 +271,6 @@
                 </introduction>
 
                 <webwork>
-                    <title>Multiplication with Exponents</title>
                     <setup>
                         <pg-code>
                             do {
@@ -407,8 +399,6 @@
                     </setup>
 
                     <stage>
-                        <title>Part 1: Identify the coefficients</title>
-
                         <statement>
                             <p>Consider the quadratic equation given by <me><var name="$quadratic" /> = 0\text{.}</me>  First, identify the coefficients for the quadratic equation using the standard form from <xref ref="theorem-quadratic-formula" />.</p>
 
@@ -421,8 +411,6 @@
                     </stage>
 
                     <stage>
-                        <title>Part 2: Solve using the quadratic formula</title>
-
                         <statement>
                             <p>Using the quadratic formula, solve <m><var name="$quadratic"/>=0</m>.</p>
                             <p><m>x=</m> <var name="$multians1" width="15"/> or <m>x=</m> <var name="$multians1" width="15"/></p>
@@ -937,7 +925,7 @@
             <p>This section samples the subject area template problems found on the <webwork /> wiki at <url href="http://webwork.maa.org/wiki/SubjectAreaTemplates"/>.</p>
 
             <exercise>
-            <title>Answer is a number or a function</title>
+                <title>Answer is a number or a function</title>
 
                 <webwork xml:id="number-or-function">
 

--- a/script/mbx
+++ b/script/mbx
@@ -574,12 +574,6 @@ def webwork_to_xml(xslt_exec, ptx_xsl_dir, xml_source, server_params, dest_dir):
             static[problem] = static[problem].replace('<webwork>', '<static>')
             static[problem] = static[problem].replace('</webwork>', '</static>')
 
-        # if authored has a title, copy it here
-        if origin[problem] == 'ptx':
-            title = re.search(r'(<title>.*<\/title>)', source[problem])
-            if title:
-                static[problem] = static[problem].replace('<static>\n','<static>\n' + title.group(1) + '\n\n')
-
         # Convert answerhashes XML to a sequence of answer elements
         # This is crude text operation on the XML
         # If correct_ans_latex_string is nonempty, use it, encased in <p><m>


### PR DESCRIPTION
This follows through with #873, removing `title` and `idx` as schema-compliant children of a `webwork`. To go along with that, `title`s are removed from the sample-chapter and minimal webwork examples. And lastly, there was a section in the `mbx` script that was intentionally copying authored `title`s into the static representations, and this removes that.

I think I am doing the right thing, in only editing `schema/pretext.xml` in the schema folder. And I think that means you generate the other schema folder files before making the "real" commit for this.