### PR TITLE
Webwork copy

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -329,7 +329,40 @@
 
     <subsection>
       <title>Reusing a <tag>webwork</tag> by <attr>xml:id</attr></title>
-      <p>Planned.</p>
+      <p>
+        If a <tag>webwork</tag> has an <attr>xml:id</attr>,
+        then another <tag>webwork</tag> can <q>copy</q> the first one simply by using a <attr>copy</attr> attribute
+        whose value is the first <tag>webwork</tag>'s <attr>xml:id</attr>.
+        The <attr>seed</attr> of the first <tag>webwork</tag> is ignored,
+        and the second <tag>webwork</tag> may set its own <attr>seed</attr>.
+        For example:
+      </p>
+      <pre>
+        <![CDATA[
+        <exercise>
+          <webwork xml:id="foo" seed="1">
+            <pg-code>
+              $a = random(1,9,1);
+              $answer = $a+1;
+            </pg-code>
+            <statement>
+              <p>
+                Enter <m><var name="$a"/>+1</m>.  <var name="$answer" width="10"/>
+              </p>
+            </statement>
+          </webwork>
+        </exercise>
+
+        <exercise>
+          <webwork copy="foo" seed="2"/>
+        </exercise>
+        ]]>
+      </pre>
+      <p>
+        The <attr>copy</attr> attribute should point to a <tag>webwork</tag> that has <pretext/>-authored source,
+        not to a <tag>webwork</tag> with a <attr>source</attr> attribute.
+        (If you want to copy one with a <attr>source</attr> attribute, just reuse the same <attr>source</attr> value.)
+      </p>
     </subsection>
 
     <subsection>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -128,7 +128,7 @@
                     <p>A simple, but functional example to begin with. If you are just learning how to add, you can test yourself here.</p>
                 </introduction>
 
-                <webwork>
+                <webwork xml:id="webwork-add-numbers">
                     <description>
                         Add two positive single-digit integers.
                     </description>
@@ -160,25 +160,11 @@
                 <title>Declaring a Problem Seed</title>
 
                 <introduction>
-                    <p>You can also declare a <c>seed</c> to specify a version of any problem that has randomization. Here is the same problem, but with a <c>seed</c> specified.</p>
+                    <p>You can also declare a <c>seed</c> to specify a version of any problem that has randomization. Here is the same problem (<q>copied</q> in the <pretext/> source), but with a <c>seed</c> specified.</p>
                 </introduction>
 
-                <webwork seed="510">
-                    <pg-code>
-                        $a = random(1, 9, 1);
-                        $b = random(1, 9, 1);
-                        $c = Compute($a + $b);
-                    </pg-code>
+                <webwork copy="webwork-add-numbers" seed="510"/>
 
-                    <statement>
-                        <p>Compute the sum of <m><var name="$a" /></m> and <m><var name="$b" /></m>:</p>
-                        <p><m><var name="$a" /> + <var name="$b" /> =</m> <var name="$c" width="5" category="integer" /></p>
-                    </statement>
-
-                    <solution>
-                        <p><m><var name="$a" /> + <var name="$b" /> = <var name="$c" /></m>.</p>
-                    </solution>
-                </webwork>
             </exercise>
 
             <exercise xml:id="integer-addition-with-control-seed">

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -338,9 +338,9 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
     if pub_file:
         stringparams['publisher'] = pub_file
     _verbose('string parameters passed to extraction stylesheet: {}'.format(stringparams))
-    # execute XSL extraction to get back five dictionaries
+    # execute XSL extraction to get back six dictionaries
     # where the keys are the internal-ids for the problems
-    # origin, seed, source, pghuman, pgdense
+    # origin, copy, seed, source, pghuman, pgdense
     ptx_xsl_dir = get_ptx_xsl_path()
     extraction_xslt = os.path.join(ptx_xsl_dir, 'extract-pg.xsl')
 
