### PR TITLE
WeBWorK: deprecate setup

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -138,11 +138,9 @@
         <![CDATA[
         <exercise>
           <webwork>
-            <setup>
-              <pg-code>
-                Context("ImplicitPlane");
-              </pg-code>
-            </setup>
+            <pg-code>
+              Context("ImplicitPlane");
+            </pg-code>
             <statement>
               <p>The answer is <m>x+y=1</m>.</p>
               <p><var name="'x+y=1'" width="8" /></p>
@@ -162,7 +160,7 @@
       <p>
         To have randomization in problems
         or otherwise take advantage of the algorithmic programming capabilities of Perl and <webwork/>'s PG language
-        requires using a <tag>setup</tag> tag.
+        requires using a <tag>pg-code</tag> tag.
         Having at least a little familiarity with coding problems in <webwork/> is necessary,
         although for simpler problems you could get away with mimicking the sample article in <c>mathbook/examples/webwork/</c>.
         A <tag>statement</tag>, <em>optional</em> <tag>hint</tag>, and <em>optional</em> <tag>solution</tag> follow.
@@ -171,8 +169,8 @@
         <![CDATA[
         <webwork>
 
-          <setup>
-          </setup>
+          <pg-code>
+          </pg-code>
 
           <statement>
           </statement>
@@ -187,12 +185,11 @@
         ]]>
       </pre>
       <p>
-        The <tag>setup</tag> contains a <tag>pg-code</tag>.
         If you are familiar with code for <webwork/> PG problems, the <tag>pg-code</tag> contains lines of PG code
         that would appear in the <q>setup</q> portion of the problem.
         Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>.
         If your code needs any special <webwork/> macro libraries,
-        you may load them in a <tag>pg-macros</tag> tag prior to <tag>setup</tag>,
+        you may load them in a <tag>pg-macros</tag> tag prior to <tag>pg-code</tag>,
         with each such <c>.pl</c> file's name inside a <tag>macro-file</tag> tag.
         However many of the most common macro libraries will be loaded automatically
         based on the content and attributes you use in the rest of your problem.
@@ -203,14 +200,12 @@
       <pre>
         <![CDATA[
         <webwork>
-          <setup>
-            <pg-code>
-              Context("LimitedNumeric");
-              $a = Compute(random(1, 9, 1));
-              $b = Compute(random(1, 9, 1));
-              $c = $a + $b;
-            </pg-code>
-          </setup>
+          <pg-code>
+            Context("LimitedNumeric");
+            $a = Compute(random(1, 9, 1));
+            $b = Compute(random(1, 9, 1));
+            $c = $a + $b;
+          </pg-code>
 
           <statement>
             <p>Compute <m><var name="$a"/> + <var name="$b"/></m>.</p>

--- a/examples/sample-errors-and-warnings.xml
+++ b/examples/sample-errors-and-warnings.xml
@@ -303,9 +303,8 @@ systems.
                 <title>Solving Quadratic Equations</title>
 
                 <webwork xml:id="quadratic-equation">
-                    <setup>
-                        <!-- TODO: move out context shift -->
-                        <pg-code>
+                    <!-- TODO: move out context shift -->
+                    <pg-code>
                         Context("Fraction");
 
                         $a = Compute(random(2,6,1));
@@ -344,11 +343,9 @@ systems.
                                 return (1,0) if $c1 == $s1 or $c2 == $s1;
                                 return (0,1) if $c1 == $s2 or $c2 == $s2;
                                 return (0,0);
-                             }
-                          );
-
-                        </pg-code>
-                    </setup>
+                            }
+                        );
+                    </pg-code>
 
                     <stage>
                         <title>Part 1: Identify the coefficients</title>
@@ -386,11 +383,9 @@ systems.
                 <title>Tables</title>
 
                 <webwork xml:id="tables">
-                    <setup>
-                        <pg-code>
-                            $x = Real(5);
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $x = Real(5);
+                    </pg-code>
 
                     <statement>
                         <p>A table with minimal XML source.</p>

--- a/examples/showcase/webwork.ptx
+++ b/examples/showcase/webwork.ptx
@@ -22,29 +22,27 @@
       </p>
     </introduction>
     <webwork>
-      <setup>
-        <pg-code>
-          Context("Numeric");
-          $f = Formula("sqrt(x)");
-          $derivative = Formula("1/(2sqrt(x))");
-          $popup = PopUp(['?','power','exponential','linear','quadratic'],1);
-          $radio = RadioButtons([
-            'It shares ancestry with "radius", as in the radius of a circle.',
-            'It shares ancestry with "radish", a vegetable.',
-            'It shares ancestry with "radler", a mixture of beer and grapefruit soda.',
-          ],1);
-          Context("LimitedRadical");
-          $a = Formula("2sqrt(3)");
-          Context("LimitedNumeric");
-          $b = Real(sqrt(12));
-          Context("Interval");
-          $domain = Interval("[0,inf)");
-          Context("Point");
-          $point = Point("(4,2)");
-          Context("RestrictedDomains");
-          $restricted = Formula("x, x >= 0");
-        </pg-code>
-      </setup>
+      <pg-code>
+        Context("Numeric");
+        $f = Formula("sqrt(x)");
+        $derivative = Formula("1/(2sqrt(x))");
+        $popup = PopUp(['?','power','exponential','linear','quadratic'],1);
+        $radio = RadioButtons([
+          'It shares ancestry with "radius", as in the radius of a circle.',
+          'It shares ancestry with "radish", a vegetable.',
+          'It shares ancestry with "radler", a mixture of beer and grapefruit soda.',
+        ],1);
+        Context("LimitedRadical");
+        $a = Formula("2sqrt(3)");
+        Context("LimitedNumeric");
+        $b = Real(sqrt(12));
+        Context("Interval");
+        $domain = Interval("[0,inf)");
+        Context("Point");
+        $point = Point("(4,2)");
+        Context("RestrictedDomains");
+        $restricted = Formula("x, x >= 0");
+      </pg-code>
       <statement>
         <p>
           Consider the function <m>f</m> defined by <m>f(x)=<var name="$f"/></m>.
