### PR TITLE
Add `--version` to mbx script and version file

### DIFF
--- a/script/mbx
+++ b/script/mbx
@@ -20,6 +20,8 @@
 
 # 2016-05-05: this script should run under Python 2.7 and Python 3
 
+from version import __version__
+
 ##############################################
 #
 #  Graphics Language Extraction and Processing
@@ -1320,6 +1322,7 @@ def get_cli_arguments():
     """Return the CLI arguments in parser object"""
     import argparse
     parser = argparse.ArgumentParser(description='MathBook XML utility script', formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
 
     verbose_help = '\n'.join(["verbosity of information on progress of the program",
                               "  -v  is actions being performed",

--- a/script/version.py
+++ b/script/version.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2020 Colin B. Macdonald
+# SPDX-License-Identifier: FSFAP
+
+__version__ = "0.0.1.dev"


### PR DESCRIPTION
Other tools can grab the version number from this file too.  Since there
is stuff here other than Python, maybe the central version number should
not be stored in a py file: that could be changed later.