### PR TITLE
Un-break pretext-*.xsl changes and add mathbook-*.xsl shims

### DIFF
--- a/xsl/README.md
+++ b/xsl/README.md
@@ -7,19 +7,17 @@ simply called "conversions."  Here we list **some** of the available
 conversions, the list is not exhaustive.  See _The PreTeXt Guide_
 for detailed documentation of use, in chapters of the part
 titled _Publisher's Guide_.
-(The `mathbook-` prefixes are historical.)
 
-
-* `mathbook-latex.xsl` - conversion to LaTeX, which can then
+* `pretext-latex.xsl` - conversion to LaTeX, which can then
 be converted to PDF, in print or electronic flavors.
-* `mathbook-html.xsl` - conversion to HTML for online use.
-* `mathbook-epub.xsl` - conversion to EPUB, needs a supporting script.
-* `mathbook-jupyter.xsl` - conversion to Jupyter notebooks.
+* `pretext-html.xsl` - conversion to HTML for online use.
+* `pretext-epub.xsl` - conversion to EPUB, needs a supporting script.
+* `pretext-jupyter.xsl` - conversion to Jupyter notebooks.
 * `pretext-revealjs.xsl` - conversion of slideshows to HTML.
 * `pretext-beamer.xsl` - conversion of slideshows to PDF.
 * `pretext-braille.xsl` - conversion to precursor of Braille output,
 requires significant further processing.
-* `mathbook-common.xsl` - base templates, and not useful in isolation.
+* `pretext-common.xsl` - base templates, and not useful in isolation.
 * `extract-*.xsl` - used to isolate particular parts of a PreTeXt
 document, typically for subsequent processing by a script.
 

--- a/xsl/extract-asymptote.xsl
+++ b/xsl/extract-asymptote.xsl
@@ -31,7 +31,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/extract-interactive.xsl
+++ b/xsl/extract-interactive.xsl
@@ -31,7 +31,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/extract-latex-image.xsl
+++ b/xsl/extract-latex-image.xsl
@@ -31,7 +31,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/extract-mom.xsl
+++ b/xsl/extract-mom.xsl
@@ -30,7 +30,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/extract-pg-common.xsl
+++ b/xsl/extract-pg-common.xsl
@@ -37,7 +37,7 @@
 <!-- exclusively on "webwork" elements, since these templates are only     -->
 <!-- designed for producing PGML from "webwork" and there is no defense    -->
 <!-- against the templates being applied elsewhere.  So a stylesheet which -->
-<!-- includes this can (and typically should) import  mathbook-common.xsl  -->
+<!-- includes this can (and typically should) import  pretext-common.xsl  -->
 <!-- for universal templates, but should not be simultaneously converting  -->
 <!-- to some other output format.                                          -->
 <!--                                                                       -->
@@ -1190,7 +1190,7 @@
 <!-- are explicitly used, so if they are nested, then "inner" macros will -->
 <!-- be missed. So authors should not use nested macro definitions.       -->
 <!-- Macros are jammed together, but maybe need protection, like {}. The  -->
-<!-- $latex-macros sanitized list assumes  mathbook-common.xsl is used.   -->
+<!-- $latex-macros sanitized list assumes  pretext-common.xsl is used.   -->
 <!-- TODO: This named template examines the current context (see '.' in   -->
 <!-- contains() below), so should be a match template. But its recursive  -->
 <!-- implementation makes it a named template for now.                    -->
@@ -1213,7 +1213,7 @@
 <!-- are explicitly used, so if they are nested, then "inner" macros will -->
 <!-- be missed. So authors should not use nested macro definitions.       -->
 <!-- Macros are jammed together, but maybe need protection, like {}. The  -->
-<!-- $latex-macros sanitized list assumes  mathbook-common.xsl is used.   -->
+<!-- $latex-macros sanitized list assumes  pretext-common.xsl is used.   -->
 <!-- TODO: This named template examines the current context (see '.' in   -->
 <!-- contains() below), so should be a match template. But its recursive  -->
 <!-- implementation makes it a named template for now.                    -->
@@ -1306,8 +1306,8 @@
 
 <!-- The cross-reference numbering scheme uses \ref, \hyperref -->
 <!-- for LaTeX and numbers elsewhere, so it is unimplmented in -->
