### PR TITLE
Add frontmatter/backmatter classes to TOC

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -10483,9 +10483,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:apply-templates select="." mode="url"/>
                </xsl:variable>
                <!-- text of anchor's class, active if a match, otherwise plain -->
-               <!-- Based on node-set union size, "part" is for styling        -->
+               <!-- Based on node-set union size; "frontmatter", "backmatter", -->
+               <!-- "part" are for styling                                     -->
                <xsl:variable name="class">
                     <xsl:text>link</xsl:text>
+                    <xsl:if test="self::frontmatter">
+                        <xsl:text> frontmatter</xsl:text>
+                    </xsl:if>
+                    <xsl:if test="self::backmatter">
+                        <xsl:text> backmatter</xsl:text>
+                    </xsl:if>
                     <xsl:if test="self::part">
                         <xsl:text> part</xsl:text>
                     </xsl:if>


### PR DESCRIPTION
This puts a class onto the TOC list item for the frontmatter and backmatter, so that they may be styled. 

Personally, I imagine styling the backmatter item in the same manner as a "part", but that can be discussed separately once there is a class to play with.

For reference, I don't love how "Backmatter", "Index", and "Colophon" appear to be peers here in the [Showcase Article](https://pretextbook.org/examples/showcase/html/frontmatter.html). And similarly with other projects.