### PR TITLE
WeBWorK: allow Make Randomize button even when there is no answer

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9918,7 +9918,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- interactive? This includes problems with only essay fields.  -->
         <!-- NB: for Runestone, we may want to allow essay answer fields  -->
         <!-- to make live problems, and Runestone records submissions.    -->
-        <xsl:when test="($b-static = 'yes') or not(static/answer or static/task/answer or static/stage/answer)">
+        <xsl:when test="($b-static = 'yes')">
             <xsl:apply-templates select="static" mode="exercise-components">
                 <xsl:with-param name="b-original"      select="$b-original"/>
                 <xsl:with-param name="b-has-statement" select="true()"/>


### PR DESCRIPTION
The code I am removing here prevented the Make Randomize button from showing when there was no answer field in the problem. This seemed to make sense at the time. But:

1. There are applet-based problems where you do submit answers even though there is no answer input field.
2. Maybe WW could be used someday to just show random versions of something even though there is nothing to submit.
3. Really "Make Randomize" should only be prevented when there just are no new random versions. And this did not do that.

Because of 1, @drgrice1 and I were seeing a problem without "Make Randomize" that should have had it.