### PR TITLE
Script: verify existence of command-line-supplied config file

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -34,7 +34,7 @@ import pretext as ptx
 
 def verify_input_file(f, file_type):
     """Verify file exists, or raise error.  Return absolute path"""
-    # file_type is 'source' or 'publisher'
+    # file_type is 'source' or 'publisher' or 'config'
     #    the source gets fed into the lxml routines and so we
     #    let Python deal with separators, etc.  However the
     #    publisher file is passed around until an XSL stylesheet
@@ -49,13 +49,23 @@ def verify_input_file(f, file_type):
         file_descriptor = 'XML source'
     elif file_type == 'publisher':
         file_descriptor = 'publisher'
+    elif file_type == 'config':
+        file_descriptor = 'executables configuration'
     else:
-        msg = "input file verification should receive 'source' or 'publisher' parameter, not '{}'"
+        msg = "input file verification should receive 'source' or 'publisher' or 'config' parameter, not '{}'"
         raise ValueError(msg.format(file_type))
 
     ptx._verbose('verifying and expanding {} file: {}'.format(file_descriptor, f))
     if not(os.path.isfile(f)):
-        raise ValueError('file {} does not exist'.format(f))
+        msg = '{} file {}{} does not exist'.format(
+            file_descriptor, f,
+            ' from the command line' if file_type == 'config' else ''
+        )
+        if file_type == 'config':
+            print('PTX:WARNING: {}'.format(msg))
+            return None
+        else:
+            raise ValueError(msg)
     absf = os.path.abspath(f)
     if file_type == 'publisher':
         absf = absf.replace(os.sep, '/')
@@ -119,6 +129,8 @@ def get_executables(arg_supplied_config_file):
     # Try to read old version, but prefer new version
     stale_user_config_file = os.path.join(ptx_dir, 'user', 'mbx.cfg')
     config_file_list = [default_config_file, stale_user_config_file, user_config_file]
+    if (arg_supplied_config_file):
+        arg_supplied_config_file = verify_input_file(arg_supplied_config_file, 'config')
     if (arg_supplied_config_file):
         config_file_list.append(arg_supplied_config_file)
 


### PR DESCRIPTION
I included "from the command line" in the file-does-not-exist warning message for `file_type == 'config'` (even though files for both `file_type == 'source'` and `file_type == 'publisher'`  also come from the command line but don't include that extra bit in their logging messages) because the most likely name for a user-supplied config file is `pretext.cfg`. So a warning message that just says "executables configuration file pretext.cfg does not exist" would be ambiguous without the "from the command line" part because there are two other pretext.cfg files it could be talking about: pretext/pretext.cfg and user/pretext.cfg from the mathbook path.