### PR TITLE
LaTeX: corral leavevmode and apply to paragraphs/sidebyside

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8165,7 +8165,7 @@ the xsltproc executable.
             <subsection>
                 <title>Testing a Side-By-Side First</title>
 
-                <p>A <tag>sidebyside</tag> that appears first within some other container can wreak havoc in <latex /> output.  Below we have this situation twice, once in an <tag>activity</tag>, then in an <tag>example</tag>.</p>
+                <p>A <tag>sidebyside</tag> that appears first within some other container can wreak havoc in <latex /> output.  Below we have this situation twice, once in an <tag>activity</tag>, then in an <tag>example</tag>, then in a <tag>paragraphs</tag>.</p>
 
                 <activity>
                     <statement>
@@ -8202,6 +8202,22 @@ the xsltproc executable.
                         </sbsgroup>
                     </statement>
                 </example>
+
+                <paragraphs>
+                    <title>First Child of a Paragraphs</title>
+                    <sidebyside>
+                        <tabular>
+                            <row>
+                                <cell>A</cell>
+                                <cell>B</cell>
+                            </row>
+                            <row>
+                                <cell>C</cell>
+                                <cell>D</cell>
+                            </row>
+                        </tabular>
+                    </sidebyside>
+                </paragraphs>
 
             </subsection>
 

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6203,9 +6203,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-answer" />
     <xsl:param name="b-has-solution" />
 
-    <xsl:if test="not(preceding-sibling::stage)">
-        <text>\leavevmode\par\noindent%&#xa;</text>
-    </xsl:if>
+    <xsl:apply-templates select="." mode="leave-vertical-mode"/>
     <!-- e.g., Part 2. -->
     <xsl:text>\textbf{</xsl:text>
     <xsl:call-template name="type-name">
@@ -6247,9 +6245,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
 
     <xsl:if test="not($dry-run = '')">
-        <xsl:if test="not(preceding-sibling::stage)">
-            <text>\leavevmode\par\noindent%&#xa;</text>
-        </xsl:if>
+        <xsl:apply-templates select="." mode="leave-vertical-mode"/>
         <!-- e.g., Part 2. -->
         <xsl:text>\textbf{</xsl:text>
         <xsl:call-template name="type-name">
@@ -8577,9 +8573,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- thing after a heading.  This could be excessive   -->
     <!-- if the cell is empty, but should not be harmful.  -->
     <!-- NB: maybe this should not even be called if all empty -->
-    <xsl:if test="not(preceding-sibling::*[not(&SUBDIVISION-METADATA-FILTER;)])">
-        <xsl:call-template name="leave-vertical-mode" />
-    </xsl:if>
+    <xsl:apply-templates select="." mode="leave-vertical-mode"/>
     <xsl:if test="$in!=''">
         <xsl:text>\begin{sageinput}&#xa;</xsl:text>
         <xsl:value-of select="$in" />
@@ -8764,8 +8758,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Potential alternate solution: write a leading "empty" \mbox{}    -->
 <!-- http://tex.stackexchange.com/questions/171220/                   -->
 <!-- include-non-floating-graphic-in-a-theorem-environment            -->
-<xsl:template name="leave-vertical-mode">
-    <xsl:text>\leavevmode%&#xa;</xsl:text>
+<xsl:template match="sage" mode="leave-vertical-mode">
+    <xsl:if test="not(preceding-sibling::*[not(&SUBDIVISION-METADATA-FILTER;)])">
+        <xsl:text>\leavevmode%&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="stage" mode="leave-vertical-mode">
+    <xsl:if test="not(preceding-sibling::stage)">
+        <xsl:text>\leavevmode\par\noindent%&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="figure|table|list|listing" mode="environment-name">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -8764,6 +8764,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
+<xsl:template match="sidebyside" mode="leave-vertical-mode">
+    <xsl:if test="not(preceding-sibling::*[not(&SUBDIVISION-METADATA-FILTER;)]) and parent::paragraphs">
+        <xsl:text>\leavevmode\par\noindent%&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
 <xsl:template match="stage" mode="leave-vertical-mode">
     <xsl:if test="not(preceding-sibling::stage)">
         <xsl:text>\leavevmode\par\noindent%&#xa;</xsl:text>
@@ -8912,6 +8918,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- headings, panels, captions.  Then put "\nopagebreak"       -->
     <!-- into the definition, so it is "hidden" and not in the body -->
 
+    <xsl:apply-templates select="." mode="leave-vertical-mode"/>
     <xsl:text>\begin{sidebyside}{</xsl:text>
     <xsl:value-of select="$number-panels" />
     <xsl:text>}{</xsl:text>


### PR DESCRIPTION
This addresses an issue reported in the [forums](https://groups.google.com/d/msg/pretext-support/oxbk1KJ1PxQ/ZY62v2mxCAAJ) where a `sidebyside` that is the first child of a `paragraphs` causes an issue with the title of the paragraphs.

I also took the liberty of moving most instances of `\leavevmode` to the same area. 

The approach I took was to tie the `\leavevmode` to the thing it precedes, not to the parent of that thing, an alternative which was considered. 

Aside from expected diffs (timestamps and different generated id~s) I don't see any diff on the sample article or sample chapter.