### PR TITLE
EPUB: Bug fixes for outcomes and conclusion 

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -43,30 +43,27 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <title>One</title>
 
             <p>The quick brown fox jumps over the lazy dog.</p>
-
             <p>Some test cross-references:<ul>
-                <li>To the next chapter: <xref ref="nonsense-chapter"/></li>
-                <li>To a figure much later: <xref ref="figure-cubic-polynomial"/></li>
-            </ul></p>
-
+	        <li>To the next chapter: <xref ref="nonsense-chapter"/></li>
+		<li>To a figure much later: <xref ref="figure-cubic-polynomial"/></li>
+	    </ul></p>
         </chapter>
-
         <chapter xml:id="nonsense-chapter">
             <title>Two</title>
-            <introduction><p>This is the introduction to the chapter.</p></introduction>
+            <introduction>
+                <p>This is the introduction to the chapter.</p>
+            </introduction>
             <section>
                 <title>A silly section.</title>
                 <p>This section just exists so that we can add <tag>introduction</tag> and <tag>conclusion</tag> tags to this chapter.
                 </p>
-            <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ultricies purus sit amet rutrum dictum. Donec sit amet ligula quis orci vestibulum tempor id in erat. Ut ut placerat lacus, sit amet feugiat lorem. Pellentesque sodales risus at eros malesuada, eget ultrices est consectetur. Praesent fermentum, ligula sit amet fermentum varius, elit eros imperdiet lectus, tempus condimentum quam elit in elit. Sed molestie mauris sem, sed laoreet elit iaculis ut. In mattis blandit ex, nec rutrum purus ullamcorper eget. Nullam maximus magna non elit euismod, non ornare nisl porttitor. Pellentesque commodo tempus viverra.</p>
-
-            <p>Curabitur ac hendrerit ligula. Aenean vitae nunc id elit convallis efficitur. Sed ultricies ut justo quis elementum. Sed eget eros venenatis, pellentesque risus sed, fermentum mi. Proin ipsum arcu, porta nec sem sit amet, sollicitudin faucibus erat. Quisque lacus lectus, pellentesque ut imperdiet sed, euismod vitae nibh. Donec dolor diam, elementum ac pharetra vitae, volutpat mollis augue.</p>
-            <aside>
-                <title>Look at this!</title>
-                <p>This is an aside. Please don't let it distract you.</p>
-            </aside>
-
-            <p>Maecenas ex enim, lobortis et blandit sit amet, pretium in ante. Sed mollis sollicitudin nibh non consectetur. Vestibulum eget tortor sit amet felis iaculis fermentum. Sed eu nisl a urna cursus congue at nec nulla. Mauris lacinia molestie tristique. Maecenas aliquet rutrum venenatis. Vivamus quis metus sit amet est feugiat facilisis quis et massa. Aenean dui sem, dapibus at imperdiet ac, auctor sit amet arcu. Vestibulum eget porttitor est. Aliquam id pellentesque quam, vitae rhoncus metus. In congue condimentum malesuada. Mauris in condimentum eros, eget mattis nibh. Praesent et ex porttitor, lobortis nibh sed, cursus ante. Suspendisse dapibus vel risus eu pellentesque. </p>
+                <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ultricies purus sit amet rutrum dictum. Donec sit amet ligula quis orci vestibulum tempor id in erat. Ut ut placerat lacus, sit amet feugiat lorem. Pellentesque sodales risus at eros malesuada, eget ultrices est consectetur. Praesent fermentum, ligula sit amet fermentum varius, elit eros imperdiet lectus, tempus condimentum quam elit in elit. Sed molestie mauris sem, sed laoreet elit iaculis ut. In mattis blandit ex, nec rutrum purus ullamcorper eget. Nullam maximus magna non elit euismod, non ornare nisl porttitor. Pellentesque commodo tempus viverra.</p>
+                <p>Curabitur ac hendrerit ligula. Aenean vitae nunc id elit convallis efficitur. Sed ultricies ut justo quis elementum. Sed eget eros venenatis, pellentesque risus sed, fermentum mi. Proin ipsum arcu, porta nec sem sit amet, sollicitudin faucibus erat. Quisque lacus lectus, pellentesque ut imperdiet sed, euismod vitae nibh. Donec dolor diam, elementum ac pharetra vitae, volutpat mollis augue.</p>
+                <aside>
+                    <title>Look at this!</title>
+                    <p>This is an aside. Please don't let it distract you.</p>
+                </aside>
+                <p>Maecenas ex enim, lobortis et blandit sit amet, pretium in ante. Sed mollis sollicitudin nibh non consectetur. Vestibulum eget tortor sit amet felis iaculis fermentum. Sed eu nisl a urna cursus congue at nec nulla. Mauris lacinia molestie tristique. Maecenas aliquet rutrum venenatis. Vivamus quis metus sit amet est feugiat facilisis quis et massa. Aenean dui sem, dapibus at imperdiet ac, auctor sit amet arcu. Vestibulum eget porttitor est. Aliquam id pellentesque quam, vitae rhoncus metus. In congue condimentum malesuada. Mauris in condimentum eros, eget mattis nibh. Praesent et ex porttitor, lobortis nibh sed, cursus ante. Suspendisse dapibus vel risus eu pellentesque. </p>
             </section>
             <section>
                 <title>A Section with Subsections</title>
