### PR TITLE
Update mj-sre-page.js to work with MathJax 3.2.0

### DIFF
--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -139,7 +139,7 @@ function action(state, code, setup = null) {
 //
 //  States for PreTeXt actions
 //
-newState('PRETEXT', STATE.COMPILED + 10);
+newState('PRETEXT', STATE.METRICS + 10);
 newState('PRETEXTACTION', STATE.PRETEXT + 10);
 
 //

--- a/script/mjsre/package.json
+++ b/script/mjsre/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "mathjax-full": "^3.1.4",
-    "speech-rule-engine": "^3.1.0-beta.4",
+    "mathjax-full": "^3.2.0",
+    "speech-rule-engine": "^3.3.3",
     "yargs": "^15.4.1"
   }
 }


### PR DESCRIPTION
Incorporates the fix from @dpvc for MathJax 3.2.0 and updates packages.json to current versions.