### PR TITLE
WW: load essay macros if explanation_box is used

### DIFF
--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -513,7 +513,7 @@
             </xsl:choose>
         </xsl:if>
         <!-- essay answers -->
-        <xsl:if test=".//var[@form='essay']">
+        <xsl:if test=".//var[@form='essay'] or contains(.//pg-code,'explanation_box')">
             <xsl:choose>
                 <xsl:when test="$b-verbose">
                     <xsl:text>  "PGessaymacros.pl",&#xa;</xsl:text>


### PR DESCRIPTION
`explanation_box` is a variant from the essay macros. It is intended to follow a quantitative answer box, where the student explains their work. (Like find the derivative: ____ Show that you used the definition of the derivative: [explanation box].)

The reason to separate this from an essay is so that you can turn it off globally. Maybe you want to use the question, but now burden yourself with grading the essays. Or if you want to use it during a WW quiz, you really want to not use essay questions, because quiz mode is not designed to handle them well.

This PR detects your desire to use `explanation_box` from the `pg-code` block, and then loads the necessary macro library for you.