### PR TITLE
WeBWorK: MathJax 3 configuration

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10995,7 +10995,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>  },&#xa;</xsl:text>
         <xsl:text>  options: {&#xa;</xsl:text>
         <xsl:text>    ignoreHtmlClass: "tex2jax_ignore",&#xa;</xsl:text>
-        <xsl:text>    processHtmlClass: "has_am"&#xa;</xsl:text>
+        <xsl:text>    processHtmlClass: "has_am",&#xa;</xsl:text>
+        <xsl:if test="$b-has-webwork-reps">
+            <xsl:text>    renderActions: {&#xa;</xsl:text>
+            <xsl:text>        findScript: [10, function (doc) {&#xa;</xsl:text>
+            <xsl:text>            document.querySelectorAll('script[type^="math/tex"]').forEach(function(node) {&#xa;</xsl:text>
+            <xsl:text>                var display = !!node.type.match(/; *mode=display/);&#xa;</xsl:text>
+            <xsl:text>                var math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);&#xa;</xsl:text>
+            <xsl:text>                var text = document.createTextNode('');&#xa;</xsl:text>
+            <xsl:text>                node.parentNode.replaceChild(text, node);&#xa;</xsl:text>
+            <xsl:text>                math.start = {node: text, delim: '', n: 0};&#xa;</xsl:text>
+            <xsl:text>                math.end = {node: text, delim: '', n: 0};&#xa;</xsl:text>
+            <xsl:text>                doc.math.push(math);&#xa;</xsl:text>
+            <xsl:text>            });&#xa;</xsl:text>
+            <xsl:text>        }, '']&#xa;</xsl:text>
+            <xsl:text>    },&#xa;</xsl:text>
+        </xsl:if>
         <xsl:text>  },&#xa;</xsl:text>
         <xsl:text>  chtml: {&#xa;</xsl:text>
         <xsl:text>    scale: 0.88,&#xa;</xsl:text>


### PR DESCRIPTION
This is needed for MathJax3 inside a live WW that comes from a version 2.16 server. It is a configuration option for when math is in a `<script type="math/tex">...</script>` instead of inside `\(...\)`. And this is how WeBWorK delivers math content. With MathJax2, nothing special needed to be done about that, which is why I hadn't noticed it before. It's less because of PTX moving to MathJax3, and more because of WeBWorK doing so recently as well.

If you pull this, then rebuild the sample chapter. I have edited `pretext-webwork.js` (and @davidfarmer, I committed that edit and pushed it to GitHub) such that the math renders on a local build of the sample chapter.