### PR TITLE
Add javascript for instructor features

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -8249,6 +8249,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="login-footer">
     <div class="login-link"><span id="loginlogout" class="login">login</span></div>
     <script src="{$html.js.server}/js/{$html.js.version}/login.js"></script>
+    <script src="{$html.js.server}/js/{$html.js.version}/instructor.js"></script>
 </xsl:template>
 
 <!-- Console Session -->


### PR DESCRIPTION
Most of the code is in place for implementing the HTML instructor version.

This pull request adds a line that reads in that code.

Inserting the instructor resources into the HTML will be explained in an upcoming
post to pretext-dev.