### PR TITLE
Add note about -xinclude flag to xsltproc in the quick start Processing section in the guide

### DIFF
--- a/doc/guide/introduction/quickstart-example.xml
+++ b/doc/guide/introduction/quickstart-example.xml
@@ -101,8 +101,9 @@
 		<p> Note that if your project includes multiple files you will need to pass the <c>-xinclude</c> flag to <c>xsltproc</c>, though this is not needed for this simple example.
 		An example of this is the command
 		<cd><cline>xsltproc -xinclude /path/to/mathbook/xsl/mathbook-html.xsl /path/to/index.xml</cline></cd>
+		For more on this see <xref ref="topic-xinclude" /> and <xref ref="processing-modular" />.
 		</p>
-
+	
         <p>That's it.  You now know all the basics of authoring with <pretext />, since you have produced two radically different output formats with identical content from the exact same structured input, via two different command lines.  Everything you need to author a complete article or textbook, and produce it in many different formats, is just an extension or variation on what you just did.  Let us look at a few simple extensions right away before being more methodical.</p>
     </section>
 

--- a/doc/guide/introduction/quickstart-example.xml
+++ b/doc/guide/introduction/quickstart-example.xml
@@ -98,6 +98,11 @@
             <cline>pdflatex quick.tex</cline>
         </cd>In the current working directory you should now find the file <c>quick.pdf</c> which you can view or print with standard PDF viewing software.  You could even send it to a print-on-demand service to get nice hardback books, though I suspect sales will not be great.</p>
 
+		<p> Note that if your project includes multiple files you will need to pass the <c>-xinclude</c> flag to <c>xsltproc</c>, though this is not needed for this simple example.
+		An example of this is the command
+		<cd><cline>xsltproc -xinclude /path/to/mathbook/xsl/mathbook-html.xsl /path/to/index.xml</cline></cd>
+		</p>
+
         <p>That's it.  You now know all the basics of authoring with <pretext />, since you have produced two radically different output formats with identical content from the exact same structured input, via two different command lines.  Everything you need to author a complete article or textbook, and produce it in many different formats, is just an extension or variation on what you just did.  Let us look at a few simple extensions right away before being more methodical.</p>
     </section>
 


### PR DESCRIPTION
After having some problems compiling my document that David Farmer converted from LaTeX, I added a note about the -xinclude flag in the Processing section of the quick start chapter in the guide. Adding this was recommended by David.