### PR TITLE
Miscellaneous side commits during PGtikz work

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -399,10 +399,10 @@
     </section>
 
     <section xml:id="overview-webwork">
-        <title><webwork /> Exercises</title>
-        <idx><h><webwork /></h><h><webwork /> exercise</h></idx>
+        <title><webwork/> Exercises</title>
+        <idx><h><webwork/></h><h><webwork/> exercise</h></idx>
 
-        <p>It is possible to author <webwork /> automated homework problems<idx><h><webwork /></h><h><webwork /> exercise</h></idx> directly within your source.  A static version will be rendered in your <latex />/PDF/print output, and a <q>live</q> version will be rendered into HTML output (though a student is not able to authenticate against a course).  However, you can also extract <em>all</em> of the <webwork /> questions from a textbook into a single archive suitable for uploading into a traditional <webwork /> server.  This is a big topic, so see the dedicated <xref ref="webwork-author" /> for details.</p>
+        <p>It is possible to author <webwork/> automated homework problems<idx><h><webwork /></h><h><webwork /> exercise</h></idx> directly within your source.  A static version will be rendered in your <latex />/PDF/print output, and a <q>live</q> version will be rendered into HTML output (though a student is not able to authenticate against a course).  However, you can also extract <em>all</em> of the <webwork/> questions from a textbook into a single archive suitable for uploading into a traditional <webwork/> server.  This is a big topic, so see the dedicated <xref ref="webwork-author" /> for details.</p>
     </section>
 
     <section xml:id="overview-url">

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -753,7 +753,7 @@
             </paragraphs>
 
             <paragraphs>
-                <title><tage>tex</tage>, <tage>latex</tage>, <tage>pretext</tage>, <tage>webwork</tage>, <tex />, <latex />, <pretext />, <webwork /></title>
+                <title><tage>tex</tage>, <tage>latex</tage>, <tage>pretext</tage>, <tage>webwork</tage>, <tex />, <latex />, <pretext />, <webwork/></title>
                 <p>Conveniences for frequently-mentioned accessories to <pretext />.</p>
             </paragraphs>
 

--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -8,7 +8,7 @@
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="webwork-author">
-  <title><webwork /> Exercises</title>
+  <title><webwork/> Exercises</title>
   <idx>
     <h><webwork/></h>
     <h><webwork/> exercises</h>

--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -386,9 +386,36 @@
           in your image code.
         </p>
         <p>
+          You must use <c>\(...\)</c> instead of <c>$...$</c> to encase inline math.
+          And if you have display math in the tikz image, that should use <c>\[...\]</c> instead of <c>$$...$$</c>.
+        </p>
+        <p>
           Your image code can use variables that you defined in the <tag>pg-code</tag> section.
           Include variables just as you would anywhere else in a problem statement,
           like <c>&lt;var name="$a"/></c>.
+        </p>
+        <p>
+          In perl, <c>$</c>, <c>@</c>, and <c>%</c> each have special meaning.
+          So you may wonder about using them in your tikz code.
+          The short answer is that you should use them just as you would use them in a regular <latex/>/tikz document.
+          So when you would like a dollar sign, write <c>\$</c>.
+          For a percent sign, use <c>\%</c>.
+          And an at character does not need escaping, so write <c>@</c>.
+        </p>
+        <p>
+          As mentioned above, <em>do not</em> use a dollar sign for math.
+          If you want to put a <latex/> comment in the code, you may write it in the usual way like <c>% This is a comment</c>.
+        </p>
+        <p>
+          When the <webwork/> server makes one of these images for the first time,
+          it caches the image. Generally, if you then edit the tikz source code,
+          the <webwork/> server will not rebuild the image. So while you are developing an image,
+          you may want to put <c>$refreshCachedImages = 1;</c> into your <tag>pg-code</tag>
+          for the problem. This will force the <webwork/> server to rebuild the image.
+          Once the image is stable, remove that line from the <tag>pg-code</tag>.
+          Otherwise every time someone views the image in an embedded interactive HTML exercise,
+          the <webwork/> server will rebuild the image. Beyond the extra strain on the server,
+          this will cause a lag for your readers to see the image.
         </p>
         <p>
           See the <webwork/> sample chapter for examples.

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -8,7 +8,7 @@
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="webwork-publisher">
-  <title><webwork /> Exercises</title>
+  <title><webwork/> Exercises</title>
   <idx>
     <h><webwork/></h>
     <h><webwork/> exercises</h>
