### PR TITLE
goggle->google typo fixes

### DIFF
--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -21,7 +21,7 @@
         <p>The<cd>
             <cline>/publisher/html/analytics</cline>
         </cd>element can have the following attributes:<ul>
-            <li><attr>goggle-gst</attr>: a Google <term>global site tag</term>, and ID you get from Google.</li>
+            <li><attr>google-gst</attr>: a Google <term>global site tag</term>, and ID you get from Google.</li>
             <li><attr>statcounter-project</attr>, <attr>statcounter-security</attr>: ID numbers you get from StatCounter.</li>
         </ul>Setting these attributes to non-empty strings is the signal to add the relevant code to each of the pages of your HTML output.  See <xref ref="online-analytics"/> for more.</p>
     </section>
@@ -51,7 +51,7 @@
         <p>The<cd>
             <cline>/publisher/html/search</cline>
         </cd>element can have the following attribute:<ul>
-            <li><attr>goggle-cx</attr>: a Google <term>cx number</term>, gained from configuring search for a site.</li>
+            <li><attr>google-cx</attr>: a Google <term>cx number</term>, gained from configuring search for a site.</li>
         </ul>Setting this attributes to a non-empty string is the signal to add the relevant code for a search box in the masthead.  See <xref ref="online-search"/> for more.</p>
     </section>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -9132,7 +9132,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- webwork's iframeResizer needs to come before sage -->
             <xsl:call-template name="webwork" />
             <xsl:apply-templates select="." mode="sagecell" />
-            <xsl:call-template name="goggle-code-prettifier" />
+            <xsl:call-template name="google-code-prettifier" />
             <xsl:call-template name="google-search-box-js" />
             <xsl:call-template name="mathbook-js" />
             <xsl:call-template name="knowl" />
@@ -10404,7 +10404,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Program Listings from Google -->
 <!--   ?skin=sunburst  on end of src URL gives black terminal look -->
-<xsl:template name="goggle-code-prettifier">
+<xsl:template name="google-code-prettifier">
     <xsl:if test="$b-has-program">
         <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
     </xsl:if>


### PR DESCRIPTION
Found some places in the publisher's guide where google was written "goggle."

Also found an instance of "goggle" inside mathbook-html.xsl.