### PR TITLE
publisher file works on windows

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -198,12 +198,20 @@ def main():
     # publisher file is optional, so allow for None here
     if args.publisher_file:
         publisher_file = verify_input_file(args.publisher_file)
+        #ensure forward slash to pass to xsltproc:
+        publisher_file = publisher_file.replace(os.sep, '/')
     else:
         publisher_file = None
 
     # convert list of string parameters into a dictionary
     # routines in module expect a dictionary, so convert here and now
     stringparams = string_parameters_as_dict(args.stringparams)
+    # if 'publisher' is passed as stringparam, pull it out as 'publisher_file' and ensure correct slashes
+    if 'publisher' in stringparams:
+        publisher_file = verify_input_file(stringparams['publisher'])
+        publisher_file = publisher_file.replace(os.sep, '/')
+        del stringparams['publisher']
+
 
     ptx._verbose('Done examining environment and initializing setup info')
 


### PR DESCRIPTION
The absolute path to the publisher file must use forward slashes.  On windows, os.path.abspath() produces the correct path with backslashes.  This fix ensures the separator for the path to the publisher file is a forward slash.

Since a user can specify the publisher file as a string param (using -x), this is checked for and fixed as well.