-<!-- mathbook-common.xsl, hence we implement it here           -->
-<!-- This is identical to mathbook-html.xsl                    -->
+<!-- pretext-common.xsl, hence we implement it here           -->
+<!-- This is identical to pretext-html.xsl                    -->
 
 <xsl:template match="*" mode="xref-number">
     <xsl:apply-templates select="." mode="number" />
@@ -1337,7 +1337,7 @@
 <!-- NB: we allow the "var" element as a child                             -->
 
 <!-- Common documentation -->
-<!-- Note: the default template for "text()" in xsl/mathbook-common.xsl    -->
+<!-- Note: the default template for "text()" in xsl/pretext-common.xsl    -->
 <!-- will drop "clause-ending" punctuation that immediately follows a bit  -->
 <!-- of math, and possibly remove some resulting leading whitespace. For   -->
 <!-- inline math "m" this behavior is under the control of the global      -->
@@ -1495,7 +1495,7 @@
             <xsl:value-of select="@prefix" />
         </xsl:variable>
         <xsl:variable name="short">
-            <xsl:for-each select="document('mathbook-units.xsl')">
+            <xsl:for-each select="document('pretext-units.xsl')">
                 <xsl:value-of select="key('prefix-key',concat('prefixes',$prefix))/@short"/>
             </xsl:for-each>
         </xsl:variable>
@@ -1508,7 +1508,7 @@
                 <xsl:value-of select="@base" />
             </xsl:variable>
             <xsl:variable name="short">
-                <xsl:for-each select="document('mathbook-units.xsl')">
+                <xsl:for-each select="document('pretext-units.xsl')">
                     <xsl:value-of select="key('base-key',concat('bases',$base))/@short"/>
                 </xsl:for-each>
             </xsl:variable>

--- a/xsl/extract-pg-ptx.xsl
+++ b/xsl/extract-pg-ptx.xsl
@@ -60,7 +60,7 @@
 <!-- for latex-images) apply to the mered file. So you must re-apply       -->
 <!-- pretext-merge.xsl  each time something changes with source XML.       -->
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- We are outputting Python code, and there is no reason to output       -->
 <!-- anything other than "text"                                            -->

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -55,7 +55,7 @@
 <!-- for latex-images) apply to the mered file. So you must re-apply       -->
 <!-- pretext-merge.xsl  each time something changes with source XML.       -->
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- We are really outputting Python code, but setting the output method   -->
 <!-- to be "xml" makes it easy to dump in the author's source.             -->

--- a/xsl/extract-sageplot.xsl
+++ b/xsl/extract-sageplot.xsl
@@ -33,7 +33,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/extract-youtube.xsl
+++ b/xsl/extract-youtube.xsl
@@ -31,7 +31,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 >
 
 <!-- Get internal ID's for filenames, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Get a "subtree" xml:id value   -->
 <!-- Then walk the XML source tree  -->

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-common.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-html.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-jupyter.xsl
+++ b/xsl/mathbook-jupyter.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-jupyter.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-latex.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-sage-doctest.xsl
+++ b/xsl/mathbook-sage-doctest.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-sage-doctest.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-smc.xsl
+++ b/xsl/mathbook-smc.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-smc.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/mathbook-units.xsl
+++ b/xsl/mathbook-units.xsl
@@ -1,0 +1,13 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+    >
+<!-- mathbook-*.xsl is deprecated -->
+<xsl:import href="./pretext-units.xsl"/>
+<xsl:template match="/">
+  <xsl:message>PTX:WARNING: Use of mathbook-*.xsl stylesheets is deprecated. These will be removed in future versions.</xsl:message>
+  <xsl:apply-imports/>
+</xsl:template>
+</xsl:stylesheet>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -32,7 +32,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- various pieces of material or content, authored or computed,  -->
 <!-- into an enhanced source tree.                                 -->
 <!--                                                               -->
-<!-- Import this stylesheet immediately after mathbook-common.xsl. -->
+<!-- Import this stylesheet immediately after pretext-common.xsl. -->
 <!--                                                               -->
 <!-- * $original will point to source file/tree/XML at the overall -->
 <!--   "pretext" element.                                          -->

--- a/xsl/pretext-basic-html.xsl
+++ b/xsl/pretext-basic-html.xsl
@@ -42,7 +42,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-html.xsl" />
+<xsl:import href="./pretext-html.xsl" />
 
 <!-- Unknowl as much as possible -->
 <xsl:param name="html.knowl.theorem" select="'no'" />

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -26,7 +26,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:date="http://exslt.org/dates-and-times"
     extension-element-prefixes="exsl date"
 >
