### PR TITLE
add environments section to showcase

### DIFF
--- a/examples/showcase/environments.ptx
+++ b/examples/showcase/environments.ptx
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- This file is part of the PreTeXt Showcase article. -->
+<!--                                                    -->
+<!-- Copyright (©) 2019 The PreTeXt Organization.       -->
+<!-- See the README file for contributing guidelines.   -->
+
+<section xml:id="environments">
+  <title>Environments</title>
+  <author>Oscar Levin</author>
+  <introduction>
+    <p>
+      This section will demonstrate some of the <q>environments</q> available in <pretext />.  In addition to cataloging the options an author has to break up content, this will be a nice place to play with various styles that are under development. 
+    </p>
+    <p>
+      Maybe a better way to describe what this section will do is by specifying our objectives.  Luckily there is an environment for that.
+    </p>
+    <objectives>
+      <ul>
+        <li>
+          <p>
+            Illustrate the various environments (blocks) available in <pretext />.
+          </p>
+        </li>
+        <li>
+          <p>
+            Provide a section that can be used to evaluate new styles.
+          </p>
+        </li>
+      </ul>
+    </objectives>
+    
+  </introduction>
+  <subsection>
+    <title>Traditional Structure</title>
+    <p>
+      Many mathematics papers and textbook chapters are organized in the traditional definition-lemma-proof-theorem-proof format.  Depending on how friendly the paper is, or who the intended audience is, there might be quite a bit of exposition surrounding these elements.  This subsection is intended to be an illustration of this structure.
+    </p>
+    <p>
+      We begin with some basic definitions.  Depending on the narrative style of your text, you might want to define terms in the middle of paragraphs.  We might call this an  <term>inline definition</term>, which can be accomplished using the <tag>term</tag> tag.  
+    </p>
+
+    <p>
+      More formal texts will likely want numbered definitions.
+    </p>
+    <definition xml:id="def-numbered-definition">
+      <statement>
+        <p>
+          A <term>numbered definition</term> is a definition that gets a number.  Note that we should still put the term being defined in <tag>term</tag> tags.
+        </p>
+      </statement>
+    </definition>
+    <p>
+      One advantage to having numbered definitions (see <xref ref="def-numbered-definition"/>) is that you can refer to them, just like we just did.  We can also refer to titled definitions (see <xref ref="def-titled-definition"/>).
+    </p>
+    <definition xml:id="def-titled-definition">
+      <title>Titled definitions</title>
+      <statement>
+        <p>
+          When a definition is a numbered definition that also gets a title, we call it a <term>titled definition</term>.
+        </p>
+      </statement>
+    </definition>
+
+    <p>
+      At this point it might be useful to give a few examples of the terms defined by your definitions.  Of course here the definitions are examples of definitions, so instead will illustrate our point with an example of an example.
+    </p>
+
+    <example>
+      <p>
+        This example is an example of an example that stands alone.  It does not have a question in it, so it does not need a solution.  
+      </p>
+      <p>
+        Of course examples can consist of more than one paragraph, as this is also an example of.  In fact, we could put an ordered list of things that could go in an example:
+        <ol>
+          <li>
+            <p>
+              There could just be a paragraph or two.
+            </p>
+          </li>
+          <li>
+            <p>
+              There could be a list of examples.
+            </p>
+          </li>
+          <li>
+            <p>
+              All of the above.
+            </p>
+          </li>
+        </ol>
+      </p>
+    </example>
+
+    <p>
+      While on this topic, it is worth mentioning that many authors choose to include examples of problems that can be solved.  This suggests that part of an example is the solution.  For example:
+    </p>
+
+    <example>
+      <idx><h>example</h><h>of example</h></idx>
+      <statement>
+        <p>
+          How do you include an example that has a solution, and maybe also a hint?
+        </p>
+      </statement>
+      <hint>
+        <p>
+          Make sure you put the <q>question</q> is the <tag>statement</tag>.
+        </p>
+      </hint>
+      <solution>
+        <p>
+          As mentioned in the hint, you must structure the example as a statement, followed by a hint, answer, and/or solution.
+        </p>
+        <p>
+          This example is not an example of an example that has a separate answer, but of course you could have an answer as well.
+        </p>
+      </solution>
+    </example>
+
+    <example>
+      <title>Examples with titles</title>
+      <statement>
+        <p>
+          Can examples have titles?
+        </p>
+      </statement>
+      <answer>
+        <p>
+          Yes.
+        </p>
+      </answer>
+    </example>
+
+    <p>
+      Returning to our main goal of establishing new mathematical theory, we might next state an axiom or two (especially if we are named <personname>Euclid</personname>).  In <pretext /> the environments for axioms are not <q>definition-like</q> (the only definition-like environment is a definition).  There are quite a few <q>axiom-like</q> environments.
+    </p>  
+    <axiom xml:id="axiom-example">
+      <statement>
+        <p>
+          Axiom-like environments consist of: axiom, conjecture, principle, heuristic, hypothesis, and assumption.  
+        </p>
+      </statement>
+    </axiom>
+
+    <p>
+      Once you have defined your terms and stated your axioms, you will likely want to prove something.  Perhaps you will start with a <term>lemma</term> or two, use them to prove a <term>theorem</term>, followed by a few <term>corollaries</term>.  If you are not as confident in the importance of your results, you might call them <term>propositions</term> or just <term>facts</term>.
+    </p>
+    <lemma xml:id="lem-example">
+      <statement>
+        <p>
+          There exist lemmas that are presented without proof.
+        </p>
+      </statement>
+    </lemma>
+    <p>
+      The lemma above did not have a proof, since it's proof is obvious.  
+    </p>
+    <lemma xml:id="lem-with-proof">
+      <statement>
+        <p>
+          Lemmas can have proofs.
+        </p>
+      </statement>
+      <proof>
+        <p>
+          This is clear, as it follows from the proof of <xref ref="lem-with-proof"/>.
+        </p>
+      </proof>
+    </lemma>
+    <p>
+      Using the two lemmas above, we arrive at the following:
+    </p>
+    <theorem xml:id="thm-example">
+      <title>The Fundamental Theorem of Nonsense</title>
+      <statement>
+        <p>
+          Let <m>P</m> be any statement that follows from the two lemmas above.  Then <m>P</m> is true.
+        </p>
+      </statement>
+    </theorem>
+    <p>
+      There is no reason you need to prove a theorem right away.  You can always have some text, like this paragraph, before the proof.  You could even have an example of how a theorem could be applied before pulling the reader back in for the eagerly awaited proof.
+    </p>
+
+     <example>
+       <p>
+         This is an example of how you might interject an example before completing a proof.  As such it is put between the statement of the theorem and its proof.
+       </p>
+     </example> 
+      
+    <p>
+      Note that if you don't give a proof a title, it will get titled <q>proof</q> automatically.  It makes sense to put a custom title in this case since you are referring to a proof of the a theorem that was stated without proof earlier.
+    </p>
+
+    <proof>
+      <title>Proof of <xref ref="thm-example"/></title>
+      <p>
+        Let <m>P</m> be as described in the theorem. By the lemmas, <m>P</m> is true.   
+      </p>
+      <p>
+        Therefore, <m>P</m>.
+      </p>
+    </proof>
+
+    <corollary xml:id="cor-example">
+      <statement>
+        <p>
+          The previous theorem is not useful.
+        </p>
+      </statement>
+    </corollary>
+
+    <p>
+      Lemmas, theorems, and corollaries naturally go together.  There are other theorem-like environments that you might view as parallel to these.  Here is an example.
+    </p>
+
+    <proposition xml:id="prop-example">
+      <statement>
+        <p>
+          Propositions are like theorems, but perhaps not as important.
+        </p>
+      </statement>
+    </proposition>
+
+    <p>
+      If students are reading your textbook, it might be time to collect the main points that you have made for your students and put them in a box.  You could also put your result in the box and let your student roam free.  The following is an <tag>assemblage</tag>.
+    </p>
+
+    <assemblage xml:id="assemblage-example">
+      <title>Types of environments</title>
+      <p>
+        <p>
+          <pretext /> allows for a variety of environments:
+          <ul>
+            <li>
+              <p>
+              Definitions
+              </p>
+            </li>
+            <li>
+              <p>
+              Theorem-like environments
+              </p>
+            </li>
+            <li>
+              <p>
+              Assemblages, to assemble or summarize important connected ideas.
+              </p>
+            </li>
+          </ul>
+        </p>
+      </p>
+    </assemblage>
+
+    <p>
+      Your paper will likely have lots of remarks about its content as the connecting text between theorems, as this section exemplifies.  However, it might also be useful to highlight important remarks, or to set off remarks that do not otherwise fit into the main flow of the text.
+    </p>
+
+    <remark>
+      <p>
+        Resist the temptation to use assemblages just because they give you the desired styling.
+      </p>
+    </remark>
+
+    <p>
+      If your remark is far removed from your main content, you might make it as an aside.
+    </p>
+
+    <aside>
+      <p>
+        The <tag>aside</tag> environment might be styled so that it is literally on the side of the page.  Also, some cats are better than some dogs, but some dogs are better than all cats.
+      </p>
+    </aside>
+
+    <note>
+      <p>
+        Another environment like a remark is a <term>note</term>.  Other <q>remark-like</q> environments are <tag>convention</tag>, <tag>observation</tag>, <tag>warning</tag>, and <tag>insight</tag>.
+      </p>
+    </note>
+
+    <p>
+      No self-respecting paper on self-reference would be complete without some open questions.  You might make some conjectures, which are axiom-like environments in <pretext />.
+    </p>
+    <conjecture xml:id="conj-example">
+      <statement>
+        <p>
+          All the conjectures made in this paper are false.
+        </p>
+      </statement>
+    </conjecture>
+
+    <p>
+      You might also present a question for your readers.  The <tag>question</tag> and <tag>problem</tag> environments might be appropriate, although note that these are example-like, as they can receive hints, answers, and solutions.
+    </p>
+
+    <question xml:id="question-example">
+      <statement>
+        <p>
+          What's the difference between an example and a question or problem?
+        </p>
+      </statement>
+      <solution>
+        <p>
+          Basically, it's just the name of the environment.  Practically, the different environments might have pedagogical uses, and potentially they could be styled differently.
+        </p>
+      </solution>
+    </question>
+    <problem>
+      <p>
+        Find a better solution to <xref ref="question-example"/>.
+      </p>
+    </problem>
+
+
+    <p>
+      As a final example, we present a renamed environment.  In <pretext />, one of the theorem-like environments is fact.  But perhaps you would rather use <q>Self Evident Fact</q> as your environment name.  The following is coded as <tag>fact</tag>, but  using <tag>rename</tag> in <tag>docinfo</tag> we can get the following
+    </p>
+
+    <fact xml:id="fact-example">
+      <statement>
+        <p>
+          It goes without saying!
+        </p>
+      </statement>
+    </fact>
+    <p>
+      In addition to <tag>example</tag>, <pretext /> provides two more <q>example-like</q> environments: question and problem.  
+    </p>
+
+  </subsection>
+
+  <subsection xml:id="subsec-the-rest">
+    <title>Inquiry Based Structure</title>
+    <p>
+      Another way you might structure a chapter is to give students more opportunities to actively engage in the material.  You might give a long list of definitions, and then a list of theorems to prove.  That would look a lot like the previous section (perhaps with fewer paragraphs between elements).  
+    </p>
+    <p>
+      Alternatively, you can mix inquiry based learning (<acro>IBL</acro>) structure into a more traditionally formatted section using appropriate environments.  You might start a section with an <tag>activity</tag>, for example.
+    </p>
+    <activity>
+      <statement>
+        <p>
+          Make a list of all the project-like environments, such as this activity.
+        </p>
+      </statement>
+    </activity>   
+
+    <p>
+      You might want to break down the activity into smaller tasks, which can be done by specifying each <tag>task</tag>, as in the following project.
+    </p> 
+
+    <project>
+      <introduction>
+        <p>
+          First you give an introduction to the project to tie the tasks together.  Then:
+        </p>
+      </introduction>
+      <task>
+        <p>
+          Specify the first task.
+        </p>
+      </task>
+      <task>
+        <statement>
+          <p>
+            Should the second task have a hint?
+          </p>
+        </statement>
+        <hint>
+          <p>
+            It could.
+          </p>
+        </hint>
+      </task>
+      <task>
+        <statement>
+          <p>
+            Can tasks, or stand alone projects, have answers or solutions?
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Yes.  They can have both.
+          </p>
+        </answer>
+        <solution>
+          <p>
+            Yes, they can.  Depending on how the publisher chooses to produce your book, these could be hidden completely, moved to the back of the book, or displayed as knowls.
+          </p>
+        </solution>
+      </task>
+      <conclusion>
+        <p>
+          You might end the project with a conclusion.
+        </p>
+      </conclusion>
+    </project>
+
+    <p>
+      Of course you might still have definitions, theorems, and examples in a document like this.  
+    </p>
+
+    <definition xml:id="def-inquiry">
+      <statement>
+        <p>
+          A definition is <term>illustrative</term> if it serves the purpose of illustrating something.
+        </p>
+      </statement>
+    </definition>
+
+    <p>
+      And then you might have an example.
+    </p>
+
+    <example>
+      <statement>
+        <p>
+          Should an example always follow a definition?
+        </p>
+      </statement>
+      <solution>
+        <p>
+          No, but it could.  
+        </p>
+      </solution>
+    </example>
+
+    <p>
+      Examples are a good way to ask students to think about a problem but provide a solution right away.  To encourage students to think about a problem more before giving the solution, you could use an exercise.  In <pretext />, exercises that occur inside a section, along with other content, are called <q>checkpoints</q>, even though they are coded simply as <tag>exercise</tag>
+    </p>
+
+    <exercise>
+      <statement>
+        <p>
+          Write an exercise inside a section to show what they look like.
+        </p>
+      </statement>
+      <answer>
+        <p>
+          Done.
+        </p>
+      </answer>
+    </exercise>
+
+    <p>
+      Of course, in this style of document, collecting important ideas is especially important. 
+    </p>
+
+    <assemblage xml:id="assemblage-ibl">
+      <title>Components of good IBL writing</title>
+      <p>
+        Texts that support inquiry based learning should contain lots of opportunities for students to engage with the material, but can still be friendly and help students along their journey of discovery.
+      </p>
+    </assemblage>
+  </subsection>
+</section>

--- a/examples/showcase/pretext-showcase.ptx
+++ b/examples/showcase/pretext-showcase.ptx
@@ -33,6 +33,9 @@
       <favicon/>
       <baseurl href="https://pretextbook.org/examples/pretext-showcase/html" />
     </html>
+
+    <rename element="fact" xml:lang="en-US">Self Evident Fact</rename>
+
   </docinfo>
 
   <article xml:id="pretext-showcase">
@@ -64,6 +67,7 @@
 
     <xi:include href="mathematics.ptx" />
     <xi:include href="latex-image.ptx" />
+    <xi:include href="environments.ptx" />
 
     <backmatter>
       <index>


### PR DESCRIPTION
This adds a new section to the showcase article, demonstrating the different environments pretext offers.  To illustrate how an environment can be renamed, "fact" is renamed in docinfo.