### PR TITLE
WeBWorK: build representations using lxml

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -141,7 +141,7 @@
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
-                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="2" category="integer" /></p>
+                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="5" category="integer" /></p>
                     </statement>
 
                     <solution>
@@ -172,7 +172,7 @@
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
-                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="2" category="integer" /></p>
+                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="5" category="integer" /></p>
                     </statement>
 
                     <solution>
@@ -198,7 +198,7 @@
 
                     <statement>
                         <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
-                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="2" category="integer" /></p>
+                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="5" category="integer" /></p>
                     </statement>
 
                     <solution>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -151,13 +151,24 @@
     </xsl:apply-templates>
     <xsl:text>"""&#xa;</xsl:text>
     <!-- 5. PG optimized (and less human-readable) for use in PTX output modes -->
+    <xsl:text>pgdense["</xsl:text>
+    <xsl:value-of select="$problem" />
+    <xsl:text>"] = """</xsl:text>
+    <xsl:apply-templates select=".">
+        <xsl:with-param name="b-hint" select="true()" />
+        <xsl:with-param name="b-solution" select="true()" />
+        <xsl:with-param name="b-human-readable" select="false()" />
+    </xsl:apply-templates>
+    <xsl:text>"""&#xa;</xsl:text>
+    <!-- Below are only needed for WeBWorK 2.15 and earlier, -->
+    <!-- where we use an iframe for the embedding. Otherwise -->
     <xsl:text>pgdense['hint_no_solution_no']["</xsl:text>
     <xsl:value-of select="$problem" />
     <xsl:text>"] = """</xsl:text>
     <xsl:apply-templates select=".">
         <xsl:with-param name="b-hint" select="false()" />
         <xsl:with-param name="b-solution" select="false()" />
-        <xsl:with-param name="b-verbose" select="false()" />
+        <xsl:with-param name="b-human-readable" select="false()" />
     </xsl:apply-templates>
     <xsl:text>"""&#xa;</xsl:text>
     <xsl:text>pgdense['hint_no_solution_yes']["</xsl:text>
@@ -166,7 +177,7 @@
     <xsl:apply-templates select=".">
         <xsl:with-param name="b-hint" select="false()" />
         <xsl:with-param name="b-solution" select="true()" />
-        <xsl:with-param name="b-verbose" select="false()" />
+        <xsl:with-param name="b-human-readable" select="false()" />
     </xsl:apply-templates>
     <xsl:text>"""&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_no']["</xsl:text>
@@ -175,7 +186,7 @@
     <xsl:apply-templates select=".">
         <xsl:with-param name="b-hint" select="true()" />
         <xsl:with-param name="b-solution" select="false()" />
-        <xsl:with-param name="b-verbose" select="false()" />
+        <xsl:with-param name="b-human-readable" select="false()" />
     </xsl:apply-templates>
     <xsl:text>"""&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_yes']["</xsl:text>
@@ -184,7 +195,7 @@
     <xsl:apply-templates select=".">
         <xsl:with-param name="b-hint" select="true()" />
         <xsl:with-param name="b-solution" select="true()" />
-        <xsl:with-param name="b-verbose" select="false()" />
+        <xsl:with-param name="b-human-readable" select="false()" />
     </xsl:apply-templates>
     <xsl:text>"""&#xa;</xsl:text>
 </xsl:template>


### PR DESCRIPTION
This is mostly as the commit says.

Additionally, there are some conditional checks if the WW version is 2.16 to write an `interactive` element instead of the four `server-url`s. The only "2.16" server is PTX-dev. After this, I'll work on the HTML style sheet so it can actually work with what comes from a 2.16 server.

Also, there will be "stage -> task". To be handled later.

I compared the diff for the representations file before and after. Caught a few things, and on the final run the only diffs were things to expect.