### PR TITLE
Add caution about punctuation in lists of math items

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -251,13 +251,13 @@
             <!-- fragment names, and their elements, from schema source
             dash-character:       nbsp, ndash, mdash
             xml-character:        ampersand, less, greater
-            latex-character:      hash, dollar, percent, tilde, underscore, 
+            latex-character:      hash, dollar, percent, tilde, underscore,
                                   circumflex, backslash, lbrace, rbrace
             delimiter-character:  lsq, rsq, rq, lq
             exotic-character:     ellipsis, asterisk, backtick, slash, midpoint,
-                                  swungdash, permille, pilcrow, section-mark, 
+                                  swungdash, permille, pilcrow, section-mark,
                                   copyright, registered, trademark
-            generator:            today, timeofday, tex, latex, pretext, webwork, 
+            generator:            today, timeofday, tex, latex, pretext, webwork,
                                   eg, ie, circa, etc
             arithmetic-character: minus, solidus, times, obelus, plusminus
             siunit:               (deferred to its own section)
@@ -556,14 +556,14 @@
                     <p>For simple arithmetic expressions in text, this symbol may be used to indicate a tolerance or a choice of two values, one the negative of the other.</p>
                 </paragraphs>
 
-                <!-- 
+                <!--
                 http://gcp.fcaglp.unlp.edu.ar/_media/integrantes:psantamaria:latex:textcomp.pdf
                 + regular
                 - negative
                 - subtract \textminus
                 <times/>  \texttimes
                 <solidus/> \textfractionsolidus
-                <division/> F7 \textdiv 
+                <division/> F7 \textdiv
                 <plusminus/> b1 \textpm
                 -->
             </subsubsection>
@@ -1295,6 +1295,8 @@
             <p>In these situations, author a list item, <tag>li</tag>, within an <tag>ol</tag> or <tag>ul</tag>, by using <em>only</em> the necessary <tag>m</tag> element.  Do not use an intervening <tag>p</tag>, and do not include any adjacent text.  Whitespace is OK.  Then <pretext/> will add <latex/>'s <c>\displaystyle</c> command to improve the visual appearance of the mathematics, and so you do not need to.</p>
 
             <p>If you prefer to not have this behavior, insert an intervening <tag>p</tag>, and output will be identical, but without the <c>\displaystyle</c>.</p>
+
+            <p>Note that <em>any</em> text, other than whitespace, outside the <tag>m</tag> tag will disable this feature, <em>including punctuation</em>. However, according to the Chicago Manual of Style, 14e, 6.127, <q>Items carry no closing punctuation unless they consist of complete sentences.</q> So that comma at the end of your equation probably doesn't belong there anyway.</p>
         </subsection>
 
         <subsection>
@@ -1480,7 +1482,7 @@
                         </p>
                     </li>
                 </ol>
-                Within the same paragraph, we transition to an unordered, two-column, list of some germs: 
+                Within the same paragraph, we transition to an unordered, two-column, list of some germs:
                 <ul cols="2">
                     <li>
                         <p>Bacteria
@@ -2161,7 +2163,7 @@
                 and you should use it, but it should not be the entire content of a heading
                 since it is not an idea by itself.  But it may be a subheading. For example,
                 suppose you have a paragraph on <q>highland sheep.</q>
-                Then <em>both</em> of the following should appear in your index, 
+                Then <em>both</em> of the following should appear in your index,
                 since a reader might consult both locations.
               </p>
               <pre>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3905,6 +3905,18 @@ the xsltproc executable.
                       </li>
                   </ul>
               </p>
+
+              <p>
+                Inclusion of any text other than math will kill the automatic display style.
+                For example, this would happen if one were to add punctuation after the math.
+              </p>
+
+              <p>
+                <ul>
+                  <li><m>\int_a^b \frac{\sin(x)}{x}\,dx</m>,</li>
+                  <li><m>\int_a^b \frac{\sin(x)}{x}\,dx</m></li>
+                </ul>
+              </p>
             </subsection>
 
             <subsection>


### PR DESCRIPTION
In both the sample article and the documentation, emphasize that *any* text outside of `m` tags in a `li` will disable automatic display math, including punctuation.
In the documentation, also mention that CMoS says that punctuation shouldn't be there anyway.