### PR TITLE
Update Czecjh translation

### DIFF
--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -65,9 +65,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='frontmatter'>Úvodní část</localization>
     <localization string-id='part'>Část</localization>
     <localization string-id='chapter'>Kapitola</localization>
-    <localization string-id='appendix'>Appendix</localization>
+    <localization string-id='appendix'>Dodatek</localization>
     <!-- Next is the plural of Appendix, used to identify a group of appendix -->
-    <!-- <localization string-id='appendices'>Appendices</localization> -->
+    <localization string-id='appendices'>Dodatky</localization>
     <localization string-id='section'>Sekce</localization>
     <localization string-id='subsection'>Podsekce</localization>
     <localization string-id='subsubsection'>Podpodsekce</localization>


### PR DESCRIPTION
Translate Appendices, and actually a more Czech less Czenglish translation of Appendix to begin with.  I have seen both in use, but Dodatek is definitely more Czech and less a loan-word.  Plus a Czech person might more think of going to the hospital with an appendix than finding it in a book (though a medical book might have an appendix on the appendix).