### PR TITLE
WeBWorK: document simpler vars in tikz

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -391,8 +391,14 @@
         </p>
         <p>
           Your image code can use variables that you defined in the <tag>pg-code</tag> section.
-          Include variables just as you would anywhere else in a problem statement,
-          like <c>&lt;var name="$a"/></c>.
+          Scalar variables may be used simply by using their perl names including the dollar sign sigil.
+          For example, <c>\draw ($a,$b) -- ($c,$d);</c> where <c>$a</c>, <c>$b</c>, <c>$c</c>, and <c>$d</c> are variables.
+          However, any instance of <c>\$</c> in code will be interpreted as an escaped dollar sign first,
+          so rare situations may require you to be more explicit.
+          The alternative is to include variables just as you would anywhere else in a problem statement,
+          using a <tag>var</tag> element like <c>&lt;var name="$a"/></c>.
+          You would also need to use a <tag>var</tag> element if you would like to insert a perl array,
+          for example <c>&lt;var name="@a"/></c>.
         </p>
         <p>
           In perl, <c>$</c>, <c>@</c>, and <c>%</c> each have special meaning.
@@ -400,7 +406,7 @@
           The short answer is that you should use them just as you would use them in a regular <latex/>/TikZ document.
           So when you would like a dollar sign, write <c>\$</c>.
           For a percent sign, use <c>\%</c>.
-          And an at character does not need escaping, so write <c>@</c>.
+          An <q>at</q> character does not need escaping, so write <c>@</c>.
         </p>
         <p>
           As mentioned above, <em>do not</em> use a dollar sign for math.

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -69,8 +69,8 @@
             \pgfplotsset{
                 every axis/.append style={
                     axis lines=middle,
-                    xlabel={$x$},
-                    ylabel={$y$},
+                    xlabel={\(x\)},
+                    ylabel={\(y\)},
                     grid = both,
                 }
             }
@@ -1115,7 +1115,7 @@
                                 and height is labeled <var name="$b"/> cm
                             </description>
                             <latex-image syntax="PGtikz">
-                                \draw[fill=blue!20] (0,0) -&#x2d;++ (6,0) node[pos=0.5,below] {\(<var name="$b"/>\)\,cm} -&#x2d;++ (0,4) node[pos=0.5,right] {\(<var name="$a"/>\)\,cm} -&#x2d;++ (-6,0) -&#x2d; cycle;
+                                \draw[fill=blue!20] (0,0) -&#x2d;++ (6,0) node[pos=0.5,below] {\($b\)\,cm} -&#x2d;++ (0,4) node[pos=0.5,right] {\($a\)\,cm} -&#x2d;++ (-6,0) -&#x2d; cycle;
                             </latex-image>
                         </image>
                         <p>
@@ -1152,7 +1152,7 @@
                             </description>
                             <latex-image syntax="PGtikz">
                                 \begin{axis}
-                                    \addplot[domain=<var name="$xmin"/>:<var name="$xmax"/>,smooth] {(x-<var name="$roots[0]"/>)*(x-<var name="$roots[1]"/>)*(x-<var name="$roots[2]"/>)};
+                                    \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
                                 \end{axis}
                             </latex-image>
                         </image>


### PR DESCRIPTION
Not urgent. I realized there is nothing wrong with doing like:
```
\draw (0,0) -- ($a,0);
```
in tikz code in a webwork, instead of having to do:
```
\draw (0,0) -- (<var name="$a"/>,0);
```
Latter is still an option, and it rare cases, may be necessary.

The former is much more pleasant. Such is my experience after an afternoon converting one section of APEX webwork images to tikz.

