### PR TITLE
Showcase exercises

### DIFF
--- a/examples/showcase/environments.ptx
+++ b/examples/showcase/environments.ptx
@@ -25,7 +25,7 @@
 
   <introduction>
     <p>
-      This section will demonstrate some of the <q>environments</q> available in <pretext />.  In addition to cataloging the options an author has to break up content, this will be a nice place to play with various styles that are under development. 
+      This section will demonstrate some of the <q>environments</q> available in <pretext />.  In addition to cataloging the options an author has to break up content, this will be a nice place to play with various styles that are under development.
     </p>
     <p>
       Maybe a better way to describe what this section will do is by specifying our objectives.  Luckily there is an environment for that.
@@ -38,7 +38,7 @@
       Many mathematics papers and textbook chapters are organized in the traditional definition-lemma-proof-theorem-proof format.  Depending on how friendly the paper is, or who the intended audience is, there might be quite a bit of exposition surrounding these elements.  This subsection is intended to be an illustration of this structure.
     </p>
     <p>
-      We begin with some basic definitions.  Depending on the narrative style of your text, you might want to define terms in the middle of paragraphs.  We might call this an  <term>inline definition</term>, which can be accomplished using the <tag>term</tag> tag.  
+      We begin with some basic definitions.  Depending on the narrative style of your text, you might want to define terms in the middle of paragraphs.  We might call this an  <term>inline definition</term>, which can be accomplished using the <tag>term</tag> tag.
     </p>
 
     <p>
@@ -69,7 +69,7 @@
 
     <example>
       <p>
-        This example is an example of an example that stands alone.  It does not have a question in it, so it does not need a solution.  
+        This example is an example of an example that stands alone.  It does not have a question in it, so it does not need a solution.
       </p>
       <p>
         Of course examples can consist of more than one paragraph, as this is also an example of.  In fact, we could put an ordered list of things that could go in an example:
@@ -139,7 +139,7 @@
     <axiom xml:id="axiom-example">
       <statement>
         <p>
-          Axiom-like environments consist of: axiom, conjecture, principle, heuristic, hypothesis, and assumption.  
+          Axiom-like environments consist of: axiom, conjecture, principle, heuristic, hypothesis, and assumption.
         </p>
       </statement>
     </axiom>
@@ -155,7 +155,7 @@
       </statement>
     </lemma>
     <p>
-      The lemma above did not have a proof, since it's proof is obvious.  
+      The lemma above did not have a proof, since it's proof is obvious.
     </p>
     <lemma xml:id="lem-with-proof">
       <statement>
@@ -188,8 +188,8 @@
        <p>
          This is an example of how you might interject an example before completing a proof.  As such it is put between the statement of the theorem and its proof.
        </p>
-     </example> 
-      
+     </example>
+
     <p>
       Note that if you don't give a proof a title, it will get titled <q>proof</q> automatically.  It makes sense to put a custom title in this case since you are referring to a proof of the a theorem that was stated without proof earlier.
     </p>
@@ -197,7 +197,7 @@
     <proof>
       <title>Proof of <xref ref="thm-example"/></title>
       <p>
-        Let <m>P</m> be as described in the theorem. By the lemmas, <m>P</m> is true.   
+        Let <m>P</m> be as described in the theorem. By the lemmas, <m>P</m> is true.
       </p>
       <p>
         Therefore, <m>P</m>.
@@ -324,7 +324,7 @@
       </statement>
     </fact>
     <p>
-      In addition to <tag>example</tag>, <pretext /> provides two more <q>example-like</q> environments: question and problem.  
+      In addition to <tag>example</tag>, <pretext /> provides two more <q>example-like</q> environments: question and problem.
     </p>
 
   </subsection>
@@ -332,7 +332,7 @@
   <subsection xml:id="subsec-the-rest">
     <title>Inquiry Based Structure</title>
     <p>
-      Another way you might structure a chapter is to give students more opportunities to actively engage in the material.  You might give a long list of definitions, and then a list of theorems to prove.  That would look a lot like the previous section (perhaps with fewer paragraphs between elements).  
+      Another way you might structure a chapter is to give students more opportunities to actively engage in the material.  You might give a long list of definitions, and then a list of theorems to prove.  That would look a lot like the previous section (perhaps with fewer paragraphs between elements).
     </p>
     <p>
       Alternatively, you can mix inquiry based learning (<acro>IBL</acro>) structure into a more traditionally formatted section using appropriate environments.  You might start a section with an <tag>activity</tag>, for example.
