### PR TITLE
WeBWorK: leave open correct scaffold sections

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -385,7 +385,7 @@
         <xsl:with-param name="block-title">Scaffold</xsl:with-param>
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:call-template>
-    <xsl:text>Scaffold::Begin(numbered=>1);</xsl:text>
+    <xsl:text>Scaffold::Begin(is_open => "correct_or_first_incorrect", numbered => 1);</xsl:text>
     <xsl:if test="$b-human-readable">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>


### PR DESCRIPTION
Suppose you have a webwork with tasks 1 and 2. When the problem is made interactive, task 1 is open and task 2 is collapsed and you may not open it.

Previously, when you correctly answer task 1, then of course task 2 opens. But task 1 will collapse. (You can open it back up by clicking on it.)

This change leaves task 1 open when you move on to task 2. I think this is better behavior for live problems in a PreTeXt book. The user can collapse task 1 if they want to.

To see before and after, try the sample chapter problem here:
Exercise 2.2: Solving Quadratic Equations 
https://pretextbook.org/examples/webwork/sample-chapter/html/section-2.html#quadratic-equation

And then after this commit, you should see the behavior described above.