### PR TITLE
WeBWorK: warn if content is missing

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1745,6 +1745,19 @@
                     </statement>
                 </webwork>
             </exercise>
+
+            <exercise>
+                <introduction>
+                    <p>
+                        This exercise has no content in its statement.
+                        It should throw a PTX warning during the representations build.
+                    </p>
+                </introduction>
+                <webwork>
+                    <statement>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -693,7 +693,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                     pass
             # blocks like this next one micromanage newlines and indentation when we print to file
             last = statement.xpath('./*[last()]')
-            last[0].tail = "\n      "
+            if last:
+                last[0].tail = "\n      "
+            else:
+                print('PTX:WARNING: a statement in {} has no content'.format(problem_identifier))
             statement.tail = "\n      "
 
             hints = response_root.findall('.//hint')
@@ -710,7 +713,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                         pass
 
                 last = htcopy.xpath('./*[last()]')
-                last[0].tail = "\n      "
+                if last:
+                    last[0].tail = "\n      "
+                else:
+                    print('PTX:WARNING: a hint in {} has no content'.format(problem_identifier))
                 htcopy.text = "\n        "
                 htcopy.tail = "\n      "
 
@@ -747,7 +753,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                         pass
 
                 last = solcopy.xpath('./*[last()]')
-                last[0].tail = "\n      "
+                if last:
+                    last[0].tail = "\n      "
+                else:
+                    print('PTX:WARNING: a solution in {} has no content'.format(problem_identifier))
                 solcopy.text = "\n        "
                 solcopy.tail = "\n      "
 
@@ -776,7 +785,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                         pass
 
                 last = statement.xpath('./*[last()]')
-                last[0].tail = "\n        "
+                if last:
+                    last[0].tail = "\n        "
+                else:
+                    print('PTX:WARNING: a statement in {} has no content'.format(problem_identifier))
                 statement.tail = "\n        "
 
                 hints = stg.findall('.//hint')
@@ -793,7 +805,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                             pass
 
                     last = htcopy.xpath('./*[last()]')
-                    last[0].tail = "\n        "
+                    if last:
+                        last[0].tail = "\n        "
+                    else:
+                        print('PTX:WARNING: a hint in {} has no content'.format(problem_identifier))
                     htcopy.text = "\n          "
                     htcopy.tail = "\n        "
 
@@ -833,7 +848,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                             pass
 
                     last = solcopy.xpath('./*[last()]')
-                    last[0].tail = "\n        "
+                    if last:
+                        last[0].tail = "\n        "
+                    else:
+                        print('PTX:WARNING: a solution in {} has no content'.format(problem_identifier))
                     solcopy.text = "\n          "
                     solcopy.tail = "\n        "
 
@@ -844,7 +862,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                 stage.tail = "\n      "
 
         last = static.xpath('./*[last()]')
-        last[0].tail = "\n    "
+        if last:
+            last[0].tail = "\n    "
+        else:
+            print('PTX:WARNING: {} has no content'.format(problem_identifier))
         static.tail = "\n    "
 
         # Add elements for interactivity


### PR DESCRIPTION
Prior to this commit, there are situations where WW reps building can fail without a good explanation. The references below to `last[0]` kill python when `last` is an empty list. (Which can happen in silly ways, like literally putting nothing into a `statement`, but also when using an OPL problem that is not PTX compatible.) Now if that happens, you get a warning that something was empty, and processing otherwise proceeds. And I put one triggering example in the sample chapter.

This branch started out as its name implies, to cleanse sidebyside (gracefully) from within a webwork. But one thing leads to another in ways that feel too intertwined to do on separate branches. So I'll try to isolate meaningful changes one commit at a time, and await review and merging. (No rush!)