### PR TITLE
Enable enhanced privacy for embedded video

### DIFF
--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -36,6 +36,24 @@
 
             <p>The default is to first have <c>index.html</c> redirect to a page for the <tag>frontmatter</tag>, and if this is not possible, then it will redirect to a page for the top-level of your content.  If your document is short or simple, you may just have a single web page.  You do not need to distribute the <c>index.html</c> file and may just wish to use a concise and descriptive <attr>xml:id</attr> for your top-level element.</p>
         </paragraphs>
+
+        <paragraphs xml:id="video-embedding">
+            <title>Privacy options for video embedding</title>
+            <idx><h>video</h><h>HTML</h></idx>
+            <idx><h>privacy</h><h>video</h></idx>
+
+            <p>When videos are embedded in <init>HTML</init> from sites like <url href="https://www.youtube.com">YouTube</url> or <url href="https://vimeo.com/">Vimeo</url>,
+            they come with whatever tracking cookies these sites want to include. Some of these can be helpful; for example, to let the viewer keep track of what they have watched.
+            Others are designed to target advertising, and load when the page loads, rather than when the video plays, which can increase the time it takes for your book to load.</p>
+
+            <p>Currently YouTube offers an <q>enhanced privacy mode</q> that disables tracking cookies on page load.
+            The assumption is that publishers will want to protect their readers' privacy and optimage page load time, so this mode is turned on by default for YouTube videos.
+            It is not known to be available for other platforms, but can be added if this changes. Note that the behavior and appearance of your videos may change slightly depending on which option you choose.</p>
+
+            <p>Within the <tag>publication</tag> element of your publisher file include an <tag>html</tag> element, with a child element <tag>video</tag> having an attribute <attr>privacy</attr>.
+            The value must be either <c>yes</c> (use enhanced privacy, if available), or <c>no</c> (allow all tracking cookies).
+            If your publisher file does not have this element (or you do not have a publisher file) you will get a warning message, and the default will be used.</p>
+          </paragraphs>
     </section>
 
     <section xml:id="knowled-content">

--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -79,6 +79,18 @@
                 <li><attr>google-cx</attr>: a Google <term>cx number</term>, gained from configuring search for a site.</li>
             </ul>Setting this attributes to a non-empty string is the signal to add the relevant code for a search box in the masthead.  See <xref ref="online-search"/> for more.</p>
         </subsection>
+
+        <subsection xml:id="embedded-video-privacy-options">
+            <title>HTML Video Embedding</title>
+            <idx><h>video</h><h>embedding</h></idx>
+            <idx><h>privacy</h><h>video</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/html/video</cline>
+            </cd>element can have the following attribute:<ul>
+                <li><attr>privacy</attr>: allowed values are <c>yes</c> or <c>no</c>.</li>
+            </ul>Setting this to yes (the default) prevents certain tracking cookies from being used. Currently only supported for videos from YouTube. See <xref ref="video-embedding"/> for more.</p>
+        </subsection>
     </section>
 
     <section xml:id="publisher-file-revealjs">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -375,6 +375,27 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- And a boolean variable for the presence of this service -->
 <xsl:variable name="b-google-cse" select="not($google-search-cx = '')" />
 
+<!-- Add a boolean variable to toggle "enhanced privacy mode" -->
+<!-- This is an option for embedded YouTube videos            -->
+<!-- and possibly other platforms at a later date.            -->
+<!-- The default is for privacy (fewer tracking cookies)      -->
+<xsl:variable name="embedded-video-privacy">
+    <xsl:choose>
+        <xsl:when test="$publication/html/video/@privacy = 'yes'">
+            <xsl:value-of select="$publication/html/video/@privacy"/>
+        </xsl:when>
+        <xsl:when test="$publication/html/video/@privacy = 'no'">
+            <xsl:value-of select="$publication/html/video/@privacy"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX WARNING:   HTML video/@privacy in publisher file should be "yes" (fewer cookies) or "no" (all cookies). Proceeding with default value: "yes" (disable cookies, if possible)</xsl:message>
+            <xsl:text>yes</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="b-video-privacy" select="$embedded-video-privacy = 'yes'"/>
+
 <!--                       -->
 <!-- HTML Platform Options -->
 <!--                       -->
@@ -6780,7 +6801,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:text>https://www.youtube.com/embed</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-video-privacy">
+            <xsl:text>https://www.youtube-nocookie.com/embed</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>https://www.youtube.com/embed</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:choose>
         <!-- playlist with a YouTube ID -->
         <xsl:when test="@youtubeplaylist">


### PR DESCRIPTION
Here is the first crack at getting "enhanced privacy mode" working for YouTube.

Possibly some adjustments needed to address questions and concerns as noted [on pretext-support](https://groups.google.com/d/msg/pretext-support/YMukQdYuwPQ/GLk1OTRZAAAJ).

- Created xsl variable `$embedded-video-privacy` (around line 400)
- Depends on element `publication/html/video/@privacy` in publisher file
- Determines xsl boolean `$b-video-privacy`
- Boolean used to set YouTube URL to `https://www.youtube-nocookie.com/embed` if true and `https://www.youtube.com/embed` if false (around line 6800)
- Default value is true.

I might have things backwards as far as the default value and boolean logic. (Maybe some `not`s are needed?) Discussed on the forum.

Documentation changes as well.

I didn't change any of the publisher files in the examples, but can if you want.