@@ -106,34 +104,32 @@
       </p>
     </introduction>
     <webwork>
-      <setup>
-        <pg-code>
-          Context()->operators->set(
-          '*' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-          ' *' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-          '* ' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-          );
-          $given = Formula("x^2 x^5");
-          $answer = Formula("x^7");
-          $special = Formula("x^10");
-          $evaluator = $answer -> cmp(
-            checker=>sub{
-              my ( $correct, $student, $ansHash ) = @_;
-              Value::Error("When multiplying powers with the same base, you do not multiply the exponents.") if ($special == $student);
-              return 0 if $ansHash->{isPreview} || $correct != $student;
-              Context()->flags->set(bizarroMul=>1);
-              delete $correct->{test_values}; delete $student->{test_values};
-              my $OK = ($correct == $student);
-              Context()->flags->set(bizarroMul=>0);
-              Value::Error(
-                "Your answer is equivalent to the correct answer, but not in the expected form.
-                Maybe it needs to be simplified, factored, expanded, have its denominator rationalized, etc."
-              ) unless $OK;
-              return $OK;
-            }
-          );
-        </pg-code>
-      </setup>
+      <pg-code>
+        Context()->operators->set(
+        '*' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+        ' *' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+        '* ' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+        );
+        $given = Formula("x^2 x^5");
+        $answer = Formula("x^7");
+        $special = Formula("x^10");
+        $evaluator = $answer -> cmp(
+          checker=>sub{
+            my ( $correct, $student, $ansHash ) = @_;
+            Value::Error("When multiplying powers with the same base, you do not multiply the exponents.") if ($special == $student);
+            return 0 if $ansHash->{isPreview} || $correct != $student;
+            Context()->flags->set(bizarroMul=>1);
+            delete $correct->{test_values}; delete $student->{test_values};
+            my $OK = ($correct == $student);
+            Context()->flags->set(bizarroMul=>0);
+            Value::Error(
+              "Your answer is equivalent to the correct answer, but not in the expected form.
+              Maybe it needs to be simplified, factored, expanded, have its denominator rationalized, etc."
+            ) unless $OK;
+            return $OK;
+          }
+        );
+      </pg-code>
       <statement>
         <p>
           Simplify the expression <m><var name="$given"/></m>.
@@ -170,63 +166,61 @@
       </p>
     </introduction>
     <webwork>
