### PR TITLE
Sage: load special MathJax3 findScript config when sage is used

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11085,7 +11085,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>  options: {&#xa;</xsl:text>
         <xsl:text>    ignoreHtmlClass: "tex2jax_ignore",&#xa;</xsl:text>
         <xsl:text>    processHtmlClass: "has_am",&#xa;</xsl:text>
-        <xsl:if test="$b-has-webwork-reps">
+        <xsl:if test="$b-has-webwork-reps or $b-has-sage">
             <xsl:text>    renderActions: {&#xa;</xsl:text>
             <xsl:text>        findScript: [10, function (doc) {&#xa;</xsl:text>
             <xsl:text>            document.querySelectorAll('script[type^="math/tex"]').forEach(function(node) {&#xa;</xsl:text>


### PR DESCRIPTION
Before this, try `pretty_print(html("$a^2$"))` in a Sage cell from `section-sage-cells.html` of the sample article. With MJ3, you will see no output. After this, you will see the output math.

With each test, make sure to clear your cache. The MathJax config from a previous run may stick around.