### PR TITLE
WeBWorK: support vars containing PGML syntax

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -663,6 +663,30 @@
                 </webwork>
             </exercise>
 
+            <p>
+                Occasionally (and probably very rarely) your PG code will include a string variable where the content is PGML syntax.
+                If this is put into the exercise statement, it will be inserted <emph>after</emph> PGML processing is done,
+                and therefore it won't render as you might expect. To insert this content and also have it processed as PGML,
+                use <c>data="pgml"</c>. (This is not in the <pretext/> schema as of 3/26/2020, and is subject to change.)
+            </p>
+
+            <exercise>
+                <webwork>
+                    <setup>
+                        <pg-code>
+                            $statement = 'some PGML math: [`\frac{1}{2}+\frac{3}{2}=2`]; and some *bold text*';
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <p>
+                            <var name="$statement"/> makes:
+                        </p>
+                        <p>
+                            <var name="$statement" data="pgml"/>
+                        </p>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -989,6 +989,10 @@
         <xsl:text>->correct_ans()</xsl:text>
     </xsl:if>
     <xsl:text>]</xsl:text>
+    <!-- if the variable is a string of PGML syntax to be processed -->
+    <xsl:if test="@data='pgml'">
+        <xsl:text>**</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- An image description may depend on the value of a simple scalar var   -->


### PR DESCRIPTION
Every so often, you are coding the setup portion of a WW problem, and you need to store something like:

``$solution = "The answer is [`\frac{1}{2}`].";``

Then in the text (`statement`, `solution`, etc.) you need to call on that variable:

`<var name="$solution"/>`

As things stand, you will literally get ``The answer is [`\frac{1}{2}`].`` in the output that the end user sees. But what we really wanted is PGML to actually process that PGML syntax with the bracw-backtick pairs. This PR makes it possible for that to happen. The `var` needs to be called on like:

`<var name="$solution" pgml="yes"/>`

where `@pgml` is indicative of the `var` being a string of PGML syntax.

Note that my example above is simple to communicate the idea, but too simple to actually need this device. This device is needed when there is randomized math content and regular text that changes significantly based on the problem's random seed. 