-      <setup>
-        <pg-code>
-          # draw Venn diagram
-          Context()->variables->are(t=>'Real');
-          $x[0] = Formula("2.5*cos(t)+5");
-          $y[0] = Formula("2.5*sin(t)+6");
-          $x[1] = Formula("2.5*cos(t)+4");
-          $y[1] = Formula("2.5*sin(t)+4");
-          $x[2] = Formula("2.5*cos(t)+6");
-          $y[2] = Formula("2.5*sin(t)+4");
-          $vd = init_graph(0,0,10,10, size=>[300,300]);
-          for my $i (0,1,2) {
-            $f[$i] = new Fun( $x[$i]->perlFunction, $y[$i]->perlFunction, $vd );
-            $f[$i]->domain(0,6.28);
-            $f[$i]->steps(90);
-            $f[$i]->weight(2);
-            $f[$i]->color('black');
-          }
-          $vd->lb(new Label(1,9,'Salmon','black','center','middle','giant'));
-          $vd->lb(new Label(5,8,'Jellyfish','black','center','middle','giant'));
-          $vd->lb(new Label(2.5,3.5,'Duck','black','center','middle','giant'));
-          $vd->lb(new Label(7.5,3.5,'Beaver','black','center','middle','giant'));
-          $vd->lb(new Label(5,4.8,'?','black','center','middle','giant'));
-          $vd->new_color("lightred",     255,102,102);
-          $vd->fillRegion([5,8,"lightred"]);
-          $vd->new_color("lightyellow",  255,255,102);
-          $vd->fillRegion([3,3,"lightyellow"]);
-          $vd->new_color("lightblue",  102,178,255);
-          $vd->fillRegion([7,3,"lightblue"]);
-          $vd->new_color("lightorange",  255,178,102);
-          $vd->fillRegion([3.3,5.7,"lightorange"]);
-          $vd->new_color("lightgreen",  102,255,102);
-          $vd->fillRegion([5,3,"lightgreen"]);
-          $vd->new_color("lightpurple",  255,102,178);
-          $vd->fillRegion([6.7,5.7,"lightpurple"]);
-          $vd->new_color("lightbrown",  210,180,140);
-          $vd->fillRegion([5,5,"lightbrown"]);
-          $vd->lb(new Label(1.7,2.5,'Has a','black','right','bottom','large'));
-          $vd->lb(new Label(1.7,2.5,'Bill','black','right','top','large'));
-          $vd->lb(new Label(8.3,2.5,'Has','black','left','bottom','large'));
-          $vd->lb(new Label(8.3,2.5,'Fur','black','left','top','large'));
-          $vd->lb(new Label(5,8.7,'Is Venemous','black','center','bottom','large'));
+      <pg-code>
+        # draw Venn diagram
+        Context()->variables->are(t=>'Real');
+        $x[0] = Formula("2.5*cos(t)+5");
+        $y[0] = Formula("2.5*sin(t)+6");
+        $x[1] = Formula("2.5*cos(t)+4");
+        $y[1] = Formula("2.5*sin(t)+4");
+        $x[2] = Formula("2.5*cos(t)+6");
+        $y[2] = Formula("2.5*sin(t)+4");
+        $vd = init_graph(0,0,10,10, size=>[300,300]);
+        for my $i (0,1,2) {
+          $f[$i] = new Fun( $x[$i]->perlFunction, $y[$i]->perlFunction, $vd );
+          $f[$i]->domain(0,6.28);
+          $f[$i]->steps(90);
+          $f[$i]->weight(2);
+          $f[$i]->color('black');
+        }
+        $vd->lb(new Label(1,9,'Salmon','black','center','middle','giant'));
+        $vd->lb(new Label(5,8,'Jellyfish','black','center','middle','giant'));
+        $vd->lb(new Label(2.5,3.5,'Duck','black','center','middle','giant'));
+        $vd->lb(new Label(7.5,3.5,'Beaver','black','center','middle','giant'));
+        $vd->lb(new Label(5,4.8,'?','black','center','middle','giant'));
+        $vd->new_color("lightred",     255,102,102);
+        $vd->fillRegion([5,8,"lightred"]);
+        $vd->new_color("lightyellow",  255,255,102);
+        $vd->fillRegion([3,3,"lightyellow"]);
+        $vd->new_color("lightblue",  102,178,255);
+        $vd->fillRegion([7,3,"lightblue"]);
+        $vd->new_color("lightorange",  255,178,102);
+        $vd->fillRegion([3.3,5.7,"lightorange"]);
+        $vd->new_color("lightgreen",  102,255,102);
+        $vd->fillRegion([5,3,"lightgreen"]);
+        $vd->new_color("lightpurple",  255,102,178);
+        $vd->fillRegion([6.7,5.7,"lightpurple"]);
+        $vd->new_color("lightbrown",  210,180,140);
+        $vd->fillRegion([5,5,"lightbrown"]);
+        $vd->lb(new Label(1.7,2.5,'Has a','black','right','bottom','large'));
+        $vd->lb(new Label(1.7,2.5,'Bill','black','right','top','large'));
+        $vd->lb(new Label(8.3,2.5,'Has','black','left','bottom','large'));
+        $vd->lb(new Label(8.3,2.5,'Fur','black','left','top','large'));
+        $vd->lb(new Label(5,8.7,'Is Venemous','black','center','bottom','large'));
 
-          # define answer
-          Context("ArbitraryString");
-          $platypus = Compute("platypus")->cmp(checker => sub {
-            my ($correct,$student,$ans) = @_;
-            $correct = $correct->value;
-            $student = $student->value;
-            $student = lc($student);
-            $student =~ s/ +/ /;
-            $student =~ s/^ //;
-            $student =~ s/ $//;
-            return ($student eq $correct);
-          });
-        </pg-code>
-      </setup>
+        # define answer
+        Context("ArbitraryString");
+        $platypus = Compute("platypus")->cmp(checker => sub {
+          my ($correct,$student,$ans) = @_;
+          $correct = $correct->value;
+          $student = $student->value;
+          $student = lc($student);
+          $student =~ s/ +/ /;
+          $student =~ s/^ //;
+          $student =~ s/ $//;
+          return ($student eq $correct);
+        });
+      </pg-code>
       <statement>
         <p>
           This Venn Diagram groups animals by certain characteristics.
@@ -268,17 +262,15 @@
       </p>
     </introduction>
     <webwork>
-      <setup>
-        <pg-code>
-          Context("Fraction");
-          $quadratic = Formula("2 x^2 - 7 x - 15")->reduce;
-          $x1 = Fraction(5,1);
-          $x2 = Fraction(-3,2);
-          Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
-          Context("FiniteSolutionSets");
-          $solutions = Formula("-3/2,5");
-        </pg-code>
-      </setup>
+      <pg-code>
+        Context("Fraction");
+        $quadratic = Formula("2 x^2 - 7 x - 15")->reduce;
+        $x1 = Fraction(5,1);
+        $x2 = Fraction(-3,2);
+        Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
+        Context("FiniteSolutionSets");
+        $solutions = Formula("-3/2,5");
+      </pg-code>
       <stage>
         <title>Identify the coefficients</title>
         <statement>
@@ -336,22 +328,20 @@
       </p>
     </introduction>
     <webwork>