@@ -147,7 +147,7 @@
       </p>
       <p>
         <c>-s</c> specifies the <webwork/> server.
-        The <webwork /> server needs to be version 2.14 or later, specified with its protocol and domain,
+        The <webwork/> server needs to be version 2.14 or later, specified with its protocol and domain,
         like <c>https://webwork-ptx.aimath.org</c>.
         It is <em>important</em> to get the protocol correct for your server (<c>http</c> versus <c>https</c>).
         If you do not have a server, you may use <c>https://webwork-ptx.aimath.org</c>.

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1119,6 +1119,34 @@
                 </webwork>
             </exercise>
 
+            <exercise>
+                <title>Special characters</title>
+                <introduction>
+                    <p>
+                        This exercise is to test that special characters behave.
+                    </p>
+                </introduction>
+                <webwork>
+                    <pg-code>
+                        $refreshCachedImages = 1;
+                    </pg-code>
+                    <statement>
+                        <p>
+                            The code below has a printed dollar sign, a printed percent sign,
+                            a printed at sign, and a percent sign used as a comment marker.
+                        </p>
+                        <image width="50%">
+                            <latex-image syntax="PGtikz">
+                                \node at (0,0) {I need about \$3.50.};
+                                \node at (0,1) {You gotta give 110\%.};  %This is a comment.
+                                \node at (0,2) {Send email user@domain.com.};
+                            </latex-image>
+                        </image>
+                    </statement>
+                </webwork>
+            </exercise>
+
+
             <!-- TODO: Support for packages, such as pgfplots -->
 
             <p>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -275,9 +275,12 @@ def latex_image_conversion(xml_source, pub_file, stringparams, xmlid_root, data_
                 print('PTX:ERROR: There was a problem compiling {} and {} was not created'.format(latex_image,latex_image_pdf))
             pcm_executable_cmd = get_executable_cmd('pdfcrop')
             pcm_cmd = pcm_executable_cmd + [latex_image_pdf, "-o", "cropped-"+latex_image_pdf, "-p", "0", "-a", "-1"]
-            _verbose("cropping {} to {}".format(latex_image_pdf, latex_image_pdf))
+            _verbose("cropping {} to {}".format(latex_image_pdf, "cropped-"+latex_image_pdf))
             subprocess.call(pcm_cmd, stdout=devnull, stderr=subprocess.STDOUT)
+            if not os.path.exists("cropped-"+latex_image_pdf):
+                print('PTX:ERROR: There was a problem cropping {} and {} was not created'.format(latex_image_pdf,"cropped-"+latex_image_pdf))
             shutil.move("cropped-"+latex_image_pdf, latex_image_pdf)
+            _verbose("renaming {} to {}".format("cropped-"+latex_image_pdf,latex_image_pdf))
             if outformat == 'all':
                 shutil.copy2(latex_image, dest_dir)
             if (outformat == 'pdf' or outformat == 'all'):
@@ -289,6 +292,8 @@ def latex_image_conversion(xml_source, pub_file, stringparams, xmlid_root, data_
                 svg_cmd = pdfsvg_executable_cmd + [latex_image_pdf, latex_image_svg]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_svg))
                 subprocess.call(svg_cmd)
+                if not os.path.exists(latex_image_svg):
+                    print('PTX:ERROR: There was a problem converting {} to svg and {} was not created'.format(latex_image_pdf,latex_image_svg))
                 shutil.copy2(latex_image_svg, dest_dir)
             if (outformat == 'png' or outformat == 'all'):
                 # create high-quality png, presumes "convert" executable
@@ -298,6 +303,8 @@ def latex_image_conversion(xml_source, pub_file, stringparams, xmlid_root, data_
                 png_cmd = pdfpng_executable_cmd + ["-density", "300",  latex_image_pdf, "-quality", "100", latex_image_png]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_png))
                 subprocess.call(png_cmd)
