### PR TITLE
WeBWorK: tunnel human readability param through groupings

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1694,6 +1694,51 @@
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
+<!-- ######### -->
+<!-- Groupings -->
+<!-- ######### -->
+
+<!-- We cannot rely on the -common templates for these,   -->
+<!-- because if they contain math, we need to respect the -->
+<!-- human readable parameter.                            -->
+
+<xsl:template match="q">
+    <xsl:param name="b-human-readable" />
+    <xsl:call-template name="lq-character"/>
+    <xsl:apply-templates>
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:call-template name="rq-character"/>
+</xsl:template>
+
+<xsl:template match="sq">
+    <xsl:param name="b-human-readable" />
+    <xsl:call-template name="lsq-character"/>
+    <xsl:apply-templates>
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:call-template name="rsq-character"/>
+</xsl:template>
+
+<xsl:template match="dblbrackets">
+    <xsl:param name="b-human-readable" />
+    <xsl:call-template name="ldblbracket-character"/>
+    <xsl:apply-templates>
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:call-template name="rdblbracket-character"/>
+</xsl:template>
+
+<xsl:template match="angles">
+    <xsl:param name="b-human-readable" />
+    <xsl:call-template name="langle-character"/>
+    <xsl:apply-templates>
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:call-template name="rangle-character"/>
+</xsl:template>
+
+
 <!-- ########################## -->
 <!-- Numbers, units, quantities -->
 <!-- ########################## -->


### PR DESCRIPTION
APEX had a `...<q><m>\dx</m></q>` where `\dx` is one of Greg's macros (`\Delta x`). What _should_ have been happening is that the `m` receives a `b-human-readable` parameter, and if that is true, it puts the macro definition right there in the PG:

```
..."[`\newcommand{\dx}{\Delta x}\dx`]"
```

But the `q` template from -common was catching this, which does not receive `b-human-readable`, let alone pass it along to the `m`.

So this PR adds a template for `q` (and a few other things) to the extract-pg stylesheet.