### PR TITLE
Pythonwarning

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -343,6 +343,7 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
     # "run" an assignment for the list of triples of strings
     ww_file = open(ww_filename, 'r')
     problem_dictionaries = ww_file.read()
+    ww_file.close()
     # "run" the dictionaries
     # protect backslashes in LaTeX code
     # globals() necessary for success
@@ -917,6 +918,9 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
         root_cause = str(e)
         msg = "PTX:ERROR: there was a problem writing a problem to the file: {}\n"
         raise ValueError(msg.format(include_file_name) + root_cause)
+
+    #close session to avoid resource wanrnings
+    session.close()
 
 
 ##############################

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -952,7 +952,6 @@ def youtube_thumbnail(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
     thumb_list = id_file.readline()
     thumbs = eval(thumb_list)
 
-    session = requests.Session()
     for thumb in thumbs:
         url = 'http://i.ytimg.com/vi/{}/default.jpg'.format(thumb[0])
         path = os.path.join(dest_dir, thumb[1] + '.jpg')
@@ -1076,7 +1075,6 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
     problem_list = id_file.readline()
     problems = eval(problem_list)
     xml_header = '<?xml version="1.0" encoding="UTF-8" ?>\n'
-    session = requests.Session()
     for problem in problems:
         url = 'https://www.myopenmath.com/util/mbx.php?id={}'.format(problem)
         path = os.path.join(dest_dir, 'mom-{}.xml'.format(problem))


### PR DESCRIPTION
First commit addresses something @mitchkeller noticed. WW representations build was not closing a file nor the requests session, and that leads to resource usage warnings if python is set to show all such warnings.

Test by changing Makefile from `$(MB)/pretext/pretext -v -c webwork -d $(WWOUT) -s $(SERVER) $(SMPCHP)` to `PYTHONWARNINGS=module $(MB)/pretext/pretext -v -c webwork -d $(WWOUT) -s $(SERVER) $(SMPCHP)`, same for sample chapter. You will see the warnings at the end of reps building, but not after this commit. Output reps file has no meaningful diff.

Second commit is just that I happened to notice sessions being initiated in other subroutines that appear to never be used.