### PR TITLE
pass through ol label from slides to revealjs html

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -342,6 +342,9 @@ dfn {
 
 <xsl:template match="ol">
   <ol>
+    <xsl:if test="@label='a'">
+      <xsl:attribute name="type">a</xsl:attribute>
+    </xsl:if>
     <xsl:apply-templates/>
   </ol>
 </xsl:template>


### PR DESCRIPTION
This is an untested hotfix to preserve list labeling in RevealJS builds - I suspect it's replicating logic from the rest of pretext that converts PTX `@label` to HTML `@type`, but I wasn't sure if Andrew wrote things this way intentionally when implementing lists.