### PR TITLE
Integrates New MathJax 3 script

### DIFF
--- a/pretext/package.json
+++ b/pretext/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "mathjax-full": "^3.0.5",
+    "speech-rule-engine": "^3.1.0-beta.4",
+    "yargs": "^15.4.1"
+  }
+}

--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -53,5 +53,5 @@ pdfeps = pdftops
 pdfcrop = pdf-crop-margins
 pageres = pageres
 # Following is a suggestion, node.js modules don't seem to be on path
-mjpage = /home/user-name-here/node_modules/mathjax-node-page/bin/mjpage
+mjpage = pretext/pretext.js
 liblouis = file2brl

--- a/pretext/pretext.js
+++ b/pretext/pretext.js
@@ -1,0 +1,241 @@
+#! /usr/bin/env node
+
+/*************************************************************************
+ *
+ *  pretext
+ *
+ *  Uses MathJax v3 to convert all TeX in an HTML document to forms
+ *  needed by PreTeXt
+ *
+ * ----------------------------------------------------------------------
+ *
+ *  Copyright (c) 2020 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//
+//  Load the packages needed for MathJax
+//
+require('mathjax-full/js/util/asyncLoad/node.js');
+const {mathjax} = require('mathjax-full/js/mathjax.js');
+const {TeX} = require('mathjax-full/js/input/tex.js');
+const {SVG} = require('mathjax-full/js/output/svg.js');
+const {RegisterHTMLHandler} = require('mathjax-full/js/handlers/html.js');
+const {liteAdaptor} = require('mathjax-full/js/adaptors/liteAdaptor.js');
+const {STATE, newState} = require('mathjax-full/js/core/MathItem.js');
+
+const {AllPackages} = require('mathjax-full/js/input/tex/AllPackages.js');
+
+//
+//  Get the command-line arguments
+//
+var argv = require('yargs')
+    .demand(0).strict()
+    .usage('$0 [options] infile.html > outfile.html')
+    .options({
+      speech: {
+        boolean: true,
+        default: false,
+        describe: 'produce speech output'
+      },
+      braille: {
+        boolean: true,
+        default: false,
+        describe: 'produce braille output'
+      },
+      svg: {
+        boolean: true,
+        default: false,
+        describe: 'produce svg output'
+      },
+      mathml: {
+        boolean: true,
+        default: false,
+        describe: 'produce MathML output'
+      },
+      fontPaths: {
+        boolean: true,
+        default: false,
+        describe: 'use svg paths not cached paths'
+      },
+      em: {
+        default: 16,
+        describe: 'em-size in pixels'
+      },
+      locale: {
+        default: 'en',
+        describe: 'the locale to use for speech output'
+      },
+      packages: {
+        default: AllPackages.sort().join(', '),
+        describe: 'the packages to use, e.g. "base, ams"'
+      },
+      rules: {
+        default: 'mathspeak',
+        describe: 'the rule set to use for speech output'
+      }
+    })
+    .argv;
+
+const needsSRE = argv.speech || argv.braille;
+
+//
+//  Load SRE if needed for speech or braille
+//
+const {sreReady} = (needsSRE ? require('mathjax-full/js/a11y/sre.js') : {sreReady: Promise.resolve()});
+
+//
+//  Read the HTML file
+//
+const htmlfile = require('fs').readFileSync(argv._[0], 'utf8');
+
+//
+//  Create DOM adaptor and register it for HTML documents
+//
+const adaptor = liteAdaptor({fontSize: argv.em});
+const handler = RegisterHTMLHandler(adaptor);
+
+//
+//  Create a MathML serializer
+//
+const {SerializedMmlVisitor} = require('mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js');
+const visitor = new SerializedMmlVisitor();
+const toMathML = (node => visitor.visitTree(node, html));
+
+
+//
+//  Create a renderAction that calls a function for each math item
+//
+function action(state, code, setup = null) {
+  return [state, (doc) => {
+    const adaptor = doc.adaptor;
+    setup && setup();
+    for (const math of doc.math) {
+      code(math, doc, adaptor);
+    }
+  }];
+}
+
+//
+//  States for PreTeXt actions
+//
+newState('PRETEXT', STATE.COMPILED + 10);
+newState('PRETEXTACTION', STATE.PRETEXT + 10);
+
+//
+//  The renderActions to use
+//
+const renderActions = {
+  //
+  //  An aciton to set up the pretext data array
+  //  and enrich the MathML, if needed
+  //
+  pretext: action(STATE.PRETEXT, (math, doc, adaptor) => {
+    math.outputData.pretext = [adaptor.text('\n')];
+    if (needsSRE) {
+      math.outputData.mml = SRE.toEnriched(toMathML(math.root)).toString();
+    }
+  }),
+  //
+  //  Override the typeset action to make the mjx-data element
+  //
+  typeset: action(STATE.TYPESET, (math, doc, adaptor) => {
+    math.typesetRoot = adaptor.node('mjx-data', {}, math.outputData.pretext);
+  })
+};
+
+//
+//  If SVG is requested, add an action to add it to the output
+//
+if (argv.svg) {
+  renderActions.svg = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
+    math.outputData.pretext.push(adaptor.firstChild(doc.outputJax.typeset(math, doc)));
+    math.outputData.pretext.push(adaptor.text('\n'));
+  });
+}
+
+//
+//  If MathML is requested, add an action to add it to the output
+//
+if (argv.mathml) {
+  renderActions.mathml = action(STATE.PRETEXTACTION, (math, doc, adpator) => {
+    const mml = adaptor.firstChild(adaptor.body(adaptor.parse(toMathML(math.root), 'text/html')));
+    math.outputData.pretext.push(mml);
+    math.outputData.pretext.push(adaptor.text('\n'));
+  });
+}
+
+//
+//  If speech is requested, add an action to add it to the output
+//  and set up the speech engine for speech in the correct locale
+//
+if (argv.speech) {
+  renderActions.speech = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
+    const speech = SRE.toSpeech(math.outputData.mml);
+    math.outputData.pretext.push(adaptor.node('mjx-speech', {}, [adaptor.text(speech)]));
+    math.outputData.pretext.push(adaptor.text('\n'));
+  }, () => {
+    SRE.setupEngine({modality: 'speech', locale: argv.locale, domain: argv.rules});
+  });
+}
+
+//
+//  If braille is requested, add an action to add it to the output
+//  and set up the speech engine for nemeth braille
+//
+if (argv.braille) {
+  renderActions.braille = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
+    const speech = SRE.toSpeech(math.outputData.mml);
+    math.outputData.pretext.push(adaptor.node('mjx-braille', {}, [adaptor.text(speech)]));
+    math.outputData.pretext.push(adaptor.text('\n'));
+  }, () => {
+    SRE.setupEngine({modality: 'braille', locale: 'nemeth', domain: 'default'});
+  });
+}
+
+//
+//  Create an HTML document using the html file and a new TeX input jax
+//
+const html = mathjax.document(htmlfile, {
+  renderActions,
+  InputJax: new TeX({packages: argv.packages.split(/\s*,\s*/)}),
+  OutputJax: new SVG({fontCache: (argv.fontPaths ? 'none' : 'local')})
+});
+
+//
+//  Don't add the stylesheet unless SVG output is requested
+//
+if (!argv.svg) {
+  html.addStyleSheet = () => {};
+}
+
+(async function () {
+  //
+  //  Wait for SRE, if needed
+  //
+  if (needsSRE) {
+    SRE.setupEngine({xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js')});
+    await sreReady();
+  }
+  //
+  //  Render the document
+  //
+  await mathjax.handleRetriesFor(() => html.render());
+  //
+  //  Output the resulting document
+  //
+  console.log('<!DOCTYPE html>');
+  console.log(adaptor.outerHTML(adaptor.root(html.document)));
+})()
+  .catch((err) => console.error(err));

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -109,11 +109,6 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
         print(xhtml_elt.sub(repl, line), end='')
     os.chdir(owd)
 
-    # if math_format in ['nemeth', 'speech']:
-    #     mjsre_exec = os.path.join(get_ptx_path(), 'script', 'braille', 'mjpage-sre.js')
-    #     mjsre_cmd=[mjsre_exec, math_format, mjintermediate, mjoutput]
-    #     subprocess.run(mjsre_cmd)
-
     # clean up and package MJ representations, font data, etc
     derivedname = get_output_filename(xml_source, out_file, dest_dir, '-' + math_format + '.xml')
     _debug('packaging math as {} from {} into XML file {}'.format(math_format, mjoutput, out_file))

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -71,23 +71,22 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
 
     # process with  mjpage  executable from  mathjax-node-page  package
     mjpage_exec = get_executable('mjpage')
-    if math_format == 'svg':
-        # kill caching to keep glyphs within SVG
-        # versus having a font cache at the end
-        mjpage_cmd = [mjpage_exec, '--output', 'SVG', '--noGlobalSVG', 'true']
-    elif math_format in ['mml', 'kindle', 'nemeth', 'speech']:
-        # MathML is precursor for SRE outputs
-        mjpage_cmd = [mjpage_exec, '--output', 'MML']
-    else:
+    output = {
+        'svg': 'svg',
+        'kindle': 'mathml',
+        'nemeth': 'braille',
+        'speech': 'speech',
+        'mml': 'mathml'
+    }
+    try:
+        mj_var = output[math_format]
+    except KeyError:
         raise ValueError('PTX:ERROR: incorrect format ("{}") for MathJax conversion'.format(math_format))
-
-    infile = open(mjinput)
-    if math_format in ['nemeth', 'speech']:
-        # braille is a two-pass pipeline
-        outfile = open(mjintermediate, 'w')
-    else:
-        outfile = open(mjoutput, 'w')
-    subprocess.run(mjpage_cmd, stdin=infile, stdout=outfile)
+    mj_option = '--' + mj_var
+    mj_tag = 'mj-' + mj_var
+    mjpage_cmd = [mjpage_exec, mj_option, mjinput]
+    outfile = open(mjoutput, 'w')
+    subprocess.run(mjpage_cmd, stdout=outfile)
 
     # the 'mjpage' executable converts spaces inside of a LaTeX
     # \text{} into &nbsp; entities, which is a good idea, and
@@ -105,18 +104,15 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
     # to kill the "extra" newline that print() creates
     owd = os.getcwd()
     os.chdir(tmp_dir)
-    if  math_format in ['nemeth', 'speech']:
-        html_file = mjintermediate
-    else:
-        html_file = mjoutput
+    html_file = mjoutput
     for line in fileinput.input(html_file, inplace=1):
         print(xhtml_elt.sub(repl, line), end='')
     os.chdir(owd)
 
-    if math_format in ['nemeth', 'speech']:
-        mjsre_exec = os.path.join(get_ptx_path(), 'script', 'braille', 'mjpage-sre.js')
-        mjsre_cmd=[mjsre_exec, math_format, mjintermediate, mjoutput]
-        subprocess.run(mjsre_cmd)
+    # if math_format in ['nemeth', 'speech']:
+    #     mjsre_exec = os.path.join(get_ptx_path(), 'script', 'braille', 'mjpage-sre.js')
+    #     mjsre_cmd=[mjsre_exec, math_format, mjintermediate, mjoutput]
+    #     subprocess.run(mjsre_cmd)
 
     # clean up and package MJ representations, font data, etc
     derivedname = get_output_filename(xml_source, out_file, dest_dir, '-' + math_format + '.xml')

--- a/pretext/update-sre
+++ b/pretext/update-sre
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+rm -rf node_modules
+npm install
+rm -rf node_modules/mathjax-full/node_modules


### PR DESCRIPTION
* Adds the new script under `pretext/pretext.js`
* Updates the `pretext.cfg` accordingly
* Adds `package.json` and `update-sre` script for `npm` handling
* Integrates the new script into the `pretext.py` script. 

### How to run 
* Install with
```bash
./update-sre
```
in `pretext` folder.
* Then run as usual.

### Tests and Problems

I believe that I get the correct output for the braille test: 
```
./pretext/pretext -vv -c all -f braille examples/braille/braille-test-book.xml
```
However, I got errors when attempting conversion with `epub-kindle`, `epub-speech`, although the `mj-output-kind.html` and `mj-output-speech.html` files looked correct. I assume there is some post-processing that needs to be adapted.

### Future Considerations

* The MathJax output is now in a `mj-data` tag that could be used for processing.
* `mj_tag` variable contains the actual inner tag for the requested output format in the form of `mj-braille`, `mj-speech` etc.
* Not sure whether the currently handling of `&nbsp;` is still correct or necessary.