### PR TITLE
WeBWorK: fix exercisegroup xrefs

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1519,13 +1519,6 @@
     <xsl:apply-templates select="." mode="number" />
 </xsl:template>
 
-<!-- In common template, but have to point -->
-<!-- to it since it is a modal template    -->
-<xsl:template match="exercisegroup" mode="xref-number">
-    <xsl:apply-imports />
-</xsl:template>
-
-
 <!-- ######### -->
 <!-- PGML Math -->
 <!-- ######### -->


### PR DESCRIPTION
I'm not sure why this was here. I think that it was needed at one time, but -common evolved nad now it is resposible for seeing `[NUM]` in output. After removing this, output is good.