### PR TITLE
Fix <kbd> to work identically in LaTeX and html

### DIFF
--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -4542,7 +4542,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- ############# -->
 
 <!-- Comments are Unicode names, from fileformat.info            -->
-<!-- @latex values are macros in teh menukeys package specifying -->
+<!-- @latex values are macros in the menukeys package specifying -->
 <!-- keyboard keys that are typically labeled with graphics      -->
 <xsl:variable name="kbdkey-rtf">
     <kbdkeyinfo name="left"
@@ -4563,6 +4563,42 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <kbdkeyinfo name="shift"
                 latex="\shift"
                 unicode="&#x21E7;"/> <!-- UPWARDS WHITE ARROW -->
+    <kbdkeyinfo name="ampersand"
+                latex='\char"26'
+                unicode="&#x0026;"/> <!-- AMPERSAND -->
+    <kbdkeyinfo name="lessthan"
+                latex='\textless'
+                unicode="&#x003C;"/> <!-- LESS-THAN SIGN-->
+    <kbdkeyinfo name="greaterthan"
+                latex='\textgreater'
+                unicode="&#x003E;"/> <!-- GREATER-THAN SIGN-->
+    <kbdkeyinfo name="dollar"
+                latex='\$'
+		unicode="&#x0024;"/> <!-- DOLLAR SIGN -->
+    <kbdkeyinfo name="percent"
+                latex='\%'
+		unicode="&#x0025;"/> <!-- PERCENT SIGN -->
+    <kbdkeyinfo name="openbrace"
+	        latex='\textbraceleft'
+		unicode='&#x007c;'/> <!-- LEFT CURLY BRACKET -->
+    <kbdkeyinfo name="closebrace"
+	        latex='\textbraceright'
+		unicode="&#x007C;"/> <!-- RIGHT CURLY BRACKET -->
+    <kbdkeyinfo name="octothorpe"
+	        latex='\#'
+		unicode="&#x0023;"/> <!-- OCTOTHORPE -->
+    <kbdkeyinfo name="backslash"
+	        latex='\textbackslash'
+		unicode="&#x005C;"/> <!-- BACKSLASH -->
+    <kbdkeyinfo name="tie"
+	        latex='\textasciitilde'
+		unicode="&#x007E;"/> <!-- TILDE -->
+    <kbdkeyinfo name="circumflex"
+	        latex='\textasciicircum'
+		unicode="&#x005E;"/> <!-- CIRCUMFLEX ACCENT -->
+    <kbdkeyinfo name="underscore"
+	        latex='\textunderscore'
+		unicode="&#x005F;"/> <!-- LOW LINE -->
 </xsl:variable>
 
 <!-- If read from a file via "document()" then   -->

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -2182,7 +2182,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\usepackage{menukeys}&#xa;</xsl:text>
         <!-- https://tex.stackexchange.com/questions/96300/how-to-change-the-style-of-menukeys -->
         <xsl:text>\renewmenumacro{\keys}{shadowedroundedkeys}&#xa;</xsl:text>
-        <xsl:text>\newcommand{\kbd}[1]{\keys{#1}}&#xa;</xsl:text>
+        <xsl:text>\newcommand{\kbd}[1]{\keys{{#1}}}&#xa;</xsl:text>
     </xsl:if>
 
     <xsl:text>%% Custom Preamble Entries, late (use latex.preamble.late)&#xa;</xsl:text>
@@ -8157,7 +8157,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="kbd[not(@name)]">
     <xsl:text>\kbd{</xsl:text>
-    <xsl:value-of select="."/>
+        <xsl:call-template name="escape-text-to-latex">
+            <xsl:with-param name="text" select="." />
+        </xsl:call-template>
     <xsl:text>}</xsl:text>
 </xsl:template>
 


### PR DESCRIPTION
For mathbook-common.xsl:

1. Filled out entries in "kbdkey-rtf" to include the three reserved character
   for xml and the problematic LaTeX characters. 
      a. The ampersand, less than and greater than seem like a really good idea.
         The others are less essential but might be nice.
      b. The unicode settings for openbrace and closebrace are incorrect (the
         values of &#007C should be &#007B and &#007D respectively). The correct
         values need to be escaped so that they won't throw an error. I'm not
         sure of the best way to do this.
      c. The sample file has a table of the entries displayed from both literal
         and named entries.

For mathbook-latex.xsl:

1. The kbd template has been modified to use escape-text-to-latex.
   This should be checked (think of me as a xslt noobie). What I
   have written works, but is, perhaps, suboptimal.

2. The LaTeX kbd macro now has an extra set of braces in its definition.
   This is because of one character: the comma. It is a separation character
   in the menukeys package, and so with no change the comma is eaten up and 
   doesn't appear on the key; the addition of extra braces saves it.
      a. The menukeys package will take \keys{a,b} call and expand it to 
         \keys(a}+\keys{b} to indicate the simultaneous pressing of keys.
         My additional braces kills this expansion. I consider this good since
         the expansion is anithetical to our philosophy of separating markup and 
         presentation. Surely it would be better to have something like
         ``<simulkeys>
             <kbd>a</kbd>
             <kbd>b</kbd>
         </simulkeys>``
      b. The use of the plus sign to indicate simultaneous pressing of keys
         is really common. We surely don't want this built in. There are
         other opitons that could make sense. The could be a horizontal list
         of keys with simultaeous one stacked, or simultaneous keys could
         be put into an fbox. I would think it better to kick the presentation
         over to David to include in the css files. 
      c. The sample file has tables for all the keyboard keys (upper and lower case).
         It works for both html and latex. 
[kbdsamples.xml.txt](https://github.com/rbeezer/mathbook/files/3952564/kbdsamples.xml.txt)

