### PR TITLE
WeBWorK: use document-language

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -97,12 +97,9 @@
 <xsl:template match="/">
     <xsl:apply-templates select="mathbook|pretext" mode="generic-warnings" />
     <xsl:apply-templates select="mathbook|pretext" mode="deprecation-warnings" />
-    <!-- Get language, if there is one -->
-    <xsl:if test="pretext/@xml:lang">
-        <xsl:text>localization = '</xsl:text>
-        <xsl:value-of select="pretext/@xml:lang"/>
-        <xsl:text>'&#xa;</xsl:text>
-    </xsl:if>
+    <xsl:text>localization = '</xsl:text>
+    <xsl:value-of select="$document-language"/>
+    <xsl:text>'&#xa;</xsl:text>
     <!-- Initialize empty dictionaries, then define key-value pairs -->
     <xsl:text>origin = {}&#xa;</xsl:text>
     <xsl:text>copiedfrom = {}&#xa;</xsl:text>


### PR DESCRIPTION
This changes from using `pretext/@xml:lang` to using `$document-language` to address the problem I caused with #1486.