### PR TITLE
WeBWorK: explicitly ask for solutions and hints from server

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -597,6 +597,8 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
             server_params_source = ('sourceFilePath',source[problem]) if origin[problem] == 'server' else ('problemSource',pgbase64['hint_yes_solution_yes'])
 
         server_params = (('answersSubmitted','0'),
+                         ('showSolutions','1'),
+                         ('showHints','1'),
                          ('displayMode','PTX'),
                          ('courseID',courseID),
                          ('userID',userID),


### PR DESCRIPTION
In the URLs that we use to return content from the WW server, this change explicitly asks for solutions and hints to be returned as well. Until recently, they were always returned.