@@ -87,9 +84,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <statement>
                         <p>A lone exercise in an <c>exercises</c> division that is a peer of a <c>section</c>.</p>
                     </statement>
-		    <hint><p>A little suggestion.</p></hint>
-		    <answer><p><m>y=x^2</m></p></answer>
-		    <solution><p>Maecenas ex enim, lobortis et blandit
+                    <hint>
+                        <p>A little suggestion.</p>
+                    </hint>
+                    <answer>
+                        <p>
+                            <m>y=x^2</m>
+                        </p>
+                    </answer>
+                    <solution>
+                        <p>Maecenas ex enim, lobortis et blandit
 		    sit amet, pretium in ante. Sed mollis sollicitudin
 		    nibh non consectetur. Vestibulum eget tortor sit
 		    amet felis iaculis fermentum. Sed eu nisl a urna
@@ -104,7 +108,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 		    condimentum eros, eget mattis nibh. Praesent et ex
 		    porttitor, lobortis nibh sed, cursus
 		    ante. Suspendisse dapibus vel risus eu
-		    pellentesque.</p></solution>
+		    pellentesque.</p>
+                    </solution>
                 </exercise>
             </exercises>
             <conclusion>
@@ -112,76 +117,65 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <p>This is the conclusion.</p>
             </conclusion>
         </chapter>
-
         <chapter>
-            <title>A Bit of Math</title>
-
-            <p><idx>Diophantine equation</idx>This paragraph has some inline math, a Diophantine equation, <m>x^2 + \doubler{y^2} = z^2</m>.  And some display math about infinite series: <me>\sum_{n=1}^\infty\,\frac{1}{n^2} = \frac{\pi^2}{6}.</me>  Look at the XML source to see how <latex /> macros are employed.</p>
-
-            <p>And a bit of multi-line display math:<mdn>
-                <mrow xml:id="equation-use-FTC">\frac{d}{dx}\definiteintegral{a}{x}{f(t)}{t}&amp;=\frac{d}{dx}\left(F(x)-F(a)\right)</mrow>
-                <mrow number="no">&amp;=\frac{d}{dx}F(x)-\frac{d}{dx}F(a)</mrow>
-                <mrow xml:id="equation-conclude">&amp;=f(x)-0 = f(x)</mrow>
-            </mdn>.</p>
-
-            <p>And multi-line math with an embedded cross-reference to a figure:<md>
-                <mrow>x^2 + y^2 &amp;= z^2&amp;&amp;<xref ref="complete-graph"/></mrow>
-                <mrow>a^2 + b^2 &amp;= c^2&amp;&amp;</mrow>
-            </md></p>
-
+            <title>A Bit of Math <m>y=mx+b</m></title>
+            <shorttitle>A Bit of Math y=mx+b</shorttitle>
+            <p><idx>Diophantine equation</idx>This paragraph has some inline math, a Diophantine equation, <m>x^2 + \doubler{y^2} = z^2</m>.  And some display math about infinite series: <me>\sum_{n=1}^\infty\,\frac{1}{n^2} = \frac{\pi^2}{6}.</me>  Look at the XML source to see how <latex/> macros are employed.</p>
+            <p>And a bit of multi-line display math:<mdn><mrow xml:id="equation-use-FTC">\frac{d}{dx}\definiteintegral{a}{x}{f(t)}{t}&amp;=\frac{d}{dx}\left(F(x)-F(a)\right)</mrow><mrow number="no">&amp;=\frac{d}{dx}F(x)-\frac{d}{dx}F(a)</mrow><mrow xml:id="equation-conclude">&amp;=f(x)-0 = f(x)</mrow></mdn>.</p>
+            <p>And multi-line math with an embedded cross-reference to a figure:<md><mrow>x^2 + y^2 &amp;= z^2&amp;&amp;<xref ref="complete-graph"/></mrow><mrow>a^2 + b^2 &amp;= c^2&amp;&amp;</mrow></md></p>
             <p>Nice.</p>