-      <setup>
-        <pg-code>
-          $newUnits = [
-            {name=>'gallons',conversion=>{factor=>0.00378541,m=>3}},
-            {name=>'gallon',conversion=>{factor=>0.00378541,m=>3}},
-            {name=>'gal',conversion=>{factor=>0.00378541,m=>3}},
-          ];
-          Context()->flags->set(tolType=>'absolute',tolerance=>0.1);
-          $volume = NumberWithUnits("20/2.78 gal", {newUnit=>$newUnits});
-          Context("Percent");
-          Context()->flags->set(tolerance=>0.01);
-          $increase = Percent(352/278-1);
-          Context("Currency");
-          $cost = Currency(3.52*1.028);
-        </pg-code>
-      </setup>
+      <pg-code>
+        $newUnits = [
+          {name=>'gallons',conversion=>{factor=>0.00378541,m=>3}},
+          {name=>'gallon',conversion=>{factor=>0.00378541,m=>3}},
+          {name=>'gal',conversion=>{factor=>0.00378541,m=>3}},
+        ];
+        Context()->flags->set(tolType=>'absolute',tolerance=>0.1);
+        $volume = NumberWithUnits("20/2.78 gal", {newUnit=>$newUnits});
+        Context("Percent");
+        Context()->flags->set(tolerance=>0.01);
+        $increase = Percent(352/278-1);
+        Context("Currency");
+        $cost = Currency(3.52*1.028);
+      </pg-code>
       <statement>
         <p>
           <ol>

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -37,13 +37,11 @@
       <title><webwork /> Minimal Section</title>
       <exercise>
         <webwork>
-          <setup>
-            <pg-code>
-              $a = Compute(random(1, 9, 1));
-              $b = Compute(random(1, 9, 1));
-              $c = $a + $b;
-            </pg-code>
-          </setup>
+          <pg-code>
+            $a = Compute(random(1, 9, 1));
+            $b = Compute(random(1, 9, 1));
+            $c = $a + $b;
+          </pg-code>
           <statement>
             <p>
               Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -129,13 +129,11 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition">
-                    <setup>
-                        <pg-code>
-                            $a = Compute(random(1, 9, 1));
-                            $b = Compute(random(1, 9, 1));
-                            $c = $a + $b;
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $a = Compute(random(1, 9, 1));
+                        $b = Compute(random(1, 9, 1));
+                        $c = $a + $b;
+                    </pg-code>
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
@@ -162,13 +160,11 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition-with-seed" seed="510">
-                    <setup>
-                        <pg-code>
-                            $a = Compute(random(1, 9, 1));
-                            $b = Compute(random(1, 9, 1));
-                            $c = $a + $b;
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $a = Compute(random(1, 9, 1));
+                        $b = Compute(random(1, 9, 1));
+                        $c = $a + $b;
+                    </pg-code>
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
@@ -189,14 +185,12 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition-with-control-seed" seed="1">
-                    <setup>
-                        <pg-code>
-                            $a = Compute(random(1, 9, 1));
-                            $b = Compute(random(1, 9, 1));
-                            if ($envir{problemSeed}==1){$a=1;$b=2};
-                            $c = $a + $b;
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $a = Compute(random(1, 9, 1));
+                        $b = Compute(random(1, 9, 1));
+                        if ($envir{problemSeed}==1){$a=1;$b=2};
+                        $c = $a + $b;
+                    </pg-code>
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
@@ -222,25 +216,23 @@
                 </introduction>
 
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            $a = Compute(random(1, 9, 1));
-                            $b = Compute(random(1, 9, 1));
-                            $c = $a + $b;
-                            $expression = Formula("x^($a)*x^($b)");
+                    <pg-code>
+                        $a = Compute(random(1, 9, 1));
+                        $b = Compute(random(1, 9, 1));
+                        $c = $a + $b;
+                        $expression = Formula("x^($a)*x^($b)");
 
-                            Context("LimitedPolynomial-Strict");
-                            # custom error message
-                            Context()->{error}{msg}{"A variable can appear only once in each term of a polynomial"}
-                                = "Your answer must be fully simplified";
+                        Context("LimitedPolynomial-Strict");
+                        # custom error message
+                        Context()->{error}{msg}{"A variable can appear only once in each term of a polynomial"}
+                            = "Your answer must be fully simplified";
 
-                            $answer = Formula("x^($c)");
-                            $product = $a*$b;
-                            $evaluator = $answer->cmp()->withPostFilter(AnswerHints(
-                                [Compute("x^($product)")] =>
-                                "When multiplying terms with the same base, you do not multiply the exponents."));
-                        </pg-code>
-                    </setup>
+                        $answer = Formula("x^($c)");
+                        $product = $a*$b;
+                        $evaluator = $answer->cmp()->withPostFilter(AnswerHints(
+                            [Compute("x^($product)")] =>
+                            "When multiplying terms with the same base, you do not multiply the exponents."));
+                    </pg-code>
 
                     <statement>
                         <p>Use the properties of exponents to simplify <m><var name="$expression" /></m>.</p>
@@ -267,21 +259,19 @@
                 </introduction>
 
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            do {
-                                $a = Compute(list_random(2,3,5,6));
-                                $b = Compute(random(1, 5, 1));
-                               } until (gcd($a,$b) == 1);
-                            $c = $a * $b**2;
-                            Context()->flags->set(reduceConstantFunctions=>0);
-                            $expression = Formula("sqrt($c)");
+                    <pg-code>
+                        do {
+                            $a = Compute(list_random(2,3,5,6));
+                            $b = Compute(random(1, 5, 1));
+                           } until (gcd($a,$b) == 1);
+                        $c = $a * $b**2;
+                        Context()->flags->set(reduceConstantFunctions=>0);
+                        $expression = Formula("sqrt($c)");
 
