### PR TITLE
reduce double escaped amp to single escaped

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1037,7 +1037,7 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                     server_url.set('hint',hint)
                     server_url.set('solution',solution)
                     server_url.set('domain',ww_domain)
-                    url_shell = "{}?courseID={}&amp;userID={}&amp;password={}&amp;course_password={}&amp;answersSubmitted=0&amp;displayMode=MathJax&amp;outputformat=simple&amp;problemSeed={}&amp;{}"
+                    url_shell = "{}?courseID={}&userID={}&password={}&course_password={}&answersSubmitted=0&displayMode=MathJax&outputformat=simple&problemSeed={}&{}"
                     server_url.text = url_shell.format(ww_domain_path,courseID,userID,password,course_password,seed[problem],source_query)
                     server_url.tail = "\n    "
 


### PR DESCRIPTION
Before this change, what happens is that WeBWorK iframe `src` was coming out with `&amp;amp;` in its value. The amp was escaped here in pretext.py, but then that string gets its `&` from the `&amp;` escaped again by `pretext-html.xsl`.

This is not just a cosmetic thing, although it may seem that way since WW in iframe from version 2.15- has been working fine. The WW developers believe there is a bug in a perl module called `Lite.pm`. A fix for this bug was identified. But that fix makes the WW iframes that have double escaped ampersands stop working.

If this is merged, for example I can apply the fix to the PCC WW server. That will immediately cause some books' embedded iframe WW that rely on the PCC server to fail. (Lane's ORCCA is the only one I can think of.) But with this merged, they could rebuild their HTML. (Their other option once I make the patch to Lite.pm, is they could sed all their `&amp;amp;` in their HMTL files to just become `&amp;` if rebuilding their HTML is too much.)