### PR TITLE
WeBWorK: static preview for 2.16+

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -92,7 +92,7 @@ SERVER = https://webwork-ptx.aimath.org
 ################
 
 #  Extract webwork problems into a single XML file called
-#  webwork-extraction.xml which holds multiple versions of each problem.
+#  webwork-representations.xml which holds multiple versions of each problem.
 #  Also locally store images from the WeBWorK server.
 
 sample-chapter-representations:

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -243,7 +243,7 @@
 
                         <instruction>To enter a power, use a <c>^</c>, as in <c>x^2</c> for <m>x^2</m>.</instruction>
 
-                        <p><m><var name="$expression" />=</m><var name="$answer" evaluator="$evaluator" width="8" category="formula" /></p>
+                        <p><m><var name="$expression" />=</m> <var name="$answer" evaluator="$evaluator" width="8" category="formula" /></p>
 
                     </statement>
 
@@ -279,7 +279,7 @@
 
                     <statement>
                         <p>Simplify the expression <m><var name="$expression"/></m>.</p>
-                        <p><m><var name="$expression"/>=</m><var name="$answer" width="10"/></p>
+                        <p><m><var name="$expression"/>=</m> <var name="$answer" width="10"/></p>
                     </statement>
 
                     <hint>
@@ -299,7 +299,7 @@
                 </introduction>
                 <webwork>
                     <statement>
-                        <p><m>1+2=</m><var name="3" width="5" /></p>
+                        <p><m>1+2=</m> <var name="3" width="5" /></p>
                     </statement>
                 </webwork>
                 <conclusion>
@@ -1230,7 +1230,12 @@
                           $expressions = RadioButtons(['\(x\)','\(x^2\)','\(2^x\)'], 2);
                     </pg-code>
                     <statement>
-                        <p>There is math in each option for this question. Which expression is not a polynomial? <var name="$expressions" form="buttons"/></p>
+                        <p>
+                            There is math in each option for this question. Which expression is not a polynomial?
+                        </p>
+                        <p>
+                            <var name="$expressions" form="buttons"/>
+                        </p>
                     </statement>
                     <solution>
                         <p>The answer is <var name="$expressions"/>.</p>


### PR DESCRIPTION
This is not ready to merge, but it is ready for some testing and feedback. I'm going to be offline the next few days, and I wanted to get some eyes on this to see what you think. The only testing I did is making the sample chapter HTML with the webwork-ptx server and it seems OK. I didn't check a diff though. And then making the sample chapter HTML with the webwork-dev server and it seems OK too. 

I haven't considered accessibility, but I will before this PR is closed and merged. There needs to be aria-live somewhere.

The Runestone stuff is on, which I think should not be the case for the final PR here. It makes some console errors when the book is not actually in Runestone. I intend for this PR to just be about the static preview -> live WW mode for HTML output. Not anything having to do with Runestone. When this one is squared away, I'm finally back to Runestone (@bnmnetp).

Also it loads a js file from my school's faculty server. That will need to evolve and go into JS_Core. And there will need to be some better styling. 

A future commit (in a future PR) should ditch the traditional WW results table in favor of something better. Like marks of some sort right where the answer blanks are. But done accessibly. 