### PR TITLE
remove "setup" instance

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -672,11 +672,9 @@
 
             <exercise>
                 <webwork>
-                    <setup>
-                        <pg-code>
-                            $statement = 'some PGML math: [`\frac{1}{2}+\frac{3}{2}=2`]; and some *bold text*';
-                        </pg-code>
-                    </setup>
+                    <pg-code>
+                        $statement = 'some PGML math: [`\frac{1}{2}+\frac{3}{2}=2`]; and some *bold text*';
+                    </pg-code>
                     <statement>
                         <p>
                             <var name="$statement"/> makes:


### PR DESCRIPTION
I think the PR that deprecated `setup` and the PR that added PGML syntax in a `var` overlapped chronologically without a rebase, and this `setup` snuck back in.