@@ -920,6 +920,11 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
         # Add PG for PTX-authored problems
         # Empty tag with @source for server problems
         pg = ET.SubElement(webwork_reps,'pg')
+        try:
+            pg.set('copied-from',copiedfrom[problem])
+        except Exception:
+            pass
+
         if origin[problem] == 'ptx':
             if badness:
                 pg_shell = "DOCUMENT();\nloadMacros('PGstandard.pl','PGML.pl','PGcourse.pl');\nTEXT(beginproblem());\nBEGIN_PGML\n{}END_PGML\nENDDOCUMENT();"

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1798,7 +1798,9 @@
                 }
             WebWorkAuthored =
                 element webwork {
+                    UniqueID?,
                     attribute seed {xsd:integer}?,
+                    attribute copy {text}?,
                     element description {
                         (
                             TextSimple |

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -39,7 +39,8 @@
 
 <!-- Each dictionary uses the webworks' visible-ids as keys. There are     -->
 <!-- dictionaries for obtaining:                                           -->
-<!-- 1. a 'ptx'|'server' flag (is it authored in PTX or on the server?)    -->
+<!-- 1. a ptx|server flag (authored in PTX [or a copy], or from server)    -->
+<!-- 1b. if it is copied, from which?                                      -->
 <!-- 2. a seed for randomization (with a default explicitly declared)      -->
 <!-- 3. source (a problem's file path if it is server-based)               -->
 <!-- 4. human readable PG (for PTX-authored)                               -->
@@ -53,10 +54,15 @@
 <!-- that lives on a server. Or if the configuration of the hosting server -->
 <!-- or course changes.                                                    -->
 
-<!-- Then other translation sheets' assempbly phase will factor in         -->
+<!-- Then other translation sheets' assembly phase will factor in          -->
 <!-- webwork-representations.xml                                           -->
 
 <xsl:import href="./pretext-common.xsl" />
+<xsl:import href="./pretext-assembly.xsl"/>
+
+<!-- Override the corresponding param in pretext-assembly so that webwork  -->
+<!-- copies can be made.                                                   -->
+<xsl:variable name="b-extracting-pg" select="true()"/>
 
 <!-- We are outputting Python code, and there is no reason to output       -->
 <!-- anything other than "text"                                            -->
@@ -93,6 +99,7 @@
     <xsl:apply-templates select="mathbook|pretext" mode="deprecation-warnings" />
     <!-- Initialize empty dictionaries, then define key-value pairs -->
     <xsl:text>origin = {}&#xa;</xsl:text>
+    <xsl:text>copiedfrom = {}&#xa;</xsl:text>
     <xsl:text>seed = {}&#xa;</xsl:text>
     <xsl:text>source = {}&#xa;</xsl:text>
     <xsl:text>pghuman = {}&#xa;</xsl:text>
@@ -109,7 +116,7 @@
     <xsl:variable name="problem">
         <xsl:apply-templates select="." mode="visible-id" />
     </xsl:variable>
-    <!-- 1. a 'ptx'|'server' flag (is it authored in PTX or on the server?)    -->
+    <!-- 1. a ptx|copy|server flag (authored in PTX, a copy, or from server)   -->
     <xsl:text>origin["</xsl:text>
     <xsl:value-of select="$problem" />
     <xsl:text>"] = "server"&#xa;</xsl:text>
@@ -132,10 +139,18 @@
     <xsl:variable name="problem">
         <xsl:apply-templates select="." mode="visible-id" />
     </xsl:variable>
-    <!-- 1. a 'ptx'|'server' flag (is it authored in PTX or on the server?)    -->
+    <!-- 1. a ptx|server flag (authored in PTX [or a copy], or from server)    -->
     <xsl:text>origin["</xsl:text>
     <xsl:value-of select="$problem" />
     <xsl:text>"] = "ptx"&#xa;</xsl:text>
+    <!-- 1b. if this problem is a copy, record where it was copied from        -->
+    <xsl:if test="@copied-from">
+        <xsl:text>copiedfrom["</xsl:text>
+        <xsl:value-of select="$problem" />
+        <xsl:text>"] = "</xsl:text>
+        <xsl:value-of select="@copied-from"/>
+        <xsl:text>"&#xa;</xsl:text>
+    </xsl:if>
     <!-- 2. a seed for randomization (with a default explicitly declared)      -->
     <xsl:text>seed["</xsl:text>
     <xsl:value-of select="$problem" />

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -184,6 +184,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- $webwork-representations-file is from publisher file      -->
 <xsl:variable name="b-doing-webwork-assembly" select="not($webwork-representations-file = '')"/>
 
+<!-- Normally we are not extracting PG. When we do, extract-pg.xsl -->
+<!-- will override the following with true()                       -->
+<xsl:variable name="b-extracting-pg" select="false()"/>
+
 <!-- Don't match on simple WeBWorK logo       -->
 <!-- Seed and possibly source attributes      -->
 <!-- Then authored?, pg?, and static children -->
@@ -195,6 +199,42 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="visible-id" />
     </xsl:variable>
     <xsl:choose>
+        <xsl:when test="$b-extracting-pg">
+            <xsl:choose>
+                <xsl:when test="@copy">
+                    <xsl:variable name="target" select="id(@copy)"/>
+                    <xsl:choose>
+                        <xsl:when test="$target/statement|$target/stage">
+                            <xsl:copy>
+                                <xsl:attribute name="copied-from">
+                                    <xsl:value-of select="@copy"/>
+                                </xsl:attribute>
+                                <xsl:apply-templates select="@*[not(local-name(.) = 'copy')]" mode="assembly"/>
+                                <xsl:apply-templates select="$target/@*[not(local-name(.) = 'id')][not(local-name(.) = 'seed')]" mode="assembly"/>
+                                <!-- TODO: The following should scrub unique IDs as it continues down the tree. -->
+                                <!-- Perhaps with a param to the assembly modal template.                       -->
+                                <xsl:apply-templates select="$target/node()" mode="assembly"/>
+                            </xsl:copy>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <webwork>
+                                <statement>
+                                    <p>
+                                        A WeBWorK problem would appear here, but something about its <c>@copy</c> attribute is not right.
+                                        Search the runtime output for <q><c>PTX:ERROR</c></q>.
+                                    </p>
+                                </statement>
+                            </webwork>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy>
+                        <xsl:apply-templates select="node()|@*" mode="assembly"/>
+                    </xsl:copy>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
         <xsl:when test="$b-doing-webwork-assembly">
             <xsl:copy-of select="document($webwork-representations-file, /pretext)/webwork-representations/webwork-reps[@ww-id=$ww-id]" />
         </xsl:when>
@@ -493,7 +533,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- A place for warnings about missing files, etc -->
 <!-- and/or temporary/experimental features        -->
 <xsl:template name="assembly-warnings">
-    <xsl:if test="$original/*[not(self::docinfo)]//webwork/node() and not($b-doing-webwork-assembly)">
+    <xsl:if test="$original/*[not(self::docinfo)]//webwork/node() and not($b-doing-webwork-assembly or $b-extracting-pg)">
         <xsl:message>PTX:WARNING: Your document has WeBworK exercises,</xsl:message>
         <xsl:message>             but your publisher file does not indicate the file</xsl:message>
         <xsl:message>             of problem representations created by a WeBWorK server.</xsl:message>
@@ -501,6 +541,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:message>             of the intended content.  Not making this file available</xsl:message>
         <xsl:message>             can cause difficulties when parts of your document get</xsl:message>
         <xsl:message>             processed by external programs (e.g. graphics, previews)</xsl:message>
+    </xsl:if>
+    <xsl:if test="$b-extracting-pg">
+        <xsl:variable name="webwork-with-copy" select="$original//webwork[@copy]"/>
+        <xsl:for-each select="$webwork-with-copy">
+            <xsl:variable name="target" select="id(@copy)"/>
+            <xsl:choose>
+                <xsl:when test="$target/statement|$target/stage"/>
+                <xsl:when test="$target/@source">
+                    <xsl:message>PTX:ERROR:   A WeBWorK problem with copy="<xsl:value-of select="@copy"/>"</xsl:message>
+                    <xsl:message>             points to a WeBWorK problem that uses a source attribute</xsl:message>
+                    <xsl:message>             to generate a problem using a file that exists on the WeBWorK server.</xsl:message>
+                    <xsl:message>             Instead of using the copy attribute, use the same source attribute.</xsl:message>
+                </xsl:when>
+                <xsl:when test="not($target)">
+                    <xsl:message>PTX:ERROR:   A WeBWorK problem uses copy="<xsl:value-of select="@copy"/>",</xsl:message>
+                    <xsl:message>             but there is no WeBWorK problem with xml:id="<xsl:value-of select="@copy"/>".</xsl:message>
+                    <xsl:message>             Is it a typo? Is the target WeBWorK problem currently commented out in source?</xsl:message>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:message>PTX:ERROR:   A WeBWorK problem with copy="<xsl:value-of select="@copy"/>"</xsl:message>
+                    <xsl:message>             points to a WeBWorK problem that does not have a statement or stage.</xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -131,6 +131,13 @@
     <xsl:value-of select="pg/@source" />
 </xsl:template>
 
+<!-- For copied problems move to the problem that was copied -->
+<xsl:template match="webwork-reps[pg/@copied-from]" mode="filename">
+    <xsl:variable name="copied-from" select="pg/@copied-from"/>
+    <xsl:apply-templates select="$document-root//webwork-reps[@ww-id=$copied-from]" mode="filename"/>
+</xsl:template>
+
+
 <!-- ################## -->
 <!-- Problem Extraction -->
 <!-- ################## -->
@@ -150,6 +157,10 @@
 <!-- OPL problems don't produce PG source files, -->
 <!-- as they live on the server already          -->
 <xsl:template match="webwork-reps[pg/@source]" />
+
+<!-- Don't make PG file for copies -->
+<xsl:template match="webwork-reps[pg/@copied-from]" />
+
 
 <!-- ################## -->
 <!-- Chunking Def Files-->


### PR DESCRIPTION
This makes it so you can use `<webwork copy="some-xml:id-on-a-webwork-element"/>`.

The target has to be a PTX-authored WW problem, and there are tests in the generic warnings section of `-common` about this.

The copying happens during assembly, keeping attributes except the `@copy` attribute. It copies "all" attributes from the target, except the target's `@seed` and `@xml:id`. Well, there aren't any other attributes that the target would have, so this is vacuous, but there in case future attributes come into existence. And then it copies children etc.

Then `extract-pg.xsl` does its thing on the enhanced source. There is one more python dictionary called `copiedfrom`. For each webwork that originally had a `@copy`, there is an entry in `copiedfrom` for that problem, with value being the `@xml:id` of the target.

You don't see a change in HTML or PDF output.

When using `pretext-ww-problem-sets.xl`, no .pg file is built for a problem that is a copy. And in a set definition file, where a copied problem occurs, the file path for the problem is the file path for the "copiedfrom" problem file.

I realize just now I did not put `@copy` in the schema. I can revisit that. I'm unsure though how you prefer I do it, since you have to regenerate all the downstream schema files. If you like, I can manually edit them all, since it is trivial to visit each of those files and see where legal `webwork` attributes are declared.

In a separate commit, I added documentation and one example in the sample chapter. Maybe you'd like to put the two commits together? I thought it might help review to separate them. 

I tested with a small part of ORCCA, and it works there too.