-<xsl:import href="./mathbook-latex.xsl" />
+<xsl:import href="./pretext-latex.xsl" />
 
 <xsl:output method="text" indent="no" encoding="UTF-8"/>
 
@@ -474,7 +474,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\ifxetex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
     <xsl:text>\ifluatex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
     <xsl:text>%% Common non-SI units&#xa;</xsl:text>
-    <xsl:for-each select="document('mathbook-units.xsl')//base[@siunitx]">
+    <xsl:for-each select="document('pretext-units.xsl')//base[@siunitx]">
       <xsl:text>\DeclareSIUnit\</xsl:text>
       <xsl:value-of select="@full" />
       <xsl:text>{</xsl:text>

--- a/xsl/pretext-braille.xsl
+++ b/xsl/pretext-braille.xsl
@@ -41,7 +41,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     >
 
 <!-- desire HTML output, but primarily content -->
-<xsl:import href="mathbook-html.xsl" />
+<xsl:import href="pretext-html.xsl" />
 
 <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
 
@@ -62,7 +62,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Entry Template -->
 <!-- ############## -->
 
-<!-- These two templates are similar to those of  mathbook-html.xsl. -->
+<!-- These two templates are similar to those of  pretext-html.xsl. -->
 <!-- Primarily the production of cross-reference ("xref") knowls     -->
 <!-- has been removed.                                               -->
 
@@ -74,7 +74,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- There is always a "document root" directly under the mathbook element, -->
 <!-- and we process it with the chunking template called below              -->
 <!-- Note that "docinfo" is at the same level and not structural, so killed -->
-<!-- We process structural nodes via chunking routine in xsl/mathbook-common.xsl    -->
+<!-- We process structural nodes via chunking routine in xsl/pretext-common.xsl    -->
 <!-- This in turn calls specific modal templates defined elsewhere in this file     -->
 <xsl:template match="/mathbook|/pretext">
     <xsl:call-template name="banner-warning">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -57,14 +57,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- your-book-latex.xsl                                              -->
 <!--   (a) is what you use on the command line                        -->
 <!--   (b) contains very specific, atomic overrides for your project  -->
-<!--   (c) imports xsl/mathbook-latex.xsl                             -->
+<!--   (c) imports xsl/pretext-latex.xsl                             -->
 <!--                                                                  -->
-<!-- xsl/mathbook-latex.xsl                                           -->
+<!-- xsl/pretext-latex.xsl                                           -->
 <!--   (a) general conversion from MBX to LaTeX                       -->
 <!--   (b) could be used at the command line for default conversion   -->
-<!--   (c) imports xsl/mathbook-common.xsl                            -->
+<!--   (c) imports xsl/pretext-common.xsl                            -->
 <!--                                                                  -->
-<!-- xsl/mathbook-common.xsl                                          -->
+<!-- xsl/pretext-common.xsl                                          -->
 <!--   (a) this file                                                  -->
 <!--   (b) ensures commonality, such as text versions                 -->
 <!--       of numbers for theorems, equations, etc                    -->
@@ -3745,7 +3745,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!--   2) match="&STRUCTURAL;" mode="intermediate"              -->
 <!--                                                            -->
 <!-- Similarities can be consolidated within the implementation -->
-<!-- See  xsl/mathbook-html.xsl  a typical example              -->
+<!-- See  xsl/pretext-html.xsl  a typical example              -->
 
 <xsl:template match="&STRUCTURAL;" mode="chunking">
     <xsl:variable name="chunk">
@@ -3814,7 +3814,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- A default summary page can just ignore the structural      -->
 <!-- divisions within though usually you might want to do       -->
 <!-- something with them, so you would override this template   -->
-<!-- with an implementation.  See xsl/mathbook-sage-doctest.xsl -->
+<!-- with an implementation.  See xsl/pretext-sage-doctest.xsl -->
 <!-- which uses all of these general routines here              -->
 <xsl:template match="&STRUCTURAL;" mode="summary">
     <xsl:apply-templates select="*[not(&STRUCTURAL-FILTER;)]" />

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -42,7 +42,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-common.xsl"/>
+<xsl:import href="./pretext-common.xsl"/>
 <xsl:import href="./pretext-assembly.xsl"/>
 
 