-	    <theorem>
-	      <title>Fundamental Theorem of Calculus</title>
-	      <creator>Newton, Leibniz</creator>
-	      <statement>
-		<p>Let <m>f</m> be a continuous function on the
+            <theorem xml:id="FTC">
+                <title>Fundamental Theorem of Calculus</title>
+                <creator>Newton, Leibniz</creator>
+                <statement>
+                    <p>Let <m>f</m> be a continuous function on the
 		interval <m>[a,b]</m>. If <m>F</m> is an
 		antiderivative for <m>f</m> on <m>[a,b]</m>, then
 		<me>\int_a^b f(t)\, dt = F(b)-F(a)</me>.</p>
-	      </statement>
-	    </theorem>
+                </statement>
+            </theorem>
+            <outcomes>
+                <ul>
+                    <li>You have read the statement of <xref ref="FTC" text="title"/>.</li>
+                    <li>
+		You have seen multiline math, and it is awesome.
+	      </li>
+                </ul>
+            </outcomes>
         </chapter>
-
         <chapter>
             <title>Some Images</title>
-
-            <p><idx>Portable Network Graphics (PNG)</idx><idx><h>PNG</h><see>Portable Network Graphics</see></idx>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
-
-            <figure xml:id="figure-cubic-polynomial">
-                <caption>A cubic polynomial and its derivative</caption>
-                <image source="cubic-function.png" width="60%"/>
-            </figure>
-
-            <p>A Scalable Vector Graphics (SVG) image created externally in Sage and then included here as a vector image (no file extension given).</p>
-
-            <figure xml:id="complete-graph" width="20%">
-                <caption>A complete graph on 16 vertices</caption>
-                <image source="complete-graph" width="70%"/>
-            </figure>
-
-            <p>A Scalable Vector Graphics (SVG) image described by Sage commands, which is produced by the <c>pretext</c> script.</p>
-
-            <figure xml:id="figure-sage-multigraph">
-                <caption>A Sage multigraph of a sentence</caption>
-                <image xml:id="sageplot-sentence-multigraph" width="50%">
-                    <sageplot>
-                    stnc = 'I am a cool multiedge graph with loops'
-                    g = DiGraph({}, loops=True, multiedges=True)
-                    for a,b in [(stnc[i], stnc[i+1]) for i in xrange(len(stnc)-1)]:
-                       g.add_edge(a, b, b)
-                    g.plot(color_by_label=True, edge_style='solid', figsize=(8,8))
-                    </sageplot>
-                </image>
-            </figure>
-
-            <!-- http://www.texample.net/media/tikz/examples/TEX/noise-shaper.tex -->
-            <figure xml:id="figure-tikz-electronics">
-                <caption>TikZ Electronics Diagram</caption>
-                <image xml:id="tikz-electronics">
-                    <description>A pile of electronic components wired together</description>
-                    <latex-image>
-                    <!-- CDATA prevents certain LaTeX code from being interpreted as xml -->
-                    <![CDATA[\tikzset{%
+            <section>
+                <title>Graphics formats</title>
+                <p><idx>Portable Network Graphics (PNG)</idx><idx><h>PNG</h><see>Portable Network Graphics</see></idx>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
+                <figure xml:id="figure-cubic-polynomial">
+                    <caption>A cubic polynomial and its derivative</caption>
+                    <image source="cubic-function.png" width="60%"/>
+                </figure>
+                <p>A Scalable Vector Graphics (SVG) image created externally in Sage and then included here as a vector image (no file extension given).</p>
+                <figure xml:id="complete-graph">
+                    <caption>A complete graph on 16 vertices</caption>
+                    <image source="complete-graph" width="70%"/>
+                </figure>
+                <p>A Scalable Vector Graphics (SVG) image described by Sage commands, which is produced by the <c>pretext</c> script.</p>
+                <figure xml:id="figure-sage-multigraph">
+                    <caption>A Sage multigraph of a sentence</caption>
+                    <image xml:id="sageplot-sentence-multigraph" width="50%">
+                        <sageplot>
+			    stnc = 'I am a cool multiedge graph with loops'
+			    g = DiGraph({}, loops=True, multiedges=True)
+			    for a,b in [(stnc[i], stnc[i+1]) for i in xrange(len(stnc)-1)]:
+			        g.add_edge(a, b, b)
+			    g.plot(color_by_label=True, edge_style='solid', figsize=(8,8))
+			</sageplot>
+                    </image>
+                </figure>
+                <!-- http://www.texample.net/media/tikz/examples/TEX/noise-shaper.tex -->
+                <figure xml:id="figure-tikz-electronics">
+                    <caption>TikZ Electronics Diagram</caption>
+                    <image xml:id="tikz-electronics">
+                        <description>A pile of electronic components wired together</description>
+                        <latex-image><!-- CDATA prevents certain LaTeX code from being interpreted as xml --><![CDATA[\tikzset{%
                       block/.style    = {draw, thick, rectangle, minimum height = 3em,
                         minimum width = 3em},
                       sum/.style      = {draw, circle, node distance = 2cm}, % Adder
@@ -257,33 +251,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         \node at (-0.5,1) [above=5mm, right=0mm] {\textsc{first-order noise shaper}};
                         \draw [color=gray,thick](-0.5,-9) rectangle (12.5,-5);
                         \node at (-0.5,-9) [below=5mm, right=0mm] {\textsc{second-order noise shaper}};
-                    \end{tikzpicture}]]>
-                    </latex-image>
-                </image>
-            </figure>
-
-            <p>We repeat an image created from an external file, because the EPUB format only wants the file noted once.</p>
-
-            <image source="complete-graph" width="70%"/>
-
-            <p>We like to put <init>URL</init>s into footnotes, especially for formats like this where they may not be active.  This output is from <url href="https://pretextbook.org"><pretext/></url><fn><c>pretextbook.org</c></fn>.</p>
-
-            <p>We make a reference to some math in another chapter
-            <xref ref="equation-conclude" /> in order to test that
+			\end{tikzpicture}
+		    ]]></latex-image>
+                    </image>
+                </figure>
+            </section>
+            <section>
+                <title>Additional stress testing</title>
+                <p>We repeat an image created from an external file, because the EPUB format only wants the file noted once.</p>
+                <image source="complete-graph" width="70%"/>
+                <p>We like to put <init>URL</init>s into footnotes, especially for formats like this where they may not be active.  This output is from <url href="https://pretextbook.org"><pretext/></url><fn><c>pretextbook.org</c></fn>.</p>
+                <p>We make a reference to some math in another chapter
+            <xref ref="equation-conclude"/> in order to test that
             validation works for this.</p>
-
-            <exercise>
-                <statement>
-                    <p>A sample exercise, where a <tag>hint</tag> and a <tag>solution</tag> should be visible (rather than in a knowl).</p>
-                </statement>
-                <hint>
-                    <p>Just a little help.</p>
-                </hint>
-                <solution>
-                    <p>The whole story with all the details.</p>
-                </solution>
-            </exercise>
-
+                <exercise>
+                    <statement>
+                        <p>A sample exercise, where a <tag>hint</tag> and a <tag>solution</tag> should be visible (rather than in a knowl).</p>
+                    </statement>
+                    <hint>
+                        <p>Just a little help.</p>
+                    </hint>
+                    <solution>
+                        <p>The whole story with all the details.</p>
+                    </solution>
+                </exercise>
+            </section>
+            <conclusion xml:id="concl-followed-by-outcomes">
+                <p>This is a <tag>conclusion</tag>. We will follow it with
+	    an <tag>outcomes</tag>.</p>
+            </conclusion>
+            <outcomes>
+                <title>The really awesome things we've done!</title>
+                <ol>
+                    <li>We just tested if we get this list of outcomes.</li>
+                </ol>
+            </outcomes>
         </chapter>
         <backmatter>
             <appendix>
@@ -295,6 +297,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <index-list/>
             </index>
         </backmatter>
-
     </book>
 </pretext>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3683,7 +3683,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Some items have default titles that make sense         -->
 <!-- Typically these are one-off subdivisions (eg preface), -->
 <!-- or repeated generic divisions (eg exercises)           -->
-<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|references|glossary|exercises|worksheet|reading-questions|solutions|backmatter|index-part|index[index-list]|case" mode="has-default-title">
+<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|references|glossary|exercises|worksheet|reading-questions|solutions|conclusion|outcomes|backmatter|index-part|index[index-list]|case" mode="has-default-title">
     <xsl:text>true</xsl:text>
 </xsl:template>
 <xsl:template match="*" mode="has-default-title">

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -217,7 +217,7 @@
 <!-- EPUB conversion with "chapter" having "section" it gets an -->
 <!-- HTML page of its own as part of the "summary" hack.  Ditto -->
 <!-- for "outcomes" which might appear in a different order.    -->
-<xsl:template match="&STRUCTURAL;|chapter/conclusion|chapter/outcomes" mode="file-wrap">
+<xsl:template match="&STRUCTURAL;|chapter/conclusion|chapter/outcomes[preceding-sibling::section]" mode="file-wrap">
     <xsl:param name="content" />
     <xsl:variable name="file">
         <xsl:value-of select="$content-dir" />
@@ -267,7 +267,7 @@
 <!-- This seems a bit dangerous, but this content is fairly small -->
 <!-- and they are going into their own files.  So it seems the    -->
 <!-- right thing to do, while making minimal changes elsewhere.   -->
-<xsl:template match="chapter/conclusion|chapter/outcomes" mode="containing-filename">
+<xsl:template match="chapter/conclusion|chapter/outcomes[preceding-sibling::section]" mode="containing-filename">
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>.xhtml</xsl:text>
 </xsl:template>
@@ -302,7 +302,7 @@
         </xsl:apply-templates>
     </xsl:if>
     <xsl:if test="outcomes">
-        <xsl:apply-templates select="conclusion" mode="file-wrap">
+        <xsl:apply-templates select="outcomes" mode="file-wrap">
             <xsl:with-param name="content">
                 <xsl:apply-templates select="outcomes"/>
             </xsl:with-param>
@@ -484,7 +484,7 @@
 <!-- recurse into contents for image files, etc    -->
 <!-- See "Core Media Type Resources"               -->
 <!-- Add to spine identically                      -->
-<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|chapter/conclusion|chapter/outcomes|appendix|index|section|exercises|references|solutions" mode="manifest">
+<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|chapter/conclusion|chapter/outcomes[preceding-sibling::section]|appendix|index|section|exercises|references|solutions" mode="manifest">
     <!-- Annotate manifest entries -->
     <xsl:comment>
         <xsl:apply-templates select="." mode="long-name" />
@@ -595,7 +595,7 @@
 <!-- Specialized divisions will only become files in the manifest at     -->
 <!-- chunk level 2, in other words, peers of chapters or sections        -->
 <!-- (book or chapter/appendix as parent, respectively)                  -->
-<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|references[parent::book|parent::chapter|parent::appendix]|solutions[parent::book|parent::chapter|parent::appendix]|glossary[parent::book|parent::chapter|parent::appendix]|conclusion[parent::chapter]|outcomes[parent::chapter]" mode="spine">
+<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|references[parent::book|parent::chapter|parent::appendix]|solutions[parent::book|parent::chapter|parent::appendix]|glossary[parent::book|parent::chapter|parent::appendix]|conclusion[parent::chapter]|outcomes[preceding-sibling::section]" mode="spine">
     <xsl:element name="itemref" xmlns="http://www.idpf.org/2007/opf">
         <xsl:attribute name="idref">
             <xsl:apply-templates select="." mode="html-id" />


### PR DESCRIPTION
* Add `outcomes` and `conclusion` to the things that have default titles, which means we don't have to check for `title` before writing the `head/title` into the EPUB XHTML.
* Refine the process of identifying `outcomes` that need to be processed separately for the manifest.
* Add things to the sampler so that we can monitor for this. There's probably a couple more configurations that need testing, but I now can successfully see all the content in the EPUB that is generated.
* Sampler had to be run through `xmllint` because the `latex-image` was horribly confusing my editor's indentation system. This results in a changelog that looks bigger than it is. (Part of this was needing to add a `section` to a `chapter` in order to do more testing.)