### PR TITLE
WeBWorK: remove sidebyside

### DIFF
--- a/examples/showcase/webwork.ptx
+++ b/examples/showcase/webwork.ptx
@@ -225,9 +225,7 @@
         <p>
           This Venn Diagram groups animals by certain characteristics.
         </p>
-        <sidebyside widths="50%">
-          <image pg-name="$vd"/>
-        </sidebyside>
+        <image pg-name="$vd" width="50%"/>
         <p>
           Name an animal that belongs in the center region. Spelling counts!
         </p>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1563,6 +1563,7 @@
             ImageWW =
                 element image {
                     attribute pg-name {text}?,
+                    attribute width {text}?,
                     element description {(TextShort | WWVariable)*}?
                 }
             </code>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1364,7 +1364,7 @@
 <!-- PGML Image Construction -->
 <!-- ####################### -->
 
-<xsl:template match="image[@pg-name]">
+<xsl:template match="image[@pg-name]" mode="components">
     <xsl:variable name="width">
         <xsl:apply-templates select="." mode="get-width-percentage" />
     </xsl:variable>
@@ -1390,7 +1390,7 @@
 <!-- is to give the reader something like keyboard syntax instructions     -->
 <!-- but withhold these in print output.                                   -->
 <xsl:template match="instruction">
-    <xsl:if test="preceding-sibling::p|preceding-sibling::sidebyside and not(child::*[1][self::ol] or child::*[1][self::ul])">
+    <xsl:if test="preceding-sibling::p and not(child::*[1][self::ol] or child::*[1][self::ul])">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:text>[@KeyboardInstructions(</xsl:text>
@@ -1450,7 +1450,7 @@
 <!-- inside a list, special handling                                      -->
 <xsl:template match="p">
     <xsl:param name="b-human-readable" />
-    <xsl:if test="preceding-sibling::p|preceding-sibling::sidebyside and not(child::*[1][self::ol] or child::*[1][self::ul])">
+    <xsl:if test="preceding-sibling::p and not(child::*[1][self::ol] or child::*[1][self::ul])">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:apply-templates>
@@ -1467,19 +1467,21 @@
     </xsl:if>
 </xsl:template>
 
-<!-- Sidebyside in a WeBWorK expects only one child: image or tabular.    -->
-<!-- Just applies templates to its child                                  -->
-<!-- NB: this may need improvements, such as positioning                  -->
-<!-- NB: a Schematron rule should enforce the single child                -->
-<xsl:template match="sidebyside">
+<!-- Some common wrappers for image and tabular   -->
+<!-- Formerly this template was for sidebyside    -->
+<!-- And we leave it to also work on a sidebyside -->
+<!-- for backwards compatibility. However, such   -->
+<!-- use will be caught by a deprectation warning -->
+<!-- as well as fail a schema validation.         -->
+<xsl:template match="image|tabular|sidebyside">
     <xsl:param name="b-human-readable" />
-    <xsl:if test="preceding-sibling::p|preceding-sibling::sidebyside">
+    <xsl:if test="preceding-sibling::p">
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:if test="not(ancestor::li)">
         <xsl:text>&gt;&gt; </xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="image|tabular">
+    <xsl:apply-templates select="self::image|self::tabular|self::sidebyside/image|self::sidebyside/tabular" mode="components">
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
     <xsl:if test="not(ancestor::li)">
@@ -2362,7 +2364,7 @@
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template match="tabular">
+<xsl:template match="tabular" mode="components">
     <!-- PTX tabular attributes top, bottom, left, right, halign are essentially passed -->
     <!-- down to cells, rather than used at the tabular level.                          -->
     <xsl:param name="b-human-readable" />

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11095,6 +11095,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="incorrect-use" select="($directory.images != '')" />
     </xsl:call-template>
  -->
+    <!--  -->
+    <!-- 2021-01-07  deprecate sidebyside within a webwork -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="$document-root//webwork//sidebyside" />
+        <xsl:with-param name="date-string" select="'2021-01-07'" />
+        <xsl:with-param name="message" select="'a &quot;sidebyside&quot; as a descendant of a &quot;webwork&quot; has been replaced and now &quot;image&quot; and &quot;tabular&quot; elements should be used directly.'"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- Miscellaneous -->


### PR DESCRIPTION
This finalizes making it so `sidebyside` is something you should never author within a `webwork`.

A WW server will still return PTX where `image` and `tabular` elements are wrapped in a `sidebyside`. This is harmless; it's like an author using a `sidebyside` around a lone `image` while _not_ inside a `webwork`.

But I willl make edits to WW so that WW 2.16 won't do that any longer.