### PR TITLE
Separate 'narrow' from 'description-list'

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5275,7 +5275,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="class">
             <xsl:choose>
                 <xsl:when test="@width = 'narrow'">
-                    <xsl:text>description-list-narrow</xsl:text>
+                    <xsl:text>description-list narrow</xsl:text>
                 </xsl:when>
                 <!-- 'medium', 'wide', and any typo (let DTD check) -->
                 <xsl:otherwise>


### PR DESCRIPTION
For a narrow description list, it is better to have
   class="description-list narrow"
than
   class="description-list-narrow"
to avoid having to repeat selectors for behavior which is common to the two cases.

The CSS has been updated and I checked that this change has no effect on the
appearance of  lists.html#subsection-43  in the sample article.