### PR TITLE
Wwpatch

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2547,6 +2547,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text> original</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
+            <!-- reliable way to distinguish adjacent hint/answer/solution knowls -->
+            <xsl:choose>
+                <xsl:when test="self::hint">
+                    <xsl:text> hint</xsl:text>
+                </xsl:when>
+                <xsl:when test="self::answer">
+                    <xsl:text> answer</xsl:text>
+                </xsl:when>
+                <xsl:when test="self::solution">
+                    <xsl:text> solution</xsl:text>
+                </xsl:when>
+            </xsl:choose>
         </xsl:attribute>
         <!-- and the id via a template for consistency -->
         <xsl:attribute name="data-refid">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -69,11 +69,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="runestone.dev" select="''"/>
 <xsl:variable name="runestone-dev" select="$runestone.dev = 'yes'"/>
 
-<!-- Temporary, undocumented, and experimental           -->
-<!-- Makes randomization buttons for inline WW probmlems -->
-<xsl:param name="debug.webwork.inline.randomize" select="''"/>
-<xsl:variable name="b-webwork-inline-randomize" select="$debug.webwork.inline.randomize = 'yes'"/>
-
 <!-- ################################################ -->
 <!-- Following is slated to migrate above, 2019-07-10 -->
 <!-- ################################################ -->
@@ -82,28 +77,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Parameters to pass via xsltproc "stringparam" on command-line            -->
 <!-- Or make a thin customization layer and use 'select' to provide overrides -->
 <!-- See more generally applicable parameters in pretext-common.xsl file     -->
-
-<!-- WeBWorK exercise may be rendered static="yes"    -->
-<!-- Or static="no" makes an interactive problem      -->
-<!-- Also in play here are params from -common:       -->
-<!-- exercise.text.statement, exercise.text.hint, exercise.text.solution -->
-<!-- For a divisional exercise, when static="no", that is an intentional -->
-<!-- decision to show the live problem, which means the statement will   -->
-<!-- be shown, regardless of exercise.text.statement. If the problem was -->
-<!-- authored in PTX source, we can respect the values for               -->
-<!-- exercise.text.hint and exercise.text.solution. If the problem       -->
-<!-- source is on the webwork server, then hints and solutions will show -->
-<!-- no matter what.                                                     -->
-<!-- For a divisional exercise, when static="yes", each of the three     -->
-<!-- -common params will be respected. Effectively the content is        -->
-<!-- handled like a non-webwork exercise.                                -->
-<!-- For an inline exercise (webwork or otherwise) statements, hints,    -->
-<!-- and solutions are always shown. The -common params mentioned above  -->
-<!-- do not apply. Whether static is "yes" or "no" doesn't matter.       -->
-<xsl:param name="webwork.inline.static" select="'no'" />
-<xsl:param name="webwork.divisional.static" select="'yes'" />
-<xsl:param name="webwork.reading.static" select="'yes'" />
-<xsl:param name="webwork.worksheet.static" select="'yes'" />
 
 <!-- Content as Knowls -->
 <!-- These parameters control if content is      -->
@@ -214,23 +187,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$root/memo">0</xsl:when>
         <xsl:otherwise>
             <xsl:message>MBX:ERROR: HTML chunk level not determined</xsl:message>
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:variable>
-
-<xsl:variable name="webwork-reps-version" select="$document-root//webwork-reps[1]/@version"/>
-
-<xsl:variable name="webwork-domain">
-    <xsl:choose>
-        <xsl:when test="$webwork-reps-version = 1">
-            <xsl:value-of select="$document-root//webwork-reps[1]/server-url[1]/@domain" />
-        </xsl:when>
-        <xsl:when test="$webwork-reps-version = 2">
-            <xsl:value-of select="$document-root//webwork-reps[1]/server-data/@domain" />
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: the WeBWorK server domain could not be determined. Using webwork-ptx.aimath.org, where content may differ.</xsl:message>
-            <xsl:text>https://webwork-ptx.aimath.org</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -364,6 +320,47 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Here we assume there is at most one                      -->
 <!-- (The old style of specifying an index is deprecated)     -->
 <xsl:variable name="the-index"          select="($document-root//index-part|$document-root//index[index-list])[1]"/>
