### PR TITLE
EPUB: Resolve svg/mathml property in manifest once and for all, pick up missing frontmatter bits

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -37,6 +37,33 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <personname>Rob Beezer</personname>
                 </author>
             </titlepage>
+	    <colophon>
+		<website>
+		    <name>PreTeXt</name>
+		    <address>https://www.pretextbook.org</address>
+		</website>
+		<copyright>
+		    <year>2016<ndash />2021</year>
+		    <holder>Robert A. Beezer</holder>
+		</copyright>
+	    </colophon>
+	    <biography>
+		<title>Biographical sketch with title</title>
+		<p>This is about the author and has a title.</p>
+	    </biography>
+	    <biography>
+		<p>This sketch doesn't actually have a title in the
+		<pretext /> source.</p>
+	    </biography>
+	    <dedication>
+		<p>To all those who like reflowable electronic
+		books.</p>
+	    </dedication>
+	    <acknowledgement>
+		<p>Mitchel T. Keller has added a number of things to
+		this sampler to continue to stress out the EPUB
+		conversion and make sure it's all working right.</p>
+	    </acknowledgement>
         </frontmatter>
 
         <chapter>

--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -80,7 +80,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
         <chapter xml:id="nonsense-chapter">
             <title>Two</title>
-            <introduction><p>This is the introduction to the chapter.</p></introduction>
+            <introduction>
+                <p>This is the introduction to the chapter. We put
+		some math <me>\int_a^b f(t)\, dt</me> in here for
+		validation purposes.</p>
+            </introduction>
             <section>
                 <title>A silly section.</title>
                 <p>This section just exists so that we can add <tag>introduction</tag> and <tag>conclusion</tag> tags to this chapter.
@@ -170,45 +174,47 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </chapter>
 
         <chapter>