@@ -343,11 +343,11 @@
           Make a list of all the project-like environments, such as this activity.
         </p>
       </statement>
-    </activity>   
+    </activity>
 
     <p>
       You might want to break down the activity into smaller tasks, which can be done by specifying each <tag>task</tag>, as in the following project.
-    </p> 
+    </p>
 
     <project>
       <introduction>
@@ -397,7 +397,7 @@
     </project>
 
     <p>
-      Of course you might still have definitions, theorems, and examples in a document like this.  
+      Of course you might still have definitions, theorems, and examples in a document like this.
     </p>
 
     <definition xml:id="def-inquiry">
@@ -420,7 +420,7 @@
       </statement>
       <solution>
         <p>
-          No, but it could.  
+          No, but it could.
         </p>
       </solution>
     </example>
@@ -443,7 +443,7 @@
     </exercise>
 
     <p>
-      Of course, in this style of document, collecting important ideas is especially important. 
+      Of course, in this style of document, collecting important ideas is especially important.
     </p>
 
     <assemblage xml:id="assemblage-ibl">

--- a/examples/showcase/environments.ptx
+++ b/examples/showcase/environments.ptx
@@ -8,6 +8,21 @@
 <section xml:id="environments">
   <title>Environments</title>
   <author>Oscar Levin</author>
+  <objectives>
+    <ul>
+      <li>
+        <p>
+          Demonstrate block environments.
+        </p>
+      </li>
+      <li>
+        <p>
+          Illustrate styling.
+        </p>
+      </li>
+    </ul>
+  </objectives>
+
   <introduction>
     <p>
       This section will demonstrate some of the <q>environments</q> available in <pretext />.  In addition to cataloging the options an author has to break up content, this will be a nice place to play with various styles that are under development. 
@@ -15,21 +30,7 @@
     <p>
       Maybe a better way to describe what this section will do is by specifying our objectives.  Luckily there is an environment for that.
     </p>
-    <objectives>
-      <ul>
-        <li>
-          <p>
-            Illustrate the various environments (blocks) available in <pretext />.
-          </p>
-        </li>
-        <li>
-          <p>
-            Provide a section that can be used to evaluate new styles.
-          </p>
-        </li>
-      </ul>
-    </objectives>
-    
+
   </introduction>
   <subsection>
     <title>Traditional Structure</title>
@@ -133,8 +134,8 @@
     </example>
 
     <p>
-      Returning to our main goal of establishing new mathematical theory, we might next state an axiom or two (especially if we are named <personname>Euclid</personname>).  In <pretext /> the environments for axioms are not <q>definition-like</q> (the only definition-like environment is a definition).  There are quite a few <q>axiom-like</q> environments.
-    </p>  
+      Returning to our main goal of establishing new mathematical theory, we might next state an axiom or two (especially if we are named Euclid).  In <pretext /> the environments for axioms are not <q>definition-like</q> (the only definition-like environment is a definition).  There are quite a few <q>axiom-like</q> environments.
+    </p>
     <axiom xml:id="axiom-example">
       <statement>
         <p>
@@ -230,26 +231,24 @@
     <assemblage xml:id="assemblage-example">
       <title>Types of environments</title>
       <p>
-        <p>
-          <pretext /> allows for a variety of environments:
-          <ul>
-            <li>
-              <p>
-              Definitions
-              </p>
-            </li>
-            <li>
-              <p>
-              Theorem-like environments
-              </p>
-            </li>
-            <li>
-              <p>
-              Assemblages, to assemble or summarize important connected ideas.
-              </p>
-            </li>
-          </ul>
-        </p>
+        <pretext /> allows for a variety of environments:
+        <ul>
+          <li>
+            <p>
+            Definitions
+            </p>
+          </li>
+          <li>
+            <p>
+            Theorem-like environments
+            </p>
+          </li>
+          <li>
+            <p>
+            Assemblages, to assemble or summarize important connected ideas.
+            </p>
+          </li>
+        </ul>
       </p>
     </assemblage>
 