+
+<!-- ######## -->
+<!-- WeBWorK  -->
+<!-- ######## -->
+
+<!-- WeBWorK exercise may be rendered static="yes" or static="no" makes  -->
+<!-- an interactive problem. Also in play here are params from -common:  -->
+<!-- exercise.text.statement, exercise.text.hint, exercise.text.solution -->
+<!-- For a divisional exercise, when static="no", that is an intentional -->
+<!-- decision to show the live problem, which means the statement will   -->
+<!-- be shown, regardless of exercise.text.statement. For webwork-reps   -->
+<!-- version 2 (WW 2.16 and later), we respect the values for            -->
+<!-- exercise.text.hint, exercise.text.answer, exercise.text.solution.   -->
+<!-- For version 1, if the problem was authored in PTX source, we can    -->
+<!-- respect the values for exercise.text.hint, exercise.text.solution.  -->
+<!-- When the problem is static, we can respect exercise.text.answer.    -->
+<!-- When the problem is live, we cannot stop the user from seeing the   -->
+<!-- answers. And if the problem source is on the webwork server, then   -->
+<!-- hints and solutions will show  no matter what.                      -->
+<xsl:param name="webwork.inline.static" select="'no'" />
+<xsl:param name="webwork.divisional.static" select="'yes'" />
+<xsl:param name="webwork.reading.static" select="'yes'" />
+<xsl:param name="webwork.worksheet.static" select="'yes'" />
+
+<xsl:variable name="webwork-reps-version" select="$document-root//webwork-reps[1]/@version"/>
+
+<xsl:variable name="webwork-domain">
+    <xsl:choose>
+        <xsl:when test="$webwork-reps-version = 1">
+            <xsl:value-of select="$document-root//webwork-reps[1]/server-url[1]/@domain" />
+        </xsl:when>
+        <xsl:when test="$webwork-reps-version = 2">
+            <xsl:value-of select="$document-root//webwork-reps[1]/server-data/@domain" />
+        </xsl:when>
+    </xsl:choose>
+</xsl:variable>
+
+<!-- Temporary, undocumented, and experimental           -->
+<!-- Makes randomization buttons for inline WW probmlems -->
+<xsl:param name="debug.webwork.inline.randomize" select="''"/>
+<xsl:variable name="b-webwork-inline-randomize" select="$debug.webwork.inline.randomize = 'yes'"/>
 
 
 <!-- ############## -->
@@ -9092,9 +9089,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="webwork">
     <xsl:if test="$b-has-webwork-reps">
         <link href="{$webwork-domain}/webwork2_files/js/apps/MathView/mathview.css" rel="stylesheet" />
-        <xsl:if test="$document-root//webwork-reps/server-url">
-            <script src="{$webwork-domain}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
-        </xsl:if>
+        <xsl:choose>
+            <xsl:when test="$webwork-reps-version = 1">
+                <script src="{$webwork-domain}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
+            </xsl:when>
+            <xsl:when test="$webwork-reps-version = 2">
+                <script src="{$html.js.server}/js/{$html.js.version}/pretext-webwork.js"></script>
+            </xsl:when>
+        </xsl:choose>
     </xsl:if>
 </xsl:template>
 
@@ -10710,9 +10712,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js"></script>
-    <xsl:if test="$webwork-reps-version = 2">
-        <script src="{$html.js.server}/js/{$html.js.version}/pretext-webwork.js"></script>
-    </xsl:if>
 </xsl:template>
 
 <!-- Font header -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6291,7 +6291,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- $b-has-webwork-reps, then on                              -->
         <!-- $document-root//webwork-reps/static//var[@form='buttons'] -->
         <xsl:when test="@form='buttons'" >
-            <xsl:text>\par&#xa;</xsl:text>
             <xsl:text>\begin{itemize}[label=$\odot$,leftmargin=3em,]&#xa;</xsl:text>
             <xsl:for-each select="li">
                 <xsl:text>\item{}</xsl:text>
@@ -6301,7 +6300,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>\end{itemize}&#xa;</xsl:text>
         </xsl:when>
         <xsl:when test="@form='checkboxes'" >
-            <xsl:text>\par&#xa;</xsl:text>
             <xsl:text>\begin{itemize*}[label=$\square$,leftmargin=3em,itemjoin=\hspace{4em plus 1em minus 3em}]&#xa;</xsl:text>
             <xsl:for-each select="li">
                 <xsl:if test="not(p[.='?']) and not(normalize-space(.)='?')">


### PR DESCRIPTION
Two commits here.

- I think it is safer to treat radio button and checkbox answers as if they do not by themselves start a new paragraph. Most authors will _want_ them to start a new paragraph, and they can easily use a `p` for that. But this way more closely mimics what WW itself does with these kinds of answers, where it's possible to have the first item start within the preceding paragraph if you really want that.

- I addressed the `webwork-domain` issue, but not using `b-has-webwork-reps`. I don't think the warning about finding a value for `$webwork-domain` is necessary. If there is a problem with that, the `pretext` script should have hit it. At the same time as making this change, I consolidated all WW top-level stuff (global params, variables) to one place. And cleaned up a thing or two with the templates that load webwork js.