### PR TITLE
add a reference to pretext script chapter in sageplot basics

### DIFF
--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -1224,10 +1224,11 @@
         Sometimes you don't want to provide an interactive SageMath environment in the middle of your book
         (or a chunk of code)
         but you would like to produce a figure to include in your project by using SageMath.
-        The cleanest way to do this his to put the SageMath code right in your <pretext/> project and use the <c>pretext</c> script to produce the image files required for your chosen output formats.
-        This is accomplished by using <tag>sageplot</tag> and the <c>pretext</c> script that we discussed in <xref ref="basics-s-latex-fig"/>.
-        (In particular,
-        see the aside in that section about the additional packages that must be installed and configured to use the <c>pretext</c> script.)
+        The cleanest way to do this his to put the SageMath code right in your <pretext/> project and use the <c>pretext</c> script
+	that we discussed in <xref ref="basics-s-latex-fig"/> to produce the image files required for your chosen output formats.
+        This is accomplished by using <tag>sageplot</tag> with the script.
+        (The <c>pretext</c> script is fully discussed in <xref ref="pretext-script"/>, but at least
+        see the aside in <xref ref="basics-s-latex-fig"/> about the additional packages that must be installed and configured to use it properly.)
       </p>
 
       <listing xml:id="basics-l-sageplot">


### PR DESCRIPTION
A suggestion since I found it confusing just now to have to loop back when I really only wanted to know about sageplot, not latex images.