### PR TITLE
Asymptote corrections

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2809,50 +2809,50 @@ the xsltproc executable.
                     <image xml:id="asymptote-workcone" width="50%">
                         <!-- aspect ratio from canvas in produced HTML -->
                         <asymptote aspect="139:151">
-                          import solids;
-                          size(0,150);
-                          currentprojection=orthographic(0,-30,5);
+                        import solids;
+                        size(0,150);
+                        currentprojection=orthographic(0,-30,5);
 
-                          real r=4;
-                          real h=10;
-                          real s=8;
-                          real x=r*s/h;
+                        real r=4;
+                        real h=10;
+                        real s=8;
+                        real x=r*s/h;
 
-                          real sr=5;
-                          real xr=r*sr/h;
+                        real sr=5;
+                        real xr=r*sr/h;
 
-                          real s1=sr-0.1;
-                          real x1=r*s1/h;
+                        real s1=sr-0.1;
+                        real x1=r*s1/h;
 
-                          real s2=sr+0.2;
-                          real x2=r*s2/h;
+                        real s2=sr+0.2;
+                        real x2=r*s2/h;
 
-                          render render=render(compression=0,merge=true);
+                        render render=render(compression=0,merge=true);
 
-                          draw(scale(x1,x1,-s1)*shift(-Z)*unitcone,lightblue+opacity(0.5),render);
+                        draw(scale(x1,x1,-s1)*shift(-Z)*unitcone,lightblue+opacity(0.5),render);
 
-                          path3 p=(x2,0,s2)--(x,0,s+0.005);
-                          revolution a=revolution(p,Z);
-                          draw(surface(a),lightblue+opacity(0.5),render);
+                        path3 p=(x2,0,s2)--(x,0,s+0.005);
+                        revolution a=revolution(p,Z);
+                        draw(surface(a),lightblue+opacity(0.5),render);
 
-                          path3 q=(x,0,s)--(r,0,h);
-                          revolution b=revolution(q,Z);
-                          draw(surface(b),white+opacity(0.5),render);
+                        path3 q=(x,0,s)--(r,0,h);
+                        revolution b=revolution(q,Z);
+                        draw(surface(b),white+opacity(0.5),render);
 
-                          draw((-r-1,0,0)--(r+1,0,0));
-                          draw((0,0,0)--(0,0,h+1),dashed);
+                        draw((-r-1,0,0)--(r+1,0,0));
+                        draw((0,0,0)--(0,0,h+1),dashed);
 
-                          path3 w=(x1,0,s1)--(x2,0,s2)--(0,0,s2);
-                          revolution b=revolution(w,Z);
-                          draw(surface(b),blue+opacity(0.5),render);
-                          draw(circle((0,0,s2),x2));
-                          draw(circle((0,0,s1),x1));
+                        path3 w=(x1,0,s1)--(x2,0,s2)--(0,0,s2);
+                        revolution b=revolution(w,Z);
+                        draw(surface(b),blue+opacity(0.5),render);
+                        draw(circle((0,0,s2),x2));
+                        draw(circle((0,0,s1),x1));
 
-                          draw("$x$",(xr,0,0)--(xr,0,sr),red,Arrow3,PenMargin3);
-                          draw("$r$",(0,0,sr)--(xr,0,sr),N,red);
-                          draw((string) r,(0,0,h)--(r,0,h),N,red);
-                          draw((string) h,(r,0,0)--(r,0,h),red,Arrow3,PenMargin3);
-                          draw((string) s,(-x,0,0)--(-x,0,s),W,red,Arrow3,Bar3,PenMargin3);
+                        draw("$x$",(xr,0,0)--(xr,0,sr),red,Arrow3,PenMargin3);
+                        draw("$r$",(0,0,sr)--(xr,0,sr),N,red);
+                        draw((string) r,(0,0,h)--(r,0,h),N,red);
+                        draw((string) h,(r,0,0)--(r,0,h),red,Arrow3,PenMargin3);
+                        draw((string) s,(-x,0,0)--(-x,0,s),W,red,Arrow3,Bar3,PenMargin3);
                         </asymptote>
                     </image>
                 </figure>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2809,48 +2809,50 @@ the xsltproc executable.
                     <image xml:id="asymptote-workcone" width="50%">
                         <!-- aspect ratio from canvas in produced HTML -->
                         <asymptote aspect="139:151">
-                        import solids;
-                        size(0,150);
-                        currentprojection=orthographic(0,-30,5);
+                          import solids;
+                          size(0,150);
+                          currentprojection=orthographic(0,-30,5);
 
-                        real r=4;
-                        real h=10;
-                        real s=8;
-                        real x=r*s/h;
+                          real r=4;
+                          real h=10;
+                          real s=8;
+                          real x=r*s/h;
 
-                        real sr=5;
-                        real xr=r*sr/h;
+                          real sr=5;
+                          real xr=r*sr/h;
 
-                        real s1=sr-0.1;
-                        real x1=r*s1/h;
+                          real s1=sr-0.1;
+                          real x1=r*s1/h;
 
