### PR TITLE
WW: when producing verbose PG, include any introduction from a parent…

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -262,6 +262,25 @@
     </subsection>
 
     <subsection>
+      <title><webwork/> in an <tag>exercisegroup</tag></title>
+      <p>
+        An <tag>exercisegroup</tag> is a collection of exercises with common instructions that are put into an <tag>introduction</tag>.
+        If you put <webwork/> exercises in an exercisegroup,
+        then when the exercises are exported to <c>.pg</c> problem files for use as online homework from a <webwork/> server
+        it makes sense that the instructions from the <tag>exercisegroup</tag>'s <tag>introduction</tag> should be included in the <c>.pg</c> file.
+        And so they are included there. Note that they are <em>not</em> included when you are building <acro>HTML</acro> or <latex/> output
+        for your proeject. (Rather, the <tag>exercisegroup</tag>'s <tag>introduction</tag> appears in its normal place.)
+      </p>
+      <p>
+        You should be aware of this when you write the <tag>exercisegroup</tag>'s <tag>introduction</tag>.
+        It impacts the specific language you should use. For example, if you write <q>Differentiate the following functions.</q>
+        or <q>Differentiate each of the functions below.</q>, then you have language that doesn't fit the individual problem
+        when it is used for homework on a <webwork/> server. Instead you might write <q>Differentiate the function</q>.
+        It makes sense as common instructions for the <tag>exercisegroup</tag> as well as the instructions for an individual exercise.
+      </p>
+    </subsection>
+
+    <subsection>
       <title>Reusing a <tag>webwork</tag> by <attr>xml:id</attr></title>
       <p>Planned.</p>
     </subsection>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -531,6 +531,51 @@
                     </webwork>
                 </exercise>
 
+                <exercisegroup cols="2">
+                    <introduction>
+                        <p>
+                            For the given function <m>f</m>, find <m>\indefiniteintegral{f(x)}{x}</m>.
+                        </p>
+                        <p>
+                            Note that these common instructions are phrased in such a way
+                            that they would read well if they were applied to only one exercise at a time.
+                            That will happen if these exercises are exported as <c>.pg</c> files,
+                            for example to be used in online homework from a <webwork/> server.
+                        </p>
+                    </introduction>
+
+                    <exercise>
+                        <webwork>
+                            <pg-code>
+                                $answer = FormulaUpToConstant("-cos(x)");
+                            </pg-code>
+                            <statement>
+                                <p>
+                                    <m>f(x)=\sin(x)</m>
+                                </p>
+                                <p>
+                                    <var name="$answer" width="20"/>
+                                </p>
+                            </statement>
+                        </webwork>
+                    </exercise>
+
+                    <exercise>
+                        <webwork>
+                            <pg-code>
+                                $answer = FormulaUpToConstant("e^x");
+                            </pg-code>
+                            <statement>
+                                <p>
+                                    <m>f(x)=e^x</m>
+                                </p>
+                                <p>
+                                    <var name="$answer" width="20"/>
+                                </p>
+                            </statement>
+                        </webwork>
+                    </exercise>
+                </exercisegroup>
             </exercises>
         </section>
 

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -259,6 +259,11 @@
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:call-template>
     <xsl:text>&#xa;BEGIN_PGML&#xa;</xsl:text>
+    <xsl:if test="$b-verbose">
+        <xsl:apply-templates select="ancestor::exercisegroup/introduction">
+            <xsl:with-param name="b-verbose" select="$b-verbose"/>
+        </xsl:apply-templates>
+    </xsl:if>
     <xsl:apply-templates>
         <xsl:with-param name="b-verbose" select="$b-verbose" />
     </xsl:apply-templates>
@@ -292,6 +297,13 @@
     <xsl:text>&#xa;BEGIN_PGML_HINT&#xa;</xsl:text>
     <xsl:apply-templates />
     <xsl:text>&#xa;END_PGML_HINT&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="exercisegroup/introduction">
+    <xsl:param name="b-verbose" />
+    <xsl:apply-templates>
+        <xsl:with-param name="b-verbose" select="$b-verbose"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- ############################## -->


### PR DESCRIPTION
… exercisegroup

If there is math in the introduction and the math uses author LaTeX macros, then we need to pass `b-verbose` to the introduction so that the LaTeX macros get defined within the PG file. So that leads to creating an `introduction` template in `extract-pg-common`.