### PR TITLE
Schema: distinguish interactive exercise

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1504,20 +1504,35 @@
             element statement { ExerciseBody }
         Exercise =
             element exercise {
+                (
+                NoninteractiveExercise |
+                InteractiveExercise
+                )
+            }
+        NoninteractiveExercise =
+            element exercise {
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 (
                 ExerciseBody |
-                (StatementExercise, Hint*, Answer*, Solution*) |
-                (IntroductionText?, WebWork, ConclusionText?)
+                (StatementExercise, Hint*, Answer*, Solution*)
                 )
+            }
+        InteractiveExercise =
+            element exercise {
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                (IntroductionText?, WebWork, ConclusionText?)
             }
         ExerciseGroup =
             element exercisegroup {
                 MetaDataTitleOptional,
                 attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                 IntroductionStatementNoCaption?,
-                Exercise+,
+                (
+                NoniteractiveExercise+ |
+                InteractiveExercise+
+                ),
                 ConclusionStatementNoCaption?
             }
         </fragment>


### PR DESCRIPTION
This is me attempting to edit the schema in a more nontrivial way than I've tried so far. For consideration/discussion.

My goal is to make it so that an exericsegroup either has non-WW exercises or it has WW exercises, but never a mix.

In the future, MOM exercises and other flavors might be established. Sort of trying to do this in a way that isn't WW-centric. (But of course, I also think it would be bad to mix WW and MOM exercises in an exercisegroup.)