@@ -423,7 +423,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Parameters -->
 <!-- Parameters to pass via xsltproc "stringparam" on command-line            -->
 <!-- Or make a thin customization layer and use 'select' to provide overrides -->
-<!-- See more generally applicable parameters in mathbook-common.xsl file     -->
+<!-- See more generally applicable parameters in pretext-common.xsl file     -->
 
 <!-- WeBWorK exercise may be rendered static="yes"    -->
 <!-- TODO: implement middle option static="preview"   -->
@@ -732,7 +732,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$root"/>
 </xsl:template>
 
-<!-- We process structural nodes via chunking routine in xsl/mathbook-common.xsl    -->
+<!-- We process structural nodes via chunking routine in xsl/pretext-common.xsl    -->
 <!-- This in turn calls specific modal templates defined elsewhere in this file     -->
 <!-- The xref-knowl templates run independently on content node of document tree    -->
 <xsl:template match="/mathbook|/pretext">
@@ -782,7 +782,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Structural Nodes -->
 <!-- ################ -->
 
-<!-- Read the code and documentation for "chunking" in xsl/mathbook-common.xsl  -->
+<!-- Read the code and documentation for "chunking" in xsl/pretext-common.xsl  -->
 <!-- This will explain document structure (not XML structure) and has the       -->
 <!-- routines which employ the realizations below of two abstract templates.    -->
 
@@ -1400,7 +1400,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Arbitrary Lists -->
 <!-- ############### -->
 
-<!-- See general routine in  xsl/mathbook-common.xsl -->
+<!-- See general routine in  xsl/pretext-common.xsl -->
 <!-- which expects the two named templates and the  -->
 <!-- two division'al and element'al templates below,  -->
 <!-- it contains the logic of constructing such a list -->
@@ -3818,7 +3818,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>exercisegroup-exercises</xsl:text>
             <xsl:if test="@cols">
                 <xsl:text> </xsl:text>
-                <!-- HTML-specific, but in mathbook-common.xsl -->
+                <!-- HTML-specific, but in pretext-common.xsl -->
                 <xsl:apply-templates select="." mode="number-cols-CSS-class" />
             </xsl:if>
         </xsl:attribute>
@@ -3861,7 +3861,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>exercisegroup-exercises</xsl:text>
                     <xsl:if test="@cols">
                         <xsl:text> </xsl:text>
-                        <!-- HTML-specific, but in mathbook-common.xsl -->
+                        <!-- HTML-specific, but in pretext-common.xsl -->
                         <xsl:apply-templates select="." mode="number-cols-CSS-class" />
                     </xsl:if>
                 </xsl:attribute>
@@ -5593,7 +5593,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="html-list-class" />
             <xsl:if test="@cols">
                 <xsl:text> </xsl:text>
-                <!-- HTML-specific, but in mathbook-common.xsl -->
+                <!-- HTML-specific, but in pretext-common.xsl -->
                 <xsl:apply-templates select="." mode="number-cols-CSS-class" />
             </xsl:if>
         </xsl:attribute>
@@ -5966,10 +5966,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- SideBySide Layouts -->
 <!-- ################## -->
 
-<!-- See xsl/mathbook-common.xsl for descriptions of the  -->
+<!-- See xsl/pretext-common.xsl for descriptions of the  -->
 <!-- four modal templates which must be implemented here  -->
 <!-- The main templates for "sidebyside" and "sbsgroup"   -->
-<!-- are in xsl/mathbook-common.xsl, as befits containers -->
+<!-- are in xsl/pretext-common.xsl, as befits containers -->
 
 <!-- When we use CSS margins (or padding), then percentage        -->
 <!-- widths are relative to the remaining space.  This utility    -->
@@ -7209,7 +7209,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Table construction utilities -->
 <!-- ############################ -->
 
-<!-- Utilities are defined in xsl/mathbook-common.xsl -->
+<!-- Utilities are defined in xsl/pretext-common.xsl -->
 
 <!-- "thickness-specification" : param "width"    -->
 <!--     none, minor, medium, major -> 0, 1, 2, 3 -->
@@ -7270,7 +7270,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and then condition on the location of the    -->
 <!-- actual link, which is sensitive to display   -->
 <!-- math in particular                           -->
-<!-- See xsl/mathbook-common.xsl for more info    -->
+<!-- See xsl/pretext-common.xsl for more info    -->
 <!-- TODO: could match on "xref" once link routines  -->
 <!-- are broken into two and other uses are rearranged -->
 <xsl:template match="*" mode="xref-link">
