### PR TITLE
HTML changes for better CSS

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5550,9 +5550,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:attribute name="src">
                     <xsl:value-of select="@source" />
                 </xsl:attribute>
-                <!-- replace with a CSS class -->
-                <xsl:attribute name="style">
-                    <xsl:text>width: 100%; height: auto;</xsl:text>
+                <xsl:attribute name="class">
+                    <xsl:text>contained</xsl:text>
                 </xsl:attribute>
                 <!-- alt attribute for accessibility -->
                 <xsl:attribute name="alt">
@@ -5701,9 +5700,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="role">
             <xsl:text>img</xsl:text>
         </xsl:attribute>
-        <!-- replace with a CSS class                           -->
-        <xsl:attribute name="style">
-            <xsl:text>width: 100%; height: auto;</xsl:text>
+        <xsl:attribute name="class">
+            <xsl:text>contained</xsl:text>
         </xsl:attribute>
         <!-- alt attribute for accessibility -->
         <xsl:attribute name="alt">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5865,6 +5865,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:if test="self::table or self::tabular">
                 <xsl:text> fixed-width</xsl:text>
             </xsl:if>
+            <!-- assumes "sbspanel" class set vertical direction -->
+            <!-- the CSS class equals the source attribute, but that may change -->
+            <xsl:choose>
+                <xsl:when test="$valign = 'top'">
+                    <xsl:text> top</xsl:text>
+                </xsl:when>
+                <xsl:when test="$valign = 'middle'">
+                    <xsl:text> middle</xsl:text>
+                </xsl:when>
+                <xsl:when test="$valign = 'bottom'">
+                    <xsl:text> bottom</xsl:text>
+                </xsl:when>
+            </xsl:choose>
         </xsl:attribute>
         <xsl:attribute name="style">
             <xsl:text>width:</xsl:text>
@@ -5873,20 +5886,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="left-margin"  select="$left-margin" />
                 <xsl:with-param name="right-margin" select="$right-margin" />
             </xsl:call-template>
-            <xsl:text>;</xsl:text>
-            <!-- assumes "sbspanel" class set vertical direction -->
-            <xsl:text>justify-content:</xsl:text>
-            <xsl:choose>
-                <xsl:when test="$valign = 'top'">
-                    <xsl:text>flex-start</xsl:text>
-                </xsl:when>
-                <xsl:when test="$valign = 'middle'">
-                    <xsl:text>center</xsl:text>
-                </xsl:when>
-                <xsl:when test="$valign = 'bottom'">
-                    <xsl:text>flex-end</xsl:text>
-                </xsl:when>
-            </xsl:choose>
             <xsl:text>;</xsl:text>
             <xsl:if test="$sbsdebug">
                 <xsl:text>box-sizing: border-box;</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -3166,7 +3166,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Overall enclosing element -->
 <xsl:template match="paragraphs" mode="body-element">
-    <xsl:text>article</xsl:text>
+    <xsl:text>section</xsl:text>
 </xsl:template>
 
 <!-- And its CSS class -->


### PR DESCRIPTION
Three small changes to handle HTML styling more appropriately:

a) A PTX 'paragraphs' now becomes a 'section' in the HTML.  (Formerly an 'article')

b) For an image, the style = "width: 100%; height: auto" is now class="contained".

c) In an sbspanel, the justify-content is now handled by a CSS class (with attribute
name the same as in the source).

Matching CSS changes have already been made (all that I caught, anyway).

Note that for c) the changes as shown in the pull request on GitHub do not give
an accurate impression of what edits were made:  a block of code which set the style
was moved higher and adjusted to add to the existing class.  The GitHub makes
it look like another block was moved down, and then something else was adjusted.

Issue #1160 can be closed after merging.
