### PR TITLE
WeBWorK: remove title and idx from schema

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1574,7 +1574,6 @@
             }
         WebWorkAuthored =
             element webwork {
-                MetaDataTitleOptional,
                 attribute seed {xsd:integer}?,
                 WWMacros?,
                 WWSetup?,


### PR DESCRIPTION
As mentioned in #1214, this removes `title` and `idx` from the WW portion of the schema.