@@ -7508,7 +7508,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="@prefix" />
         </xsl:variable>
         <xsl:variable name="short">
-            <xsl:for-each select="document('mathbook-units.xsl')">
+            <xsl:for-each select="document('pretext-units.xsl')">
                 <xsl:value-of select="key('prefix-key',concat('prefixes',$prefix))/@short"/>
             </xsl:for-each>
         </xsl:variable>
@@ -7519,7 +7519,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="@base" />
     </xsl:variable>
     <xsl:variable name="short">
-        <xsl:for-each select="document('mathbook-units.xsl')">
+        <xsl:for-each select="document('pretext-units.xsl')">
             <xsl:value-of select="key('base-key',concat('bases',$base))/@short"/>
         </xsl:for-each>
     </xsl:variable>
@@ -7846,7 +7846,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:element>
 </xsl:template>
 
-<!-- cline template is in xsl/mathbook-common.xsl -->
+<!-- cline template is in xsl/pretext-common.xsl -->
 <xsl:template match="cd[cline]">
     <xsl:param name="b-original" select="true()" />
     <xsl:element name="pre">
@@ -7864,7 +7864,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The "interior" templates decide between two styles  -->
 <!--   (a) clean up raw text, just like for Sage code    -->
 <!--   (b) interpret cline as line-by-line structure     -->
-<!-- (See templates in xsl/mathbook-common.xsl file)     -->
+<!-- (See templates in xsl/pretext-common.xsl file)     -->
 <!-- Then wrap in a pre element that MathJax ignores     -->
 <xsl:template match="pre">
     <xsl:element name="pre">
@@ -7880,7 +7880,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################### -->
 
 <!-- XML and LaTeX equal to ASCII defaults  -->
-<!-- See mathbook-common.xsl for discussion -->
+<!-- See pretext-common.xsl for discussion -->
 
 <!--           -->
 <!-- XML, HTML -->
@@ -8202,7 +8202,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################## -->
 
 <!-- These are specific instances of abstract templates        -->
-<!-- See the similar section of  mathbook-common.xsl  for more -->
+<!-- See the similar section of  pretext-common.xsl  for more -->
 
 <!-- Non-breaking space, which "joins" two words as a unit            -->
 <!-- Using &nbsp; does not travel well into node-set() in common file -->

--- a/xsl/pretext-json-manifest.xsl
+++ b/xsl/pretext-json-manifest.xsl
@@ -65,7 +65,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="base-url" select="'http://abstract.ups.edu/aata/'"/>
 <!-- <xsl:param name="base-url" select="'http://set-base-url/'"/> -->
 
-<!-- Necessary variables, typically set in  mathbook-html.xsl -->
+<!-- Necessary variables, typically set in  pretext-html.xsl -->
 <!-- $chunk-level will eventually be referenced by templates  -->
 <!-- for the containing filename used to construct a URL      -->
 <!-- Since we are describing HTML output, we want filenames   -->

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -31,8 +31,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl str"
     >
 
-<xsl:import href="./mathbook-common.xsl" />
-<xsl:import href="./mathbook-html.xsl" />
+<xsl:import href="./pretext-common.xsl" />
+<xsl:import href="./pretext-html.xsl" />
 
 <!-- Output is JSON, enriched with serialized HTML -->
 <xsl:output method="text" />
@@ -66,7 +66,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates />
 </xsl:template>
 
-<!-- We process structural nodes via chunking routine in  xsl/mathbook-common.html -->
+<!-- We process structural nodes via chunking routine in  xsl/pretext-common.xsl -->
 <!-- This in turn calls specific modal templates defined elsewhere in this file    -->
 <xsl:template match="/mathbook|/pretext">
     <xsl:call-template name="banner-warning">
@@ -92,7 +92,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Structural Nodes -->
 <!-- ################ -->
 
-<!-- Read the code and documentation for "chunking" in xsl/mathbook-common.html -->
+<!-- Read the code and documentation for "chunking" in xsl/pretext-common.xsl -->
 <!-- This will explain document structure (not XML structure) and has the       -->
 <!-- routines which call the necessary realizations of two abstract templates.  -->
 
@@ -147,7 +147,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Three modal templates accomodate all document structure nodes -->
 <!-- and all possibilities for chunking.  Read the description     -->