-                        real s2=sr+0.2;
-                        real x2=r*s2/h;
+                          real s2=sr+0.2;
+                          real x2=r*s2/h;
 
-                        render render=render(compression=0,merge=true);
+                          render render=render(compression=0,merge=true);
 
-                        path3 p=(0,0,0)--(x,0,s);
-                        revolution a=revolution(p,Z);
-                        draw(surface(a,4),lightblue+opacity(0.5),render);
+                          draw(scale(x1,x1,-s1)*shift(-Z)*unitcone,lightblue+opacity(0.5),render);
 
-                        path3 q=(x,0,s)--(r,0,h);
-                        revolution b=revolution(q,Z);
-                        draw(surface(b),white+opacity(0.5),render);
+                          path3 p=(x2,0,s2)--(x,0,s+0.005);
+                          revolution a=revolution(p,Z);
+                          draw(surface(a),lightblue+opacity(0.5),render);
 
-                        draw((-r-1,0,0)--(r+1,0,0));
-                        draw((0,0,0)--(0,0,h+1),dashed);
+                          path3 q=(x,0,s)--(r,0,h);
+                          revolution b=revolution(q,Z);
+                          draw(surface(b),white+opacity(0.5),render);
 
-                        path3 w=(x1,0,s1)--(x2,0,s2)--(0,0,s2);
-                        revolution b=revolution(w,Z);
-                        draw(surface(b),blue+opacity(0.5),render);
-                        draw(circle((0,0,s2),x2));
-                        draw(circle((0,0,s1),x1));
+                          draw((-r-1,0,0)--(r+1,0,0));
+                          draw((0,0,0)--(0,0,h+1),dashed);
 
-                        draw("$x$",(xr,0,0)--(xr,0,sr),red,Arrow3,PenMargin3);
-                        draw("$r$",(0,0,sr)--(xr,0,sr),N,red);
-                        draw((string) r,(0,0,h)--(r,0,h),N,red);
-                        draw((string) h,(r,0,0)--(r,0,h),red,Arrow3,PenMargin3);
-                        draw((string) s,(-x,0,0)--(-x,0,s),W,red,Arrow3,Bar3,PenMargin3);
+                          path3 w=(x1,0,s1)--(x2,0,s2)--(0,0,s2);
+                          revolution b=revolution(w,Z);
+                          draw(surface(b),blue+opacity(0.5),render);
+                          draw(circle((0,0,s2),x2));
+                          draw(circle((0,0,s1),x1));
+
+                          draw("$x$",(xr,0,0)--(xr,0,sr),red,Arrow3,PenMargin3);
+                          draw("$r$",(0,0,sr)--(xr,0,sr),N,red);
+                          draw((string) r,(0,0,h)--(r,0,h),N,red);
+                          draw((string) h,(r,0,0)--(r,0,h),red,Arrow3,PenMargin3);
+                          draw((string) s,(-x,0,0)--(-x,0,s),W,red,Arrow3,Bar3,PenMargin3);
                         </asymptote>
                     </image>
                 </figure>

--- a/script/mbx
+++ b/script/mbx
@@ -102,7 +102,7 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             asyout = "{}.{}".format(filebase, outformat)
             # asysvg = "{}.svg".format(filebase)
             asypng = "{}_*.png".format(filebase)
-            asy_cmd = [asy_executable, 
+            asy_cmd = [asy_executable,
                        '-f', 'svg',
                        '-render=4', '-iconify',
                        asydiagram
@@ -110,12 +110,10 @@ def asymptote_conversion(xml_source, xmlid_root, dest_dir, outformat):
             _verbose("converting {} to {}".format(asydiagram, asyout))
             _debug("asymptote conversion {}".format(asy_cmd))
             subprocess.call(asy_cmd, stdout=devnull, stderr=subprocess.STDOUT)
-            if os.path.exists(asyout) == True:
-                shutil.copy2(asyout, dest_dir)
-            else:
-                # Sometimes Asymptotes SVGs include multiple PNGs for colored regions
-                for f in glob.glob(asypng):
-                    shutil.copy2(f, dest_dir)
+            shutil.copy2(asyout, dest_dir)
+            # Sometimes Asymptotes SVGs include multiple PNGs for colored regions
+            for f in glob.glob(asypng):
+                shutil.copy2(f, dest_dir)
         # 2020-05-18, EPS, PDF not really examined
         else:
             filebase, _ = os.path.splitext(asydiagram)


### PR DESCRIPTION
Update to mbx script for svg output. Tested against svg, pdf, and html output successfully.

- I did not add the option `-tex xelatex` to the `asy` executable but this should be considered in the future: I can install `asy 2.66` on my 18.04 laptop (by compiling from source) but not `dvisvgm 2.9.1` (need more recent `libc6`) and this is needed to test this option.
- With current options for `svg` the subroutine to copy over `png` files is needed. Adding the `-tex xelatex` option might eliminate the need for this: in all examples I've tested, I get a standalone `svg`.
- Also updated the `workcone` example in the sample article to include the improvements from John Bowman.