-                            Context("LimitedRadical");
+                        Context("LimitedRadical");
 
-                            $answer = Formula("$b sqrt($a)");
-                        </pg-code>
-                    </setup>
+                        $answer = Formula("$b sqrt($a)");
+                    </pg-code>
 
                     <statement>
                         <p>Simplify the expression <m><var name="$expression"/></m>.</p>
@@ -347,9 +337,8 @@
 
                 <webwork xml:id="quadratic-equation">
 
-                    <setup>
-                        <!-- TODO: move out context shift -->
-                        <pg-code>
+                    <!-- TODO: move out context shift -->
+                    <pg-code>
                         Context("Fraction");
 
                         $a = Compute(random(2,6,1));
@@ -389,10 +378,8 @@
                                 return (0,1) if $c1 == $s2 or $c2 == $s2;
                                 return (0,0);
                              }
-                          );
-
-                        </pg-code>
-                    </setup>
+                        );
+                    </pg-code>
 
                     <stage>
                         <statement>
@@ -625,25 +612,24 @@
 
             <exercise>
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            $xmlchars = q(&lt;>&amp;'";);
-                            $latex0 = '#%&amp;&lt;>\^_`|~';
-                            $latex1 = '${}';
-                            $alphanumeric = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-                            $otherchars = '!()*+,-./:=?@[]';
-                            Context()->strings->add($xmlchars=>{});
-                            Context()->strings->add($latex0=>{});
-                            Context()->strings->add($latex1=>{});
-                            Context()->strings->add($alphanumeric=>{});
-                            Context()->strings->add($otherchars=>{});
-                            $xmlcharsMO = String($xmlchars);
-                            $latex0MO = String($latex0);
-                            $latex1MO = String($latex1);
-                            $alphanumericMO = String($alphanumeric);
-                            $othercharsMO = String($otherchars);
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $xmlchars = q(&lt;>&amp;'";);
+                        $latex0 = '#%&amp;&lt;>\^_`|~';
+                        $latex1 = '${}';
+                        $alphanumeric = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+                        $otherchars = '!()*+,-./:=?@[]';
+                        Context()->strings->add($xmlchars=>{});
+                        Context()->strings->add($latex0=>{});
+                        Context()->strings->add($latex1=>{});
+                        Context()->strings->add($alphanumeric=>{});
+                        Context()->strings->add($otherchars=>{});
+                        $xmlcharsMO = String($xmlchars);
+                        $latex0MO = String($latex0);
+                        $latex1MO = String($latex1);
+                        $alphanumericMO = String($alphanumeric);
+                        $othercharsMO = String($otherchars);
+                    </pg-code>
+
                     <statement>
                         <p><ol>
                             <li>
@@ -693,14 +679,12 @@
 
                 <webwork>
 
-                    <setup>
-                        <pg-code>
-                            $rational = PopUp(
-                                ["?","is","is not",],
-                                "is not",
-                            );
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $rational = PopUp(
+                            ["?","is","is not",],
+                            "is not",
+                        );
+                    </pg-code>
 
                     <statement>
                         <p>The number <m>\sqrt{2}</m> <var name="$rational" form="popup"/> rational.</p>
@@ -719,14 +703,12 @@
 
                 <webwork>
 
-                    <setup>
-                        <pg-code>
-                            $theorem = RadioButtons(
-                              ["The Quadratic Formula","The Fundamental Theorem of Calculus","The Fundamental Theorem of Arithmetic","None of these"],
-                              1, # index of correct answer; could also just be the correct answer
-                            );
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $theorem = RadioButtons(
+                          ["The Quadratic Formula","The Fundamental Theorem of Calculus","The Fundamental Theorem of Arithmetic","None of these"],
+                          1, # index of correct answer; could also just be the correct answer
+                        );
+                    </pg-code>
 
                     <statement>
                         <p>Which of the following suggest that differentiation and integration are inverse processes?</p>
@@ -746,23 +728,20 @@
 
                 <webwork>
 
-                    <setup>
-                        <pg-code>
-                            $expressions = new_checkbox_multiple_choice();
-                            $expressions -> qa (
-                            "A question can go here, but PTX ignores this",
-                            "\( e^{x^2} e^{1/x} \)$BR",
-                            "\( e^{x^2} e^{x^{-1}} \)$BR",
-                            "\( e^{ (x^3+1) / x } \)$BR",
-                            );
-                            $expressions -> extra(
-                            "\( \displaystyle \frac{ e^{x^2} }{ e^x } \)$BR",
-                            "\( e^{x^2} + e^{1/x} \)$BR",
-                            );
-                            $expressions -> makeLast("None of the above");
-
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $expressions = new_checkbox_multiple_choice();
+                        $expressions -> qa (
+                        "A question can go here, but PTX ignores this",
+                        "\( e^{x^2} e^{1/x} \)$BR",
+                        "\( e^{x^2} e^{x^{-1}} \)$BR",
+                        "\( e^{ (x^3+1) / x } \)$BR",
+                        );
+                        $expressions -> extra(
+                        "\( \displaystyle \frac{ e^{x^2} }{ e^x } \)$BR",
+                        "\( e^{x^2} + e^{1/x} \)$BR",
+                        );
+                        $expressions -> makeLast("None of the above");
+                    </pg-code>
 
                     <statement>
                         <p>Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.  There may be more than one correct answer.</p>
@@ -786,13 +765,11 @@
                 <title>Complete this Table</title>
 
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            @a = (random(2,9,1),random(2,9,1));
-                            @b = (random(2,9,1),random(2,9,1));
-                            for my$i(0..3){$p[$i]=$a[int($i/2)]*$b[$i % 2]};
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        @a = (random(2,9,1),random(2,9,1));
+                        @b = (random(2,9,1),random(2,9,1));
+                        for my$i(0..3){$p[$i]=$a[int($i/2)]*$b[$i % 2]};
+                    </pg-code>
 
                     <statement>
                         <p>Complete this multiplication table.</p>
@@ -862,29 +839,26 @@
 
                 <webwork>
 
-                    <setup>
-                        <pg-code>
-                            $answer = random(1,3,1);
-                            $gr = init_graph(-1,-1,4,4,
-                            axes=>[0,0],
-                            grid=>[5,5],
-                            size=>[300,300]
-                            );
-                            add_functions($gr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
-                            $second_x = Real($answer*2**(1/3));
+                    <pg-code>
+                        $answer = random(1,3,1);
+                        $gr = init_graph(-1,-1,4,4,
+                        axes=>[0,0],
+                        grid=>[5,5],
+                        size=>[300,300]
+                        );
+                        add_functions($gr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
+                        $second_x = Real($answer*2**(1/3));
 
-                            $solgr = init_graph(-1,-1,4,4,
-                            axes=>[0,0],
-                            grid=>[5,5],
-                            size=>[300,300]
-                            );
-                            add_functions($solgr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
-                            $solgr->moveTo(0,1);
-                            $solgr->lineTo($answer,1,'black',3);
-                            $solgr->arrowTo($answer,0,'black',3);
-
-                        </pg-code>
-                    </setup>
+                        $solgr = init_graph(-1,-1,4,4,
+                        axes=>[0,0],
+                        grid=>[5,5],
+                        size=>[300,300]
+                        );
+                        add_functions($solgr, "x^3/$answer^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
+                        $solgr->moveTo(0,1);
+                        $solgr->lineTo($answer,1,'black',3);
+                        $solgr->arrowTo($answer,0,'black',3);
+                    </pg-code>
 
                     <statement>
                         <p>The graph below is a graph of <m>y=f(x)</m>. Use the graph to solve the equation <m>f(x)=1</m>.</p>
@@ -925,14 +899,12 @@
 
                 <webwork xml:id="number-or-function">
 
-                    <setup>
-                        <pg-code>
-                            $a = non_zero_random(-9,9,1);
-                            do { $b = random(2,9,1); } until ( $b != $a );
-                            $answer1 = Compute("$a");
-                            $answer2 = Compute("($a x^($b) + $b)/x")->reduce();
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $a = non_zero_random(-9,9,1);
+                        do { $b = random(2,9,1); } until ( $b != $a );
+                        $answer1 = Compute("$a");
+                        $answer2 = Compute("($a x^($b) + $b)/x")->reduce();
+                    </pg-code>
 
                     <statement>
                         <p><ol>
@@ -967,16 +939,14 @@
 
                 <webwork xml:id="function-with-domain-issues">
 
-                    <setup>
-                        <pg-code>
-                            $a = random(2,5,1);
-                            $answer1 = Compute("sqrt(x-$a)");
-                            $answer1->{limits} = [$a+1,$a+4];
-                            $answer2 = Compute("ln(abs( x / (x-$a) ))");
-                            $answer2->{test_points} = [[-5],[-4],[1],[$a-1],[7],[8]];
-                            $answer2evaluator = $answer2 -> cmp() -> withPostFilter( AnswerHints( [Compute("ln(abs((x-$a)/x))"),] => "This is the opposite of correct...",));
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $a = random(2,5,1);
+                        $answer1 = Compute("sqrt(x-$a)");
+                        $answer1->{limits} = [$a+1,$a+4];
+                        $answer2 = Compute("ln(abs( x / (x-$a) ))");
+                        $answer2->{test_points} = [[-5],[-4],[1],[$a-1],[7],[8]];
+                        $answer2evaluator = $answer2 -> cmp() -> withPostFilter( AnswerHints( [Compute("ln(abs((x-$a)/x))"),] => "This is the opposite of correct...",));
+                    </pg-code>
 
                     <statement>
                         <p><ol>
@@ -1012,14 +982,12 @@
 
                 <webwork xml:id="multiple-choice-popup-or-radio-buttons">
 
-                    <setup>
                         <pg-code>
                             $color1 = PopUp(["?","Red","Blue","Green"], 2);
 
                             $color2 = RadioButtons(["Red","Blue","Green","None of these"], 1);
-
                         </pg-code>
-                     <!-- include below in pg-code once checkboxes implemented
+                        <!-- include below in pg-code once checkboxes implemented
                             $mc = new_checkbox_multiple_choice();
                             $mc -> qa (
                             "A question can go here, but PTX ignores this",
@@ -1033,7 +1001,6 @@
                             );
                             $mc -> makeLast("None of the above");
                         -->
-                    </setup>
 
                     <statement>
                         <p>My favorite color is <var name="$color1" form="popup"/>.</p>
@@ -1056,11 +1023,9 @@
 
             <exercise>
                 <webwork>
-                    <setup>
-                        <pg-code>
-                              $expressions = RadioButtons(['\(x\)','\(x^2\)','\(2^x\)'], 2);
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                          $expressions = RadioButtons(['\(x\)','\(x^2\)','\(2^x\)'], 2);
+                    </pg-code>
                     <statement>
                         <p>There is math in each option for this question. Which expression is not a polynomial? <var name="$expressions" form="buttons"/></p>
                     </statement>
@@ -1076,11 +1041,9 @@
 
                 <webwork xml:id="tables">
 
-                    <setup>
-                        <pg-code>
-                            $x = Real(5);
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $x = Real(5);
+                    </pg-code>
 
                     <statement>
                         <p>A table with minimal XML source.</p>
@@ -1145,19 +1108,17 @@
             <exercise>
                 <title>PTX problem source with server-generated images</title>
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            for my $i(0..7){$gr[$i] = init_graph(-1,-1,4,4,axes=>[0,0],grid=>[5,5],size=>[150,150]);};
-                            add_functions($gr[0], "1 for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[1], "x for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[2], "x^2 for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[3], "x^3 for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[4], "e^x for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[5], "sin(x) for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[6], "cos(x) for x in &lt;-1,4> using color:blue and weight:2");
-                            add_functions($gr[7], "exp(-x^2) for x in &lt;-1,4> using color:blue and weight:2");
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        for my $i(0..7){$gr[$i] = init_graph(-1,-1,4,4,axes=>[0,0],grid=>[5,5],size=>[150,150]);};
+                        add_functions($gr[0], "1 for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[1], "x for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[2], "x^2 for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[3], "x^3 for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[4], "e^x for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[5], "sin(x) for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[6], "cos(x) for x in &lt;-1,4> using color:blue and weight:2");
+                        add_functions($gr[7], "exp(-x^2) for x in &lt;-1,4> using color:blue and weight:2");
+                    </pg-code>
                     <stage>
                         <statement>
                             <sidebyside widths="25%">
@@ -1471,11 +1432,9 @@
             <exercise>
                 <title>Checking Proper Indentation In Lists with Images and Tables</title>
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            $g=init_graph(-1,-1,1,1,axes=>[0,0]);
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $g=init_graph(-1,-1,1,1,axes=>[0,0]);
+                    </pg-code>
                     <statement>
                         <p><ol>
                             <li>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1593,7 +1593,7 @@
             element webwork {
                 attribute seed {xsd:integer}?,
                 WWMacros?,
-                WWSetup?,
+                element pg-code {text}?
                 (
                     (StatementExerciseWW, HintWW?, SolutionWW?)
                 |
@@ -1617,10 +1617,6 @@
         WWMacros =
             element pg-macros {
                 element macro-file {text}+
-            }
-        WWSetup =
-            element setup {
-                element pg-code {text}?
             }
         WWVariable =
             ## The WeBWorK "var" element appears in the RELAX-NG schema as a child of many elements, but almost always as a descendant of a "p" element or a "cell" element.  As an element that is only relevant for a WeBWorK problem, occurences of "var" must be within a "webwork" element.  A Schematron rule will check on these two situations.

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -126,7 +126,7 @@
     <xsl:call-template   name="pg-header">
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:call-template>
-    <xsl:apply-templates select="." mode="pg-setup">
+    <xsl:apply-templates select="." mode="pg-code">
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:apply-templates>
     <xsl:apply-templates select="statement">
@@ -164,7 +164,7 @@
     <xsl:if test="$b-verbose">
         <xsl:text>COMMENT('This problem is scaffolded with multiple parts');&#xa;</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="." mode="pg-setup" >
+    <xsl:apply-templates select="." mode="pg-code" >
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:apply-templates>
     <xsl:call-template   name="begin-block">
@@ -192,17 +192,15 @@
     </xsl:call-template>
 </xsl:template>
 
-<!-- The setup element formerly had more internal structure. Now it only   -->
-<!-- contains the pg-code element, and therefore could be eliminated.      -->
-<xsl:template match="webwork" mode="pg-setup">
+<xsl:template match="webwork" mode="pg-code">
     <xsl:param name="b-verbose" />
     <xsl:call-template name="begin-block">
-        <xsl:with-param name="block-title">PG Setup</xsl:with-param>
+        <xsl:with-param name="block-title">PG Setup Code</xsl:with-param>
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:call-template>
     <!-- All our problems load MathObjects, and so should have at least    -->
     <!-- one explicit Context() load.                                      -->
-    <xsl:if test="not(contains(setup/pg-code,'Context('))">
+    <xsl:if test="not(contains(.//pg-code,'Context('))">
         <xsl:text>Context('Numeric');</xsl:text>
         <xsl:if test="$b-verbose">
             <xsl:text>&#xa;</xsl:text>
@@ -210,7 +208,7 @@
     </xsl:if>
     <!-- pg-code verbatim, but trim indentation -->
     <xsl:call-template name="sanitize-text">
-        <xsl:with-param name="text" select="setup/pg-code" />
+        <xsl:with-param name="text" select=".//pg-code" />
     </xsl:call-template>
 </xsl:template>
 
@@ -460,7 +458,7 @@
             </xsl:choose>
         </xsl:if>
         <!-- bizarro arithmetic technique for assesing answer form -->
-        <xsl:if test="contains(./setup/pg-code,'bizarro')">
+        <xsl:if test="contains(.//pg-code,'bizarro')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "bizarroArithmetic.pl",&#xa;</xsl:text>
@@ -493,7 +491,7 @@
             </xsl:choose>
         </xsl:if>
         <!-- targeted feedback messages for specific wrong answers -->
-        <xsl:if test="contains(./setup/pg-code,'AnswerHints')">
+        <xsl:if test="contains(.//pg-code,'AnswerHints')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "answerHints.pl",&#xa;</xsl:text>
@@ -504,7 +502,7 @@
             </xsl:choose>
         </xsl:if>
         <!-- checkboxes multiple choice answers or the very useful NchooseK function-->
-        <xsl:if test=".//var[@form='checkboxes'] or contains(./setup/pg-code,'NchooseK')">
+        <xsl:if test=".//var[@form='checkboxes'] or contains(.//pg-code,'NchooseK')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "PGchoicemacros.pl",&#xa;</xsl:text>
@@ -538,7 +536,7 @@
         </xsl:if>
         <!-- instructions for entering answers into HTML forms -->
         <!-- utility for randomly generating variable letters -->
-        <xsl:if test=".//instruction or contains(./setup/pg-code,'RandomVariableName')">
+        <xsl:if test=".//instruction or contains(.//pg-code,'RandomVariableName')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "PCCmacros.pl",&#xa;</xsl:text>
@@ -584,7 +582,7 @@
         </xsl:apply-templates>
         <!-- allow "f(x)" as part of answers -->
         <!-- note unusual usage precludes using parser modal template here -->
-        <xsl:if test="contains(setup/pg-code,'parserFunction')">
+        <xsl:if test="contains(.//pg-code,'parserFunction')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "parserFunction.pl",&#xa;</xsl:text>
@@ -646,7 +644,7 @@
         </xsl:apply-templates>
         <!-- allow "'" as part of answers, as an effective derivative operator -->
         <!-- note unusual usage precludes using parser modal template here -->
-        <xsl:if test="contains(setup/pg-code,'parser::Prime')">
+        <xsl:if test="contains(.//pg-code,'parser::Prime')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "parserPrime.pl",&#xa;</xsl:text>
@@ -668,7 +666,7 @@
         </xsl:apply-templates>
         <!-- allow a root(n,x) function -->
         <!-- note unusual usage precludes using parser modal template here -->
-        <xsl:if test="contains(setup/pg-code,'parser::Root')">
+        <xsl:if test="contains(.//pg-code,'parser::Root')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "parserRoot.pl",&#xa;</xsl:text>
@@ -685,7 +683,7 @@
         </xsl:apply-templates>
         <!-- Some utility routines that are useful in vector problems -->
         <!-- note unusual usage precludes using parser modal template here -->
-        <xsl:if test="contains(setup/pg-code,'Overline') or contains(setup/pg-code,'BoldMath' or contains(setup/pg-code,'non_zero_point') or contains(setup/pg-code,'non_zero_vector'))">
+        <xsl:if test="contains(.//pg-code,'Overline') or contains(.//pg-code,'BoldMath' or contains(.//pg-code,'non_zero_point') or contains(.//pg-code,'non_zero_vector'))">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "parserVectorUtils.pl",&#xa;</xsl:text>
@@ -950,7 +948,7 @@
 <xsl:template match="webwork" mode="context">
     <xsl:param name="context"/>
     <xsl:param name="b-verbose"/>
-    <xsl:if test="contains(setup/pg-code,$context)">
+    <xsl:if test="contains(.//pg-code,$context)">
         <xsl:if test="$b-verbose">
             <xsl:text>  </xsl:text>
         </xsl:if>
@@ -966,7 +964,7 @@
 <xsl:template match="webwork" mode="parser">
     <xsl:param name="parser"/>
     <xsl:param name="b-verbose"/>
-    <xsl:if test="contains(setup/pg-code,$parser)">
+    <xsl:if test="contains(.//pg-code,$parser)">
         <xsl:if test="$b-verbose">
             <xsl:text>  </xsl:text>
         </xsl:if>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -10841,6 +10841,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
             <xsl:with-param name="incorrect-use" select="$html.google-search != ''" />
     </xsl:call-template>
     <!--  -->
+    <!-- 2020-03-13  deprecated setup element in a webwork -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="$document-root//webwork/setup" />
+        <xsl:with-param name="date-string" select="'2020-03-13'" />
+        <xsl:with-param name="message" select="'the &quot;setup&quot; element in a &quot;webwork&quot; is no longer necessary, simply use &quot;pg-code&quot;'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->


### PR DESCRIPTION
This deprecates the `setup` element in a WeBWorK. Once upon a time, `setup` was a wrapper for a few things. Over time it became the wrapper for `pg-code` only, and it's out of place.

* Removed from all examples
* Update the author guide
* Edit the XSLT to behave with or without `setup`
* Add deprecation message
* Adjust schema