### PR TITLE
EPUB: Add @id to span containing MathJax output 

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -268,6 +268,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>We like to put <init>URL</init>s into footnotes, especially for formats like this where they may not be active.  This output is from <url href="https://pretextbook.org"><pretext/></url><fn><c>pretextbook.org</c></fn>.</p>
 
+	    <p>We make a reference to some math in another chapter
+	    <xref ref="equation-conclude" /> in order to test that
+	    validation works for this.</p>
+
             <exercise>
                 <statement>
                     <p>A sample exercise, where a <tag>hint</tag> and a <tag>solution</tag> should be visible (rather than in a knowl).</p>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -1164,6 +1164,9 @@ width: 100%
                 </xsl:when>
             </xsl:choose>
         </xsl:attribute>
+	<xsl:attribute name="id">
+	    <xsl:text>mjx-eqn:</xsl:text><xsl:value-of select="$id" />
+	</xsl:attribute>
         <!-- Finally, drop a "svg" element, "math" element, or ASCII speech -->
         <xsl:choose>
             <xsl:when test="$math.format = 'svg'">


### PR DESCRIPTION
With this three-line addition, _Applied Combinatorics_ passes `epubcheck`. My EPUB aggregator distributor would not distribute the book to certain channels unless it passed `epubcheck`. Added something to the sampler for testing purposes as well. In Apple Books and Calibre, the `a` does properly jump back to an earlier page with the `@id` on the `span` containing math.