-<!-- in  xsl/mathbook-common.xsl to understand these.              -->
+<!-- in  xsl/pretext-common.xsl to understand these.              -->
 <!-- The  "file-wrap"  template is defined elsewhre in this file.  -->
 
 <!-- Content of a summary page is usual content,  -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -34,7 +34,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 <xsl:import href="./pretext-assembly.xsl"/>
 
 <!-- Intend output for rendering by pdflatex -->
@@ -81,7 +81,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--  -->
 <!-- Author's Tools                                            -->
 <!-- Set the author-tools parameter to 'yes'                   -->
-<!-- (Documented in mathbook-common.xsl)                       -->
+<!-- (Documented in pretext-common.xsl)                       -->
 <!-- Installs some LaTeX-specific behavior                     -->
 <!-- (1) Index entries in margin of the page                   -->
 <!--      where defined, on single pass (no real index)        -->
@@ -159,7 +159,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- LaTeX is handled natively, so we flip a  -->
 <!-- switch here to signal the general text() -->
-<!-- handler in xsl/mathbook-common.xsl to    -->
+<!-- handler in xsl/pretext-common.xsl to    -->
 <!-- not dress-up clause-ending punctuation   -->
 <xsl:variable name="latex-processing" select="'native'" />
 
@@ -1075,7 +1075,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\ifxetex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
         <xsl:text>\ifluatex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
         <xsl:text>%% Common non-SI units&#xa;</xsl:text>
-        <xsl:for-each select="document('mathbook-units.xsl')//base[@siunitx]">
+        <xsl:for-each select="document('pretext-units.xsl')//base[@siunitx]">
             <xsl:text>\DeclareSIUnit\</xsl:text>
             <xsl:value-of select="@full" />
             <xsl:text>{</xsl:text>
@@ -1571,7 +1571,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
     </xsl:if>
     <!-- Numbering Equations -->
-    <!-- See numbering-equations variable being set in mathbook-common.xsl         -->
+    <!-- See numbering-equations variable being set in pretext-common.xsl         -->
     <!-- With number="yes|no" on mrow, we must allow for the possibility of an md  -->
     <!-- variant having numbers (we could be more careful, but it is not critical) -->
     <!-- NB: global numbering is level 0 and "level-to-name" is (a) incorrect,     -->
@@ -4477,7 +4477,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Arbitrary Lists -->
 <!-- ############### -->
 
-<!-- See general routine in  xsl/mathbook-common.xsl -->
+<!-- See general routine in  xsl/pretext-common.xsl -->
 <!-- which expects the two named templates and the  -->
 <!-- two division'al and element'al templates below,  -->
 <!-- it contains the logic of constructing such a list -->
@@ -7856,7 +7856,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- With a "cline" element present, we assume   -->
 <!-- that is the entire structure (see the cline -->
-<!-- template in the mathbook-common.xsl file)   -->
+<!-- template in the pretext-common.xsl file)   -->
 <xsl:template match="cd[cline]">
     <xsl:text>%&#xa;</xsl:text>
     <xsl:text>\begin{codedisplay}&#xa;</xsl:text>
@@ -7868,7 +7868,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The "interior" templates decide between two styles  -->
 <!--   (a) clean up raw text, just like for Sage code    -->
 <!--   (b) interpret cline as line-by-line structure     -->
-<!-- (See templates in xsl/mathbook-common.xsl file)     -->
+<!-- (See templates in xsl/pretext-common.xsl file)     -->
 <!-- Then wrap in a  verbatim  environment               -->
 <xsl:template match="pre">
     <xsl:text>\begin{preformatted}&#xa;</xsl:text>
@@ -7890,7 +7890,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################### -->
 
 <!-- Across all possibilities                     -->
-<!-- See mathbook-common.xsl for discussion       -->
+<!-- See pretext-common.xsl for discussion       -->
 <!-- See default LaTeX2e textcomp symbols at:     -->
 <!-- http://hevea.inria.fr/examples/test/sym.html -->
 
@@ -8442,7 +8442,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################## -->
 
 <!-- These are specific instances of abstract templates        -->
-<!-- See the similar section of  mathbook-common.xsl  for more -->
+<!-- See the similar section of  pretext-common.xsl  for more -->
 
 <!-- TODO: Perhaps use LaTeX double and triple hyphen variants of  -->
 <!-- en-dash and em-dash under some option for human-variant LaTeX -->