+                if not os.path.exists(latex_image_png):
+                    print('PTX:ERROR: There was a problem converting {} to png and {} was not created'.format(latex_image_pdf,latex_image_png))
                 shutil.copy2(latex_image_png, dest_dir)
             if (outformat == 'eps' or outformat == 'all'):
                 pdfeps_executable_cmd = get_executable_cmd('pdfeps')
@@ -306,6 +313,8 @@ def latex_image_conversion(xml_source, pub_file, stringparams, xmlid_root, data_
                 eps_cmd = pdfeps_executable_cmd + ['-eps', latex_image_pdf, latex_image_eps]
                 _verbose("converting {} to {}".format(latex_image_pdf, latex_image_eps))
                 subprocess.call(eps_cmd)
+                if not os.path.exists(latex_image_eps):
+                    print('PTX:ERROR: There was a problem converting {} to eps and {} was not created'.format(latex_image_pdf,latex_image_eps))
                 shutil.copy2(latex_image_eps, dest_dir)
 
 

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -610,6 +610,8 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
         # Ready, go out on the wire
         try:
             response = session.get(ww_domain_path, params=server_params)
+            _verbose('Getting problem response from: ' + response.url)
+
         except requests.exceptions.RequestException as e:
             root_cause = str(e)
             msg = "PTX:ERROR: there was a problem collecting a problem,\n Server: {}\nRequest Parameters: {}\n"

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -677,7 +677,7 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
         # Then change targets of img (while downloading the original target as an image file)
 
         # When a PG Math Object is a text string that has to be rendered in a math environment,
-        # depending on the string's content and the version of WeBworK, it can come back as:
+        # depending on the string's content and the version of WeBWorK, it can come back as:
 
         # \text{string}            only when the string is built solely from -A-Za-z0-9 ,.;:+=?()[]
         # \verb\x85string\x85      version 2.14 and earlier

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1454,7 +1454,10 @@
 </xsl:template>
 
 <xsl:template match="text()" mode="latex-image">
-    <xsl:value-of select="."/>
+    <xsl:variable name="dollar-fixed"  select="str:replace(.,             '\$', '\~~$')"/>
+    <xsl:variable name="percent-fixed" select="str:replace($dollar-fixed, '\%', '\~~%')"/>
+    <xsl:variable name="at-fixed"      select="str:replace($percent-fixed, '@',  '~~@')"/>
+    <xsl:value-of select="$at-fixed"/>
 </xsl:template>
 
 <!-- An "instruction" is a peer of p, only within a webwork. The purpose   -->

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1401,7 +1401,7 @@
     <xsl:value-of select="substring-before($width, '%') div 100 * $design-width-pg"/>
     <xsl:if test="description">
         <xsl:text>, extra_html_tags=&gt;qq!alt="</xsl:text>
-        <xsl:apply-templates select="description" mode="pg" />
+        <xsl:apply-templates select="description" />
         <xsl:text>"!</xsl:text>
     </xsl:if>
     <xsl:text>)@]* </xsl:text>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -401,7 +401,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and/or temporary/experimental features        -->
 <xsl:template name="assembly-warnings">
     <xsl:if test="$original/*[not(self::docinfo)]//webwork/node() and not($b-doing-webwork-assembly or $b-extracting-pg)">
-        <xsl:message>PTX:WARNING: Your document has WeBworK exercises,</xsl:message>
+        <xsl:message>PTX:WARNING: Your document has WeBWorK exercises,</xsl:message>
         <xsl:message>             but your publisher file does not indicate the file</xsl:message>
         <xsl:message>             of problem representations created by a WeBWorK server.</xsl:message>
         <xsl:message>             Exercises will have a small informative message instead</xsl:message>


### PR DESCRIPTION
While I was doing the last batch of PGtikz edits, I ran into these small things that I wanted to change. They are small things that didn't really fit into the PGtikz pull request. So I separated them, but I still think they are good changes to assess separately. It may help to look at them one commit at a time.

Why `<webwork/>` in place of `<webwork />`?  It made it a little easier for me to search for the real `<webwork ...>` that are not just generators.

The "description fix" fixes something that is actually broken.

One commit is trivial typo correction for WeBWorK camelcase.

The other two (I believe) give helpful debugging info during image and webwork extraction.