### PR TITLE
WeBWorK: description element

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -280,6 +280,53 @@
       </p>
     </subsection>
 
+    <subsection xml:id="webwork-metadata">
+      <title>Metadata</title>
+      <p>
+        A <tag>webwork</tag> <em>without a source attribute</em> can have a plain text <tag>description</tag>.
+        This should be a summary of what the exercise asks a user to do,
+        including any relevant pedagogical details of the exercise. For example:
+      </p>
+      <pre>
+        <![CDATA[
+        <webwork>
+
+          <description>
+            Add two fractions with distinct one-digit prime denominators.
+          </description>
+
+          ...
+
+        </webwork>
+        ]]>
+      </pre>
+      <p>
+        A longer description may be broken into lines where the lines are plain text.
+      </p>
+      <pre>
+        <![CDATA[
+        <webwork>
+
+          <description>
+            <line>
+              Add two fractions with distinct one-digit prime denominators.
+            </line>
+            <line>
+              One fraction is always positive, the other always negative.
+            </line>
+          </description>
+
+          ...
+
+        </webwork>
+        ]]>
+      </pre>
+      <p>
+        The content of the description will be written into a PG <c>COMMENT</c> command,
+        making the description visible in a <webwork/> Library Browser.
+      </p>
+    </subsection>
+
     <subsection>
       <title>Reusing a <tag>webwork</tag> by <attr>xml:id</attr></title>
       <p>Planned.</p>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -129,10 +129,14 @@
                 </introduction>
 
                 <webwork xml:id="integer-addition">
+                    <description>
+                        Add two positive single-digit integers.
+                    </description>
+
                     <pg-code>
-                        $a = Compute(random(1, 9, 1));
-                        $b = Compute(random(1, 9, 1));
-                        $c = $a + $b;
+                        $a = random(1, 9, 1);
+                        $b = random(1, 9, 1);
+                        $c = Compute($a + $b);
                     </pg-code>
 
                     <statement>
@@ -161,9 +165,9 @@
 
                 <webwork xml:id="integer-addition-with-seed" seed="510">
                     <pg-code>
-                        $a = Compute(random(1, 9, 1));
-                        $b = Compute(random(1, 9, 1));
-                        $c = $a + $b;
+                        $a = random(1, 9, 1);
+                        $b = random(1, 9, 1);
+                        $c = Compute($a + $b);
                     </pg-code>
 
                     <statement>
@@ -186,10 +190,10 @@
 
                 <webwork xml:id="integer-addition-with-control-seed" seed="1">
                     <pg-code>
-                        $a = Compute(random(1, 9, 1));
-                        $b = Compute(random(1, 9, 1));
+                        $a = random(1, 9, 1);
+                        $b = random(1, 9, 1);
                         if ($envir{problemSeed}==1){$a=1;$b=2};
-                        $c = $a + $b;
+                        $c = Compute($a + $b);
                     </pg-code>
 
                     <statement>
@@ -217,8 +221,8 @@
 
                 <webwork>
                     <pg-code>
-                        $a = Compute(random(1, 9, 1));
-                        $b = Compute(random(1, 9, 1));
+                        $a = random(1, 9, 1);
+                        $b = random(1, 9, 1);
                         $c = $a + $b;
                         $expression = Formula("x^($a)*x^($b)");
 
@@ -261,8 +265,8 @@
                 <webwork>
                     <pg-code>
                         do {
-                            $a = Compute(list_random(2,3,5,6));
-                            $b = Compute(random(1, 5, 1));
+                            $a = list_random(2,3,5,6);
+                            $b = random(1, 5, 1);
                            } until (gcd($a,$b) == 1);
                         $c = $a * $b**2;
                         Context()->flags->set(reduceConstantFunctions=>0);
@@ -336,8 +340,11 @@
                 <title>Solving Quadratic Equations</title>
 
                 <webwork xml:id="quadratic-equation">
+                    <description>
+                        <line>Find a quadratic equation's solutions.</line>
+                        <line>One positive integer solution and one negative fraction solution.</line>
+                    </description>
 
-                    <!-- TODO: move out context shift -->
                     <pg-code>
                         Context("Fraction");
 

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -890,6 +890,8 @@
                 Paragraph+,
                 Attribution?
             }
+        SimpleLine =
+            element line {TextSimple}
         ShortLine =
             element line {TextShort}
         LongLine =
@@ -1593,6 +1595,12 @@
         WebWorkAuthored =
             element webwork {
                 attribute seed {xsd:integer}?,
+                element description {
+                    (
+                        TextSimple |
+                        SimpleLine+
+                    )
+                }?,
                 WWMacros?,
                 element pg-code {text}?,
                 (


### PR DESCRIPTION
Allows a `webwork` to have a `description` element. If the `webwork` is PTX-authored, this goes into a `COMMENT()` in the archival (aka verbose) version of the PG file. (OPL problems tend to have a description like this as perl comments at the top of the file, but we feel that is less useful than in a `COMMENT()`. If there is user feedback, we could duplicate the description in the "traditional" way too.)

If the source is a problem file on the server, nothing is done with any `description`. This seems appropriate, since we assume server problems are managed separately. Anyway it would be unusual for a "webwork" with "@source" to not be a self-closing tag and have child elements. 

I did a file diff on the webwork extraction files, and the only changes are the good ones.

Please take a closer look at where I edited the schema for this. In particular I'm unsure if I put "SimpleLine" in a good place.