-            <title>Some Images</title>
-
-            <p><idx>Portable Network Graphics (PNG)</idx><idx><h>PNG</h><see>Portable Network Graphics</see></idx>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
-
-            <figure xml:id="figure-cubic-polynomial">
-                <caption>A cubic polynomial and its derivative</caption>
-                <image source="cubic-function.png" width="60%"/>
-            </figure>
-
-            <p>A Scalable Vector Graphics (SVG) image created externally in Sage and then included here as a vector image (no file extension given).</p>
-
-            <figure xml:id="complete-graph" width="20%">
-                <caption>A complete graph on 16 vertices</caption>
-                <image source="complete-graph" width="70%"/>
-            </figure>
-
-            <p>A Scalable Vector Graphics (SVG) image described by Sage commands, which is produced by the <c>pretext</c> script.</p>
-
-            <figure xml:id="figure-sage-multigraph">
-                <caption>A Sage multigraph of a sentence</caption>
-                <image xml:id="sageplot-sentence-multigraph" width="50%">
-                    <sageplot>
-                    stnc = 'I am a cool multiedge graph with loops'
-                    g = DiGraph({}, loops=True, multiedges=True)
-                    for a,b in [(stnc[i], stnc[i+1]) for i in xrange(len(stnc)-1)]:
-                       g.add_edge(a, b, b)
-                    g.plot(color_by_label=True, edge_style='solid', figsize=(8,8))
-                    </sageplot>
-                </image>
-            </figure>
-
-            <!-- http://www.texample.net/media/tikz/examples/TEX/noise-shaper.tex -->
-            <figure xml:id="figure-tikz-electronics">
-                <caption>TikZ Electronics Diagram</caption>
-                <image xml:id="tikz-electronics">
-                    <description>A pile of electronic components wired together</description>
-                    <latex-image>
-                    <!-- CDATA prevents certain LaTeX code from being interpreted as xml -->
-                    <![CDATA[\tikzset{%
+            <title>Some Images <m>ax^2+bx+c=0</m></title>
+            <shorttitle>Some Imagex ax^2+bx+c=0</shorttitle>
+	    <objectives>
+		<ul>
+		    <li>To discuss formats for graphics</li>
+		    <li>To stress test the EPUB conversion with
+		    <m>y=f'(x)</m> math in here</li>
+		</ul>
+	    </objectives>
+            <section>
+                <title>Graphics formats <m>f'(x)</m></title>
+		<shorttitle>Graphics formats f'(x)</shorttitle>
+                <p><idx>Portable Network Graphics (PNG)</idx><idx><h>PNG</h><see>Portable Network Graphics</see></idx>A Portable Network Graphics (PNG) image created externally in Sage and then included directly here.</p>
+                <figure xml:id="figure-cubic-polynomial">
+                    <caption>A cubic polynomial and its derivative</caption>
+                    <image source="cubic-function.png" width="60%"/>
+                </figure>
+                <p>A Scalable Vector Graphics (SVG) image created externally in Sage and then included here as a vector image (no file extension given).</p>
+                <figure xml:id="complete-graph">
+                    <caption>A complete graph on 16 vertices</caption>
+                    <image source="complete-graph" width="70%"/>
+                </figure>
+                <p>A Scalable Vector Graphics (SVG) image described by Sage commands, which is produced by the <c>pretext</c> script.</p>
+                <figure xml:id="figure-sage-multigraph">
+                    <caption>A Sage multigraph of a sentence</caption>
+                    <image xml:id="sageplot-sentence-multigraph" width="50%">
+                        <sageplot>
+                            stnc = 'I am a cool multiedge graph with loops'
+                            g = DiGraph({}, loops=True, multiedges=True)
+                            for a,b in [(stnc[i], stnc[i+1]) for i in xrange(len(stnc)-1)]:
+                                g.add_edge(a, b, b)
+                            g.plot(color_by_label=True, edge_style='solid', figsize=(8,8))
+                        </sageplot>
+                    </image>
+                </figure>
+                <!-- http://www.texample.net/media/tikz/examples/TEX/noise-shaper.tex -->
+                <figure xml:id="figure-tikz-electronics">
+                    <caption>TikZ Electronics Diagram</caption>
+                    <image xml:id="tikz-electronics">
+                        <description>A pile of electronic components wired together</description>
+                        <latex-image><!-- CDATA prevents certain LaTeX code from being interpreted as xml --><![CDATA[\tikzset{%
                       block/.style    = {draw, thick, rectangle, minimum height = 3em,
                         minimum width = 3em},
                       sum/.style      = {draw, circle, node distance = 2cm}, % Adder
@@ -284,43 +290,62 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         \node at (-0.5,1) [above=5mm, right=0mm] {\textsc{first-order noise shaper}};
                         \draw [color=gray,thick](-0.5,-9) rectangle (12.5,-5);
                         \node at (-0.5,-9) [below=5mm, right=0mm] {\textsc{second-order noise shaper}};
-                    \end{tikzpicture}]]>
-                    </latex-image>
-                </image>
-            </figure>
-
-            <p>We repeat an image created from an external file, because the EPUB format only wants the file noted once.</p>
-
-            <image source="complete-graph" width="70%"/>
-
-            <p>We like to put <init>URL</init>s into footnotes, especially for formats like this where they may not be active.  This output is from <url href="https://pretextbook.org"><pretext/></url><fn><c>pretextbook.org</c></fn>.</p>
-
-            <p>We make a reference to some math in another chapter
-            <xref ref="equation-conclude" /> in order to test that
+                        \end{tikzpicture}
+                    ]]></latex-image>
+                    </image>
+                </figure>
+            </section>
+            <section>
+                <title>Additional stress testing</title>
+                <p>We repeat an image created from an external file, because the EPUB format only wants the file noted once.</p>
+                <image source="complete-graph" width="70%"/>
+                <p>We like to put <init>URL</init>s into footnotes, especially for formats like this where they may not be active.  This output is from <url href="https://pretextbook.org"><pretext/></url><fn><c>pretextbook.org</c></fn>.</p>
+                <p>We make a reference to some math in another chapter
+            <xref ref="equation-conclude"/> in order to test that
             validation works for this.</p>
-
-            <exercise>
-                <statement>
-                    <p>A sample exercise, where a <tag>hint</tag> and a <tag>solution</tag> should be visible (rather than in a knowl).</p>
-                </statement>
-                <hint>
-                    <p>Just a little help.</p>
-                </hint>
-                <solution>
-                    <p>The whole story with all the details.</p>
-                </solution>
-            </exercise>
-
+                <exercise>
+                    <statement>
+                        <p>A sample exercise, where a <tag>hint</tag> and a <tag>solution</tag> should be visible (rather than in a knowl).</p>
+                    </statement>
+                    <hint>
+                        <p>Just a little help.</p>
+                    </hint>
+                    <solution>
+                        <p>The whole story with all the details.</p>
+                    </solution>
+                </exercise>
+            </section>
+            <conclusion xml:id="concl-followed-by-outcomes">
+                <p>This is a <tag>conclusion</tag>. We will follow it with
+            an <tag>outcomes</tag>.</p>
+            </conclusion>
+            <outcomes>
+                <title>The really awesome things we've done!</title>
+                <ol>
+                    <li>We just tested if we get this list of outcomes.</li>
+                </ol>
+            </outcomes>
         </chapter>
         <backmatter>
             <appendix>
                 <title>Maybe the license</title>
                 <p>Lots of books written in <pretext/> include the terms of their license in an appendix, so let's use this as a test.</p>
             </appendix>
+            <appendix xml:id="figure-list">
+                <title>List of Figures</title>
+                <list-of elements="figure" divisions="chapter subsection" empty="no" />
+	    </appendix>
             <index>
                 <title>Index</title>
                 <index-list/>
             </index>
+	    <colophon>
+		<blockquote><p>This document was authored in <pretext
+		/> to stress test conversion to
+		<init>EPUB</init>. Please do not judge its contents,
+		which randomly has some <m>y=e^{ax+b}</m> math in the
+		rear colophon.</p></blockquote>
+	    </colophon>
         </backmatter>
 
     </book>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1388,6 +1388,7 @@ def epub(xml_source, pub_file, out_file, dest_dir, math_format, stringparams):
     # the EPUB production is parmameterized by how math is produced
     params['mathfile'] = math_representations
     params['math.format'] = math_format
+    params['tmpdir'] = tmp_dir
     if pub_file:
         params['publisher'] = pub_file
     xsltproc(epub_xslt, xml_source, packaging_file, tmp_dir, {**params, **stringparams})

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -484,7 +484,7 @@
 <!-- recurse into contents for image files, etc    -->
 <!-- See "Core Media Type Resources"               -->
 <!-- Add to spine identically                      -->
-<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|chapter/conclusion|chapter/outcomes|appendix|index|section|exercises|references|solutions" mode="manifest">
+<xsl:template match="frontmatter|colophon|biography|dedication|acknowledgement|preface|chapter|chapter/conclusion|chapter/outcomes[preceding-sibling::section]|appendix|index|section|exercises|references|solutions" mode="manifest">
     <!-- Annotate manifest entries -->
     <xsl:comment>
         <xsl:apply-templates select="." mode="long-name" />
@@ -595,7 +595,7 @@
 <!-- Specialized divisions will only become files in the manifest at     -->
 <!-- chunk level 2, in other words, peers of chapters or sections        -->
 <!-- (book or chapter/appendix as parent, respectively)                  -->
-<xsl:template match="frontmatter|colophon|acknowledgement|preface|biography|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|references[parent::book|parent::chapter|parent::appendix]|solutions[parent::book|parent::chapter|parent::appendix]|glossary[parent::book|parent::chapter|parent::appendix]|conclusion[parent::chapter]|outcomes[parent::chapter]" mode="spine">
+<xsl:template match="frontmatter|colophon|acknowledgement|biography|dedication|preface|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|references[parent::book|parent::chapter|parent::appendix]|solutions[parent::book|parent::chapter|parent::appendix]|glossary[parent::book|parent::chapter|parent::appendix]|conclusion[parent::chapter]|outcomes[preceding-sibling::section]" mode="spine">
     <xsl:element name="itemref" xmlns="http://www.idpf.org/2007/opf">
         <xsl:attribute name="idref">
             <xsl:apply-templates select="." mode="html-id" />

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -92,6 +92,7 @@
 <!-- XHTML files as output -->
 <xsl:variable name="file-extension" select="'.xhtml'" />
 
+<xsl:param name="tmpdir"/>
 <xsl:param name="mathfile"/>
 <xsl:variable name="math-repr" select="document($mathfile)/pi:math-representations"/>
 
@@ -192,9 +193,9 @@
     <!-- Following should use $root or $document-root as defined -->
     <!-- by the "assembly" template.  Checked 2020-07-16.        -->
     <xsl:call-template name="setup" />
+    <xsl:apply-templates select="$root"/>
     <xsl:call-template name="package-document" />
     <xsl:call-template name="packaging-info"/>
-    <xsl:apply-templates select="$root"/>
 </xsl:template>
 
 <!-- First, we use the frontmatter element to trigger various necessary files     -->
@@ -292,7 +293,6 @@
         <xsl:apply-templates select="." mode="section-header" />
         <xsl:apply-templates select="author|objectives|introduction|titlepage|abstract" />
         <!-- deleted "nav" and summary links here -->
-        <!-- "conclusion" is being missed here    -->
     </section>
     <xsl:if test="conclusion">
         <xsl:apply-templates select="conclusion" mode="file-wrap">
@@ -437,9 +437,48 @@
             </xsl:otherwise>
         </xsl:choose>
         <item id="cover-page" href="{$xhtml-dir}/cover-page.xhtml" media-type="application/xhtml+xml"/>
-        <item id="table-contents" href="{$xhtml-dir}/table-contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
-        <item id="cover-image" href="{$xhtml-dir}/{$cover-filename}" properties="cover-image" media-type="image/png"/>
-
+        <item id="table-contents"
+              href="{$xhtml-dir}/table-contents.xhtml"
+              media-type="application/xhtml+xml">
+            <!-- TODO: If the TOC expands to include more than -->
+            <!-- chapter and appendix, this will need revision. -->
+            <xsl:attribute name="properties">
+                <xsl:choose>
+                    <xsl:when test="$document-root//chapter/title/m or
+                                    $document-root//appendix/title/m">
+                        <xsl:choose>
+                            <xsl:when test="$math.format = 'mml' or
+                                            $math.format = 'kindle'">
+                                <xsl:text>nav mathml</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="$math.format = 'svg'">
+                                <xsl:text>nav svg</xsl:text>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>nav</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+        </item>
+        <item id="cover-image" href="{$xhtml-dir}/{$cover-filename}" properties="cover-image">
+            <xsl:attribute name="media-type">
+                <xsl:variable name="extension">
+                    <xsl:call-template name="file-extension">
+                        <xsl:with-param name="filename" select="$cover-filename" />
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="$extension='png'">
+                        <xsl:text>image/png</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$extension='jpeg' or $extension='jpg'">
+                        <xsl:text>image/jpeg</xsl:text>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:attribute>
+        </item>
         <!-- cruise found objects, including comments we generate to help debug       -->
         <!-- NB: * could be just "item", but we generally want all elements           -->
         <!-- Strategy: compare @href of each candidate item with the @href of each    -->
@@ -501,46 +540,26 @@
         <!-- Processing with page2svg makes it appear SVG images exist -->
         <!-- Set properties="svg" or properties="mathml" when a -->
         <!-- file contains math in one of thse formats. -->
-        <xsl:variable name="is-structured">
-            <xsl:apply-templates select="." mode="is-structured-division"/>
-        </xsl:variable>
-        <xsl:variable name="b-is-structured" select="$is-structured = 'true'"/>
-
+        <!-- There are simply too many edge cases to do this -->
+        <!-- based on document structure alone, so read the actual -->
+        <!-- XHTML files we've already written and look for svg -->
+        <!-- or math tags in them. -->
         <xsl:variable name="has-math">
+            <xsl:variable name="contents-filename">
+                <xsl:value-of select="$tmpdir" />
+                <xsl:text>/</xsl:text>
+                <xsl:value-of select="$content-dir" />
+                <xsl:text>/</xsl:text>
+                <xsl:value-of select="$xhtml-dir" />
+                <xsl:text>/</xsl:text>
+                <xsl:apply-templates select="."
+                                     mode="containing-filename"/>
+            </xsl:variable>
+            <xsl:variable name="filedata"
+                          select="document($contents-filename)"/>
             <xsl:choose>
-                <xsl:when test="self::frontmatter">
-                    <xsl:text>false</xsl:text>
-                </xsl:when>
-                <!-- TODO: Condition more on exercises in case -->
-                <!-- answer/solution is suppressed. -->
-                <xsl:when test="../section or ../preface or ../exercises">
-                    <xsl:if test=".//m or .//me or .//men or .//md or .//mdn">
-                        <xsl:text>true</xsl:text>
-                    </xsl:if>
-                </xsl:when>
-                <xsl:when test=".//notation-list">
+                <xsl:when test="$filedata//svg:svg|$filedata//math:math">
                     <xsl:text>true</xsl:text>
-                </xsl:when>
-                <xsl:when test="index-list and $document-root//idx//m">
-                    <xsl:text>true</xsl:text>
-                </xsl:when>
-                <xsl:when test="../chapter or ../appendix">
-                    <xsl:choose>
-                        <xsl:when test="$b-is-structured">
-                            <xsl:if test="chapter/title|objectives|introduction//m or
-                                          chapter/title|objectives|introduction//me or
-                                          chapter/title|objectives|introduction//men or
-                                          chapter/title|objectives|introduction//md or
-                                          chapter/title|objectives|introduction//mdn">
-                                <xsl:text>true</xsl:text>
-                            </xsl:if>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:if test=".//m or .//me or .//men or .//md or .//mdn">
-                                <xsl:text>true</xsl:text>
-                            </xsl:if>
-                        </xsl:otherwise>
-                    </xsl:choose>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:text>false</xsl:text>


### PR DESCRIPTION
As a bit of explanation, when I started trying to deal with @kcrisman's `list-of` to pass validation, I quickly realized that this was going to rapidly spiral out of control for the manifest, especially with `list-of/@empty='no'` set in PTX source. So I changed the order that the templates are applied in the entry template and passed in the temp directory as a parameter. This allows the template that builds the manifest to actually inspect the files to see if they contain an `svg` or `math` element and thus need the appropriate property set. The one place that this is not done is for the table of contents file, which gets the property set based on whether or not there is a `title/m` in a `chapter` or `appendix`.

This PR also ensures that everything that can be specified in `frontmatter` gets picked up and sets the right `@media-type` for the cover image. (Previously had assumed PNG.)