### PR TITLE
WeBWorK: perl string variables

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1152,6 +1152,10 @@
         <xsl:text>->correct_ans()</xsl:text>
     </xsl:if>
     <xsl:text>]</xsl:text>
+    <!-- if the variable is a string of perl code to be executed -->
+    <xsl:if test="@data='perl'">
+        <xsl:text>*</xsl:text>
+    </xsl:if>
     <!-- if the variable is a string of PGML syntax to be processed -->
     <xsl:if test="@data='pgml'">
         <xsl:text>**</xsl:text>


### PR DESCRIPTION
If you were writing a .pg problem from scratch, in the middle of the statement, you might put some "raw" perl code. This would be for the rare occasion that you need to do something that you know can be done across the various WeBWorK output formats, but PGML has no macro to do it. So you could use PGML like `[code goes here]*`. The brackets tell PGML you are making a substitution. The star tells PGML not to escape any of the characters inside.

So this commit adds the option `data="perl"` for this situation. We already have `data="pgml"` for a similar situation. In that case, it makes two stars, which tells PGML not only to hold back on escaping the characters inside, but also to process the code inside as PGML syntax, not regular "raw" perl.

The need: the MHCC project has GeoGebra applets they have put into WeBWorK problems. This meets the criteria of being something PGML has no macro for, but the WW output formats can handle it. In the distant past, this was doable without `data="perl"`, because PreTeXt itself allowed them to type a command like `[code goes here]*` directly into a `p`. But today, PTX itself escapes the brackets and star, assuming the author wanted those literally.

So this PR adds `data="perl"` alongside `data="pgml"`.