### PR TITLE
Add support for Asymptote WebGL

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -99,6 +99,19 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
     cwd = os.getcwd()
     os.chdir(tmp_dir)
     devnull = open(os.devnull, 'w')
+    # perhaps replace following stock advisory with a real version
+    # check using the (undocumented) distutils.version module, see:
+    # https://stackoverflow.com/questions/11887762/how-do-i-compare-version-numbers-in-python
+    if outformat == 'html':
+        # https://stackoverflow.com/questions/4514751/pipe-subprocess-standard-output-to-a-variable
+        proc = subprocess.Popen([asy_executable, '--version'], stderr=subprocess.PIPE)
+        asyversion = proc.stderr.read()
+        _verbose("#####################################################")
+        _verbose("Asymptote 3D HTML output is experimental (2020-01-24)")
+        _verbose("it is only supported by Asymptote 2.62 and")
+        _verbose("newer, your Asymptote executable in use reports:")
+        _verbose(asyversion)
+        _verbose("#####################################################")
     for asydiagram in os.listdir(tmp_dir):
         if outformat == 'source':
             shutil.copy2(asydiagram, dest_dir)

--- a/script/mbx
+++ b/script/mbx
@@ -102,14 +102,18 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
     for asydiagram in os.listdir(tmp_dir):
         if outformat == 'source':
             shutil.copy2(asydiagram, dest_dir)
-	elif outformat == 'html':
-	    filebase, _ = os.path.splitext(asydiagram)
+        elif outformat == 'html':
+            filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)
-	    asy_cmd = [asy_executable, '-outformat', outformat, asydiagram]
-	    _verbose("converting {} to {}".format(asydiagram, asyout))
+            asysvg = "{}.svg".format(filebase)
+            asy_cmd = [asy_executable, '-outformat', outformat, asydiagram]
+            _verbose("converting {} to {}".format(asydiagram, asyout))
             _debug("asymptote conversion {}".format(asy_cmd))
             subprocess.call(asy_cmd, stdout=devnull, stderr=subprocess.STDOUT)
-            shutil.copy2(asyout, dest_dir)
+            if os.path.exists(asyout) == True:
+                shutil.copy2(asyout, dest_dir)
+            else:
+                shutil.copy2(asysvg, dest_dir) 
         else:
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)

--- a/script/mbx
+++ b/script/mbx
@@ -102,6 +102,14 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
     for asydiagram in os.listdir(tmp_dir):
         if outformat == 'source':
             shutil.copy2(asydiagram, dest_dir)
+	elif outformat == 'html':
+	    filebase, _ = os.path.splitext(asydiagram)
+            asyout = "{}.{}".format(filebase, outformat)
+	    asy_cmd = [asy_executable, '-outformat', outformat, asydiagram]
+	    _verbose("converting {} to {}".format(asydiagram, asyout))
+            _debug("asymptote conversion {}".format(asy_cmd))
+            subprocess.call(asy_cmd, stdout=devnull, stderr=subprocess.STDOUT)
+            shutil.copy2(asyout, dest_dir)
         else:
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)
@@ -1454,7 +1462,9 @@ if args.component == 'tikz':
     else:
         raise NotImplementedError('cannot make TikZ pictures in "{}" format'.format(args.format))
 elif args.component == 'asy':
-    if args.format == 'pdf':
+    if args.format == 'html':
+        asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'html')
+    elif args.format == 'pdf':
         asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'pdf')
     elif args.format == 'svg':
         asymptote_conversion(args.xml_file, args.xmlid, output_dir, 'svg')

--- a/script/mbx
+++ b/script/mbx
@@ -106,6 +106,7 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)
             asysvg = "{}.svg".format(filebase)
+            asypng = "{}_*.png".format(filebase)
             asy_cmd = [asy_executable, '-outformat', outformat, asydiagram]
             _verbose("converting {} to {}".format(asydiagram, asyout))
             _debug("asymptote conversion {}".format(asy_cmd))
@@ -113,7 +114,10 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             if os.path.exists(asyout) == True:
                 shutil.copy2(asyout, dest_dir)
             else:
-                shutil.copy2(asysvg, dest_dir) 
+                shutil.copy2(asysvg, dest_dir)
+                # Sometimes Asymptotes SVGs include multiple PNGs for colored regions
+                for f in glob.glob(asypng):
+                    shutil.copy2(f, dest_dir)
         else:
             filebase, _ = os.path.splitext(asydiagram)
             asyout = "{}.{}".format(filebase, outformat)

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -5605,6 +5605,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="html-filename" select="concat($base-pathname, '.html')" />
 
     <object data="{$html-filename}">
+	      <xsl:attribute name="id">
+	          <xsl:apply-templates select="." mode="visible-id" />
+	      </xsl:attribute>
         <xsl:attribute name="width">
             <xsl:apply-templates select="." mode="get-width-pixels" />
         </xsl:attribute>


### PR DESCRIPTION
This adds a new output option for Asymptote in the mbx script.
Doing `mbx -v -c asy -f html -d foo/ bar` will output Asymptote images to WebGL HTML files.

One bug I need to fix before you merge this:
If a book has both 2D and 3D Asymptote images, mbx will fail. But I think someone with better Python skills can fix it.
The good news is that if asy doesn't detect `graph3` being loaded, it reverts to svg as output instead of html.
The problem is that mbx script will be looking to copy img_foo.html from the tmp directory, not img_foo.svg, so the script halts with a file not found error.