### PR TITLE
Exercisegroup: within a worksheet page, handle numbering specially

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -11219,6 +11219,44 @@ the xsltproc executable.
                     </sidebyside>
                 </page>
             </worksheet>
+
+            <worksheet>
+                <title>Exercisegroups in a Worksheet</title>
+                <introduction>
+                    <p>
+                        This worksheet tests what happens when a worksheet contains exercisegroups.
+                    </p>
+                </introduction>
+                <page>
+                    <exercisegroup cols="2">
+                        <introduction>
+                            <p>
+                                Find the derivative of each function.
+                            </p>
+                        </introduction>
+                        <exercise>
+                            <p>
+                                <m>x^2</m>
+                            </p>
+                        </exercise>
+                        <exercise>
+                            <p>
+                                <m>2^x</m>
+                            </p>
+                        </exercise>
+                        <exercise>
+                            <p>
+                                <m>\log_2(x)</m>
+                            </p>
+                        </exercise>
+                        <exercise>
+                            <p>
+                                <m>2x</m>
+                            </p>
+                        </exercise>
+                    </exercisegroup>
+                </page>
+            </worksheet>
         </section>
 
         <section xml:id="exercises-single">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5803,7 +5803,14 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Structure Numbers: Exercise Groups -->
 <!-- An exercisegroup gets it structure number from the parent exercises -->
 <xsl:template match="exercisegroup" mode="structure-number">
-    <xsl:apply-templates select="parent::*" mode="number" />
+    <xsl:choose>
+        <xsl:when test="parent::page">
+            <xsl:apply-templates select="parent::page/parent::*" mode="number" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="parent::*" mode="number" />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Hints, answers, solutions get structure number from parent       -->


### PR DESCRIPTION
There is a special template for the number of an exercisegroup, but it fails right now when the eg is inside a worksheet page. This makes it look one level above the page to get the right structure number.

Two commits: first one adds an offending example to the sample article. Next one fixes the issue.