### PR TITLE
revealJs simplistic support for <term>s

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -378,6 +378,10 @@ Reveal.initialize({
   </dl>
 </xsl:template>
 
+<xsl:template match="term">
+  <b class="term"><xsl:apply-templates/></b>
+</xsl:template>
+
 
 <xsl:template match="ul/li|ol/li">
   <li>


### PR DESCRIPTION
Slideshow terms are wrapped in `<b/>` when converted to RevealJs.