--- a/examples/showcase/exercises.ptx
+++ b/examples/showcase/exercises.ptx
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- This file is part of the PreTeXt Showcase article. -->
+<!--                                                    -->
+<!-- Copyright (©) 2019 The PreTeXt Organization.       -->
+<!-- See the README file for contributing guidelines.   -->
+
+<section xml:id="exercises">
+  <title>Exercises</title>
+
+  <p>
+    An interesting concept from group theory is that of a Sylow-<m>p</m> subgroup.
+  </p>
+
+  <definition>
+    <title>Sylow-<m>p</m> subgroup</title>
+    <statement>
+      <p>
+        If <m>G</m> is a finite group, and <m>p</m> is a prime number,
+        and <m>p^k</m> is the largest power of <m>p</m> dividing <m>\order{G}</m>,
+        then a <term>Sylow-<m>p</m> subgroup</term> of <m>G</m> is a subgroup of <m>G</m>
+        with order <m>p^k</m>.
+      </p>
+    </statement>
+  </definition>
+
+  <p>
+    This defintion allows <m>k</m> to be <m>0</m>, so <m>p</m> might not divide <m>\order{G}</m>.
+    There is a theorem that gives information about how many Sylow-<m>p</m> subgroups a finite group might have.
+  </p>
+
+  <theorem xml:id="theorem-sylow">
+    <title>Sylow Theorem</title>
+    <statement>
+      <p>
+        If <m>G</m> is a finite group and <m>p</m> is a prime dividing <m>\order{G}</m>,
+        then the number of Sylow-<m>p</m> subgroups of <m>G</m> divides <m>\order{G}</m>
+        and is congruent to <m>1</m> modulo <m>p</m>.
+      </p>
+    </statement>
+  </theorem>
+
+  <example>
+    <p>
+      If <m>G</m> is a group of order <m>45</m>, how many Sylow-<m>3</m> subgroups could <m>G</m> have?
+    </p>
+    <p>
+      Write <m>n_3</m> to represent the number of Sylow-<m>3</m> subgroups.
+      We factor <m>45=9\cdot5</m>, separating the maximal power of <m>3</m> from its complement.
+      Since <m>n_3</m> divides <m>45</m> and <m>n_3\equiv1</m> modulo <m>3</m>,
+      it follows that <m>n_3</m> divides <m>5</m>. So either <m>n_3=1</m> or <m>n_3=5</m>.
+      But of those two options, only <m>1</m> is congruent to <m>1</m> mod <m>3</m>.
+      So <m>G</m> must have <m>1</m> Sylow-<m>3</m> subgroup.
+    </p>
+  </example>
+
+  <exercise>
+    <statement>
+      <p>
+        If <m>G</m> is a group of order <m>63</m>, how many Sylow-<m>7</m> subgroups could <m>G</m> have?
+      </p>
+    </statement>
+    <hint>
+      <p>
+        Factor <m>63</m> and use <xref ref="theorem-sylow"/>.
+      </p>
+    </hint>
+    <answer>
+      <p>
+        <m>G</m> has <m>1</m> Sylow-<m>7</m> subgroup.
+      </p>
+    </answer>
+    <solution>
+      <p>
+        Write <m>n_7</m> to represent the number of Sylow-<m>7</m> subgroups.
+        We factor <m>63=9\cdot7</m>, separating the maximal power of <m>7</m> from its complement.
+        Since <m>n_7</m> divides <m>63</m> and <m>n_7\equiv1</m> modulo <m>7</m>,
+        it follows that <m>n_7</m> divides <m>9</m>. So either <m>n_7=1</m>, <m>n_7=3</m>, or <m>n_7=9</m>.
+        But of those, only <m>1</m> is a real possibility, since only <m>1</m> is congruent to <m>1</m> mod <m>7</m>.
+        So <m>G</m> has <m>1</m> Sylow-<m>7</m> subgroup.
+      </p>
+    </solution>
+  </exercise>
+
+  <exercise>
+    <statement>
+      <p>
+        If <m>G</m> is a group of order <m>63</m>, how many Sylow-<m>3</m> subgroups could <m>G</m> have?
+      </p>
+    </statement>
+    <hint>
+      <p>
+        Factor <m>63</m> and use <xref ref="theorem-sylow"/>.
+      </p>
+    </hint>
+    <answer>
+      <p>
+        <m>G</m> either has <m>1</m> Sylow-<m>3</m> subgroup or it has <m>7</m>.
+      </p>
+    </answer>
+    <solution>
+      <p>
+        Write <m>n_3</m> to represent the number of Sylow-<m>3</m> subgroups.
+        We factor <m>63=9\cdot7</m>, separating the maximal power of <m>3</m> from its complement.
+        Since <m>n_3</m> divides <m>63</m> and <m>n_3\equiv1</m> modulo <m>3</m>,
+        it follows that <m>n_3</m> divides <m>7</m>. So either <m>n_3=1</m> or <m>n_3=7</m>.
+        Both of those are real possibilities, since both are congruent to <m>1</m> mod <m>3</m>.
+        So <m>G</m> either has <m>1</m> Sylow-<m>3</m> subgroup or it has <m>7</m>.
+      </p>
+    </solution>
+  </exercise>
+
+  <p>
+    Understanding how to count Sylow-<m>p</m> subgroups will help us later when we are classifying finite groups.
+  </p>
+
+  <reading-questions>
+    <exercise>
+      <statement>
+        <p>
+          Does a group of order <m>21</m> have a Sylow-<m>5</m> subgroup?
+        </p>
+      </statement>
+    </exercise>
+    <exercise>
+      <statement>
+        <p>
+          Does <xref ref="theorem-sylow"/> always tell you exactly how many Sylow-<m>p</m> subgroups a finite group <m>G</m> has
+          when you know the order of <m>G</m>?
+        </p>
+      </statement>
+    </exercise>
+  </reading-questions>
+
+  <exercises>
+    <subexercises>
+      <title>Vocabulary</title>
+      <exercise>
+        <statement>
+          <p>
+            Research <q>Sylow</q> and explain who this person was with a short, one-paragraph biography.
+          </p>
+        </statement>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            Given a group <m>G</m> of order <m>72</m>, what would be the order of a Sylow-<m>2</m> subgroup?
+          </p>
+        </statement>
+      </exercise>
+    </subexercises>
+
+    <subexercises>
+      <title>Calculations</title>
+      <exercise>
+        <statement>
+          <p>
+            If <m>G</m> is a group of order <m>2p</m> for an odd prime <m>p</m>,
+            how many Sylow-<m>p</m> subgroups might <m>G</m> have?
+          </p>
+        </statement>
+      </exercise>
+      <exercisegroup cols="3">
+        <introduction>
+          <p>
+            Let <m>G</m> be a group of order <m>30</m>.
+            For each <m>p</m>, how many Sylow-<m>p</m> subgroups might <m>G</m> have?
+          </p>
+        </introduction>
+        <exercise>
+          <statement>
+            <p>
+              <m>p=2</m>
+            </p>
+          </statement>
+        </exercise>
+        <exercise>
+          <statement>
+            <p>
+              <m>p=3</m>
+            </p>
+          </statement>
+        </exercise>
+        <exercise>
+          <statement>
+            <p>
+              <m>p=5</m>
+            </p>
+          </statement>
+        </exercise>
+      </exercisegroup>
+    </subexercises>
+
+    <subexercises>
+      <title>Thinking Deeper</title>
+      <exercise>
+        <statement>
+          <p>
+            If <m>G</m> has only one Sylow-<m>p</m> subgroup for some prime <m>p</m>,
+            prove that it is a normal subgroup.
+          </p>
+        </statement>
+      </exercise>
+      <exercise>
+        <statement>
+          <p>
+            If <m>\order{G}=pq</m> for primes <m>p\lt q</m>,
+            what conditions on <m>p</m> and <m>q</m> guarantee that <m>G\cong C_p\times C_q</m>?
+          </p>
+        </statement>
+      </exercise>
+    </subexercises>
+  </exercises>
+</section>

--- a/examples/showcase/pretext-showcase.ptx
+++ b/examples/showcase/pretext-showcase.ptx
@@ -15,6 +15,7 @@
     </images>
 
     <macros>
+      \newcommand{\order}[1]{\left\lvert#1\right\rvert}
     </macros>
 
     <latex-image-preamble>
@@ -68,6 +69,7 @@
     <xi:include href="mathematics.ptx" />
     <xi:include href="environments.ptx" />
     <xi:include href="latex-image.ptx" />
+    <xi:include href="exercises.ptx" />
     <xi:include href="webwork.ptx" />
 
     <backmatter>


### PR DESCRIPTION
Main commit here adds an exercises section to the Showcase Article. Two other commits clear trailing whitespace and schema violations from the environments section.

The Showcase Article currently has these schema violations, which may just be signs that the schema is ready to catch up:

- It doesn't like `index` having an `introduction`.
- It doesn't recognize `document-id` and `html` from `docinfo`.
- It doesn't recognize `reading-questions`.
- It doesn't recognize `subexercises`.

The latter two are introduced by this PR. Unsure if you'd want to wait to merge this until the schema has some of these things.