### PR TITLE
WeBWorK: suppress 'Make Interactive' button when there are no answer …

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9307,7 +9307,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                           (ancestor::worksheet and ($webwork.worksheet.static = 'yes')) or
                                           (not(ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and ($webwork.inline.static = 'yes'))"/>
     <xsl:choose>
-        <xsl:when test="$b-static = 'yes'">
+        <!-- We print the static version when that is explicitly directed -->
+        <!-- but also when the static has no "answer" element. This means -->
+        <!-- the problem had no answer input fields, so why make it       -->
+        <!-- interactive? This includes problems with only essay fields.  -->
+        <!-- NB: for Runestone, we may want to allow essay answer fields  -->
+        <!-- to make live problems, and Runestone records submissions.    -->
+        <xsl:when test="$b-static = 'yes' or not(static/answer or static/stage/answer)">
             <xsl:apply-templates select="static" mode="exercise-components">
                 <xsl:with-param name="b-original"      select="$b-original"/>
                 <xsl:with-param name="b-has-statement" select="true()"/>


### PR DESCRIPTION
…input fields

Some PG files either never ask a question, or they only ask for an essay response. At present, making these interactive is at best silly, at worst disappointing to the reader. This commit causes any such problem to be rendered in only its static form in HTML.

For example, problems 2 and 3 here:
https://pretextbook.org/examples/webwork/sample-chapter/html/section-4.html
will now just come out static.