### PR TITLE
pass through revealjs list management to pretext-html, add css to match in revealjs

### DIFF
--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -73,8 +73,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 
             <slide>
-                <title>Ordered Lists, With Pauses</title>
+                <title>Ordered Lists, With Features</title>
 
+                <p>These are enumerated with capital letters.</p>
+
+                <p><ol label="A">
+                    <li>Two conversions: print-on-demand, electronic <init>PDF</init></li>
+                    <li>Extensive use of the <c>tcolorbox</c> package (CSS-like)</li>
+                    <li>Evolving styling/themes (Andrew Rechnitzer, David Farmer)</li>
+                </ol></p>
+
+                <p>These are inline</p>
+
+                <p><ol label="i" cols="2">
+                    <li>print-on-demand</li>
+                    <li>electronic <init>PDF</init></li>
+                </ol></p>
+
+                <p>And these have pauses.</p>
                 <p><ol pause="yes">
                     <li>Two conversions: print-on-demand, electronic <init>PDF</init></li>
                     <li>Extensive use of the <c>tcolorbox</c> package (CSS-like)</li>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -151,6 +151,49 @@ ul {
 dfn {
   font-weight: bold;
 }
+.pretext-content ol.no-marker,
+.pretext-content ul.no-marker,
+.pretext-content li.no-marker {
+    list-style-type: none;
+}
+
+.pretext-content ol.decimal {
+    list-style-type: decimal;
+}
+.pretext-content ol.lower-alpha {
+    list-style-type: lower-alpha;
+}
+.pretext-content ol.upper-alpha {
+    list-style-type: upper-alpha;
+}
+.pretext-content ol.lower-roman {
+    list-style-type: lower-roman;
+}
+.pretext-content ol.upper-roman {
+    list-style-type: upper-roman;
+}
+.pretext-content ul.disc {
+    list-style-type: disc;
+}
+.pretext-content ul.square {
+    list-style-type: square;
+}
+.pretext-content ul.circle {
+    list-style-type: circle;
+}
+.pretext-content ol.no-marker,
+.pretext-content ul.no-marker {
+    list-style-type: none;
+}
+.pretext-content .cols1 li,
+.pretext-content .cols2 li,
+.pretext-content .cols3 li,
+.pretext-content .cols4 li,
+.pretext-content .cols5 li,
+.pretext-content .cols6 li {
+    float: left;
+    padding-right:2em;
+}
           </style>
 
         </head>
@@ -159,7 +202,7 @@ dfn {
             <!-- For mathematics/MathJax -->
             <xsl:call-template name="latex-macros"/>
 
-            <div class="reveal">
+            <div class="reveal pretext-content">
                 <div class="slides">
                      <xsl:apply-templates select="frontmatter"/>
                     <xsl:apply-templates select="section|slide"/>
@@ -333,25 +376,6 @@ dfn {
     <xsl:apply-templates/>
   </div>
 </xsl:template>
-
-<xsl:template match="ul">
-  <ul>
-    <xsl:apply-templates/>
-  </ul>
-</xsl:template>
-
-<xsl:template match="ol">
-  <ol>
-    <xsl:apply-templates/>
-  </ol>
-</xsl:template>
-
-<xsl:template match="dl">
-  <dl>
-    <xsl:apply-templates select="li"/>
-  </dl>
-</xsl:template>
-
 
 <xsl:template match="ul/li|ol/li">
   <li>


### PR DESCRIPTION
Replaces #1547, and this one actually was shown to work for my particular usecase:

![image](https://user-images.githubusercontent.com/1559632/126794585-0dbc7d1c-addc-474a-9e91-82712ed244cb.png)

I'm not super happy with the copypasta CSS from https://github.com/PreTeXtBook/CSS_core/blob/main/pretext_add_on.css but it's a start to get list markers working as expected. I also added `.pretext-content` as a class alongside `.reveal` anticipating that maybe we can just use core CSS directly down the road.

It's been a minute since I thought about inline lists, but `float:left;padding-right:2em` seemed to be the slickest solution. I didn't attempt to preserve choices of columns and just made any column-ed list be an inline list. Maybe RevealJs has a proper grid layout system that should be used instead.