### PR TITLE
Update pretext-liblouis.cfg

### DIFF
--- a/script/braille/pretext-liblouis.cfg
+++ b/script/braille/pretext-liblouis.cfg
@@ -176,8 +176,8 @@ style contents5
 # Bug?
 style boxline
 	linesBefore 0
-	topBoxline 7
-	bottomBoxline G
+	topBoxLine 7
+	bottomBoxLine G
 	linesAfter 1
 
 # Lists,  [BANA-2016, 8.3.2]


### PR DESCRIPTION
In lines 179,180 changed "Boxline" to "BoxLine" so liblouisutdml can correctly format the braille output.