@@ -8765,10 +8765,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- SideBySide Layouts -->
 <!-- ################## -->
 
-<!-- See xsl/mathbook-common.xsl for descriptions of the  -->
+<!-- See xsl/pretext-common.xsl for descriptions of the  -->
 <!-- four modal templates which must be implemented here  -->
 <!-- The main templates for "sidebyside" and "sbsgroup"   -->
-<!-- are in xsl/mathbook-common.xsl, as befits containers -->
+<!-- are in xsl/pretext-common.xsl, as befits containers -->
 
 <!-- Note: Various end-of-line "%" are necessary to keep  -->
 <!-- headings, panels, and captions together as one unit  -->
@@ -9636,7 +9636,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Typically use these at the last moment,             -->
 <!-- while outputting, and thus use MBX terms internally -->
 
-<!-- Some utilities are defined in xsl/mathbook-common.xsl -->
+<!-- Some utilities are defined in xsl/pretext-common.xsl -->
 
 <!-- "halign-specification" : param "align" -->
 <!--     left, right, center -> l, c, r     -->
@@ -9645,7 +9645,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--     top, middle, bottom -> t, m, b     -->
 
 <!-- paragraph valign-specifications (p, m, b) are  -->
-<!-- different from (t, m, b) in mathbook-common    -->
+<!-- different from (t, m, b) in pretext-common    -->
 
 <!-- paragraph halign-specifications (left, center, right, justify) -->
 <!-- converted to \raggedright, \centering, \raggedleft, <empty>    -->
@@ -10001,7 +10001,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ways LaTeX cannot, so the union of the match critera here should be    -->
 <!-- the list above.  Or said differently, a new object needs to preserve   -->
 <!-- this union property across the various "xref-number" templates.        -->
-<!-- See xsl/mathbook-common.xsl for more info.                             -->
+<!-- See xsl/pretext-common.xsl for more info.                             -->
 
 <xsl:template match="*" mode="xref-number">
     <xsl:param name="xref" select="/.." />

--- a/xsl/pretext-litprog.xsl
+++ b/xsl/pretext-litprog.xsl
@@ -34,7 +34,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Intend output for rendering by pdflatex -->
 <xsl:output method="text" />

--- a/xsl/pretext-merge.xsl
+++ b/xsl/pretext-merge.xsl
@@ -34,7 +34,7 @@
 <!-- List of auxiliary XML this sytle sheet merges:                        -->
 <!-- * WeBWorK extractions                                                 -->
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- We output a single, large .ptx file for further -->
 <!-- processing by other PTX style sheets            -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -36,7 +36,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Necessary to get some HTML constructions, -->
 <!-- but want to be sure to override the entry -->
 <!-- template to avoid chunking, etc.          -->
-<xsl:import href="mathbook-html.xsl" />
+<xsl:import href="pretext-html.xsl" />
 
 <!-- HTML5 format -->
 <xsl:output method="html" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat"/>

--- a/xsl/pretext-sage-doctest.xsl
+++ b/xsl/pretext-sage-doctest.xsl
@@ -15,7 +15,7 @@
 >
 
 <!-- For numbers, titles, text utilities, etc -->
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- Intend output for Python docstring -->
 <xsl:output method="text" />
@@ -23,7 +23,7 @@
 <!-- Doctest files are Python (docstring) -->
 <xsl:variable name="file-extension" select="'.py'" />
 
-<!-- Set the chunking level variable for the routines in mathbook-common.xsl. -->
+<!-- Set the chunking level variable for the routines in pretext-common.xsl. -->
 <!-- Default to zero, else use whatever an author specifies                   -->
 <xsl:variable name="chunk-level">
     <xsl:choose>
@@ -49,7 +49,7 @@
 </xsl:template>
 
 <!-- We process structural nodes via chunking        -->
-<!-- routine in   xsl/mathbook-common.html           -->
+<!-- routine in   xsl/pretext-common.xsl             -->
 <!-- The default templates there do everything       -->
 <!-- we need once we have "file-wrap" modal template -->
 <xsl:template match="mathbook|pretext">

--- a/xsl/pretext-smc.xsl
+++ b/xsl/pretext-smc.xsl
@@ -12,7 +12,7 @@
     xmlns:math="http://exslt.org/math"
     extension-element-prefixes="exsl date math">
 
