### PR TITLE
Removes MathML enrichment.

### DIFF
--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -153,7 +153,7 @@ const renderActions = {
   pretext: action(STATE.PRETEXT, (math, doc, adaptor) => {
     math.outputData.pretext = [adaptor.text('\n')];
     if (needsSRE) {
-      math.outputData.mml = SRE.toEnriched(toMathML(math.root)).toString();
+      math.outputData.mml = toMathML(math.root).toString();
     }
   }),
   //


### PR DESCRIPTION
This fixes [SRE issue 394[(https://github.com/zorkow/speech-rule-engine/issues/394).

The reason that the separator showed up was that an already enriched expression was sent to SRE. I.e., SRE processed the expression twice, which led to the added invisible separator being treated as an explicit one.

@dpvc was there a reason to call the enrichment? After removing it, I can't see a change of behaviour on `--svg` or `--mathml` output, so I don't think we need that there.