### PR TITLE
Replace pdfcrop dependency with pip-installable pdf-crop-margins (works in Windows)

### DIFF
--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -40,6 +40,7 @@
 # 2020-05-21  Rename:  script/mbx.cfg => pretext/pretext.cfg
 # 2020-06-12  Added mathjax "mjpage" node.js script
 # 2020-06-12  Added liblouis file2brl executable
+# 2020-07-07  Replaced pdfcrop with pdf-crop-margins
 
 [executables]
 xslt = xsltproc
@@ -49,7 +50,7 @@ asy = asy
 sage = sage
 pdfpng = convert
 pdfeps = pdftops
-pcm = pdf-crop-margins
+pdfcrop = pdf-crop-margins
 pageres = pageres
 # Following is a suggestion, node.js modules don't seem to be on path
 mjpage = /home/user-name-here/node_modules/mathjax-node-page/bin/mjpage

--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -49,7 +49,7 @@ asy = asy
 sage = sage
 pdfpng = convert
 pdfeps = pdftops
-pdfcrop = pdfcrop
+pcm = pdf-crop-margins
 pageres = pageres
 # Following is a suggestion, node.js modules don't seem to be on path
 mjpage = /home/user-name-here/node_modules/mathjax-node-page/bin/mjpage

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -301,7 +301,7 @@ def latex_image_conversion(xml_source, stringparams, xmlid_root, data_dir, dest_
             subprocess.call(latex_cmd, stdout=devnull, stderr=subprocess.STDOUT)
             pcm_executable = get_executable('pdfcrop')
             _debug("pdf-crop-margins executable: {}".format(pcm_executable))
-            pcm_cmd = [pcm_executable, latex_image_pdf, "-o", "cropped-"+latex_image_pdf, "-p", "0"]
+            pcm_cmd = [pcm_executable, latex_image_pdf, "-o", "cropped-"+latex_image_pdf, "-p", "0", "-a", "-1"]
             _verbose("cropping {} to {}".format(latex_image_pdf, latex_image_pdf))
             subprocess.call(pcm_cmd, stdout=devnull, stderr=subprocess.STDOUT)
             shutil.move("cropped-"+latex_image_pdf, latex_image_pdf)

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -301,9 +301,11 @@ def latex_image_conversion(xml_source, stringparams, xmlid_root, data_dir, dest_
             subprocess.call(latex_cmd, stdout=devnull, stderr=subprocess.STDOUT)
             pcm_executable = get_executable('pcm')
             _debug("pdf-crop-margins executable: {}".format(pcm_executable))
-            pcm_cmd = [pcm_executable, latex_image_pdf, "-o "+latex_image_pdf, "-p 0"]
+            pcm_cmd = [pcm_executable, latex_image_pdf, "-o", "cropped-"+latex_image_pdf, "-p", "0"]
+            pcm_cmd_2 = [pcm_executable, "cropped-"+latex_image_pdf, "-o", latex_image_pdf, "-p", "0"] #hax, please improve
             _verbose("cropping {} to {}".format(latex_image_pdf, latex_image_pdf))
             subprocess.call(pcm_cmd, stdout=devnull, stderr=subprocess.STDOUT)
+            subprocess.call(pcm_cmd_2, stdout=devnull, stderr=subprocess.STDOUT) #hax, please improve
             if outformat == 'all':
                 shutil.copy2(latex_image, dest_dir)
             if (outformat == 'pdf' or outformat == 'all'):

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -299,21 +299,11 @@ def latex_image_conversion(xml_source, stringparams, xmlid_root, data_dir, dest_
             latex_cmd = [tex_executable, "-interaction=batchmode", latex_image]
             _verbose("converting {} to {}".format(latex_image, latex_image_pdf))
             subprocess.call(latex_cmd, stdout=devnull, stderr=subprocess.STDOUT)
-            pdfcrop_executable = get_executable('pdfcrop')
-            _debug("pdfcrop executable: {}".format(pdfcrop_executable))
-            if platform.system() == "Windows":
-                _debug("using pdfcrop is not reliable on Windows unless you are using a linux-like shell, e.g. Git Bash or SageMathCloud terminal")
-                # Test for 32-bit v. 64-bit OS
-                # http://stackoverflow.com/questions/2208828/
-                # detect-64-bit-os-windows-in-python
-                if platform.machine().endswith('64'):
-                    pdfcrop_cmd = [pdfcrop_executable, "--gscmd", "gswin64c.exe", latex_image_pdf, latex_image_pdf]
-                else:
-                    pdfcrop_cmd = [pdfcrop_executable, "--gscmd", "gswin32c.exe", latex_image_pdf, latex_image_pdf]
-            else:
-                pdfcrop_cmd = [pdfcrop_executable, latex_image_pdf, latex_image_pdf]
+            pcm_executable = get_executable('pcm')
+            _debug("pdf-crop-margins executable: {}".format(pcm_executable))
+            pcm_cmd = [pcm_executable, latex_image_pdf, "-o "+latex_image_pdf, "-p 0"]
             _verbose("cropping {} to {}".format(latex_image_pdf, latex_image_pdf))
-            subprocess.call(pdfcrop_cmd, stdout=devnull, stderr=subprocess.STDOUT)
+            subprocess.call(pcm_cmd, stdout=devnull, stderr=subprocess.STDOUT)
             if outformat == 'all':
                 shutil.copy2(latex_image, dest_dir)
             if (outformat == 'pdf' or outformat == 'all'):

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1410,7 +1410,7 @@ def get_executable(exec_name):
     if config_name=="pdfcrop":
         error_messages += [
             "PTX:ERROR: Program `pdfcrop` was replaced by `pdf-crop-margins` as of 2020-07-07.",
-            "Install with `pip install pdf-crop-margins` and update your configuration file with `pdfcrop = pdf-crop-margins`."
+            "Install with `pip install pdfCropMargins` and update your configuration file with `pdfcrop = pdf-crop-margins`."
         ]
     if error_messages:
         raise OSError('\n'.join(error_messages))


### PR DESCRIPTION
Closes #1327. End users will need to `pip install pdfCropMargins`, unless they have version `>=0.1rc0` of PreTeXt-CLI (since I'll be adding it as a dependency shortly).