-<xsl:import href="./mathbook-html.xsl" />
+<xsl:import href="./pretext-html.xsl" />
 
 <!-- Intend output for rendering by browsers-->
 <xsl:output method="html" indent="yes"/>
@@ -43,7 +43,7 @@
     <xsl:apply-templates />
 </xsl:template>
 
-<!-- We process structural nodes via chunking routine in   xsl/mathbook-common.html -->
+<!-- We process structural nodes via chunking routine in   xsl/pretext-common.xsl   -->
 <!-- This in turn calls specific modal templates defined elsewhere in this file     -->
 <!-- Contrary to HTML production, we do not have a pass through to build the knowls -->
 <xsl:template match="mathbook">
@@ -189,7 +189,7 @@
     </xsl:apply-templates>
 </xsl:template>
 
-<!-- Most Sage options are implemented in  xsl/mathbook-common.xsl -->
+<!-- Most Sage options are implemented in  xsl/pretext-common.xsl -->
 <!-- We just output the input code, with no XHTML protections      -->
 <xsl:template match="sage" mode="sage-active-markup">
     <xsl:param name="in" />

--- a/xsl/pretext-solution-manual-latex.xsl
+++ b/xsl/pretext-solution-manual-latex.xsl
@@ -34,12 +34,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-latex.xsl" />
+<xsl:import href="./pretext-latex.xsl" />
 
 <!-- Intend output for rendering by pdflatex -->
 <xsl:output method="text" />
 
-<!-- These variables are interpreted in mathbook-common.xsl and  -->
+<!-- These variables are interpreted in pretext-common.xsl and  -->
 <!-- so may be used/set in a custom XSL stylesheet for a         -->
 <!-- project's solution manual.                                  -->
 <!--                                                             -->
@@ -65,7 +65,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- project.solution                                            -->
 <!--                                                             -->
 <!-- The second set of variables are internal, and are derived   -->
-<!-- from the above via careful routines in mathbook-common.xsl. -->
+<!-- from the above via careful routines in pretext-common.xsl. -->
 <!--                                                             -->
 <!-- b-has-inline-statement                                      -->
 <!-- b-has-inline-hint                                           -->
@@ -99,7 +99,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- We have a switch for just this situation, to force -->
 <!-- (overrule) the auto-detetion of the necessity for  -->
 <!-- LaTeX styles for the solutions to exercises.       -->
-<!-- See  mathbook-latex.xsl  for more explanation.     -->
+<!-- See  pretext-latex.xsl  for more explanation.     -->
 <xsl:variable name="b-needs-solution-styles" select="true()"/>
 
 <!-- We hardcode the numbers of 2D displays so they are correct where  -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -42,7 +42,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl date str"
 >
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 
 <!-- This is a conversion to "plain" text.  Upon initiation it is mainly -->
 <!-- meant as a foundation for various simple conversions to things like -->
@@ -50,7 +50,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- conversion.  But obviously, there are many PreTeXt constructions    -->
 <!-- which cannot be realized in text.                                   -->
 <!--                                                                     -->
-<!-- Goal is to make it so *no* conversion imports "mathbook-common.xsl" -->
+<!-- Goal is to make it so *no* conversion imports "pretext-common.xsl" -->
 <!-- since some foundational conversion (such as this one) can be the    -->
 <!-- basis of the conversion and will import the foundationa one instead.-->
 <!--                                                                     -->

--- a/xsl/pretext-view-source.xsl
+++ b/xsl/pretext-view-source.xsl
@@ -38,7 +38,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="exsl"
 >
 
-<xsl:import href="./mathbook-html.xsl" />
+<xsl:import href="./pretext-html.xsl" />
 
 <!-- We assume the source is in great shape, typically having been -->
 <!-- created by a pretty-printing tool.  So we keep all the        -->

--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -39,7 +39,7 @@
 <!-- upload into a WeBWorK course (perhaps in the templates/local folder); -->
 <!-- or into a server's libraries folder and set up site-wide access.      -->
 
-<xsl:import href="./mathbook-common.xsl" />
+<xsl:import href="./pretext-common.xsl" />
 <xsl:import href="./pretext-assembly.xsl" />
 
 <!-- Intend output to be a PG/PGML problem or a "def" file -->


### PR DESCRIPTION
This should complete the `pretext-`ification of the historical `mathbook-` XSLTs.

At some point we can have the `mathbook-*.xsl` shims stop importing `pretext-*.xsl` and raise an error rather than a warning, before eventually removing them altogether.