### PR TITLE
Slide image scaling

### DIFF
--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -73,8 +73,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 
             <slide>
-                <title>Ordered Lists, With Pauses</title>
+                <title>Ordered Lists, With Features</title>
 
+                <p>These are enumerated with capital letters.</p>
+
+                <p><ol label="A">
+                    <li>Two conversions: print-on-demand, electronic <init>PDF</init></li>
+                    <li>Extensive use of the <c>tcolorbox</c> package (CSS-like)</li>
+                    <li>Evolving styling/themes (Andrew Rechnitzer, David Farmer)</li>
+                </ol></p>
+
+                <p>These are inline</p>
+
+                <p><ol label="i" cols="2">
+                    <li>print-on-demand</li>
+                    <li>electronic <init>PDF</init></li>
+                </ol></p>
+
+                <p>And these have pauses.</p>
                 <p><ol pause="yes">
                     <li>Two conversions: print-on-demand, electronic <init>PDF</init></li>
                     <li>Extensive use of the <c>tcolorbox</c> package (CSS-like)</li>

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -266,6 +266,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <p>But this is still visible from the outset.</p>
             </slide>
 
+            <slide>
+                <title>Images</title>
+
+                <p>External <c>image</c>s may be added via URL using the <c>@href</c> attribute.</p>
+
+                <figure>
+                    <image href="https://via.placeholder.com/1200x800"/>
+                    <caption>A big image scaled to cap vertical size (click to expand).</caption>
+                </figure>
+            </slide>
+
         </section>
     </slideshow>
 </pretext>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -128,6 +128,10 @@ ul {
   border: 0.5px !important;
   border-radius: 2px 10px 2px;
   padding: 4px;
+  max-height:50vh;
+}
+.figure-like {
+  text-align: center;
 }
 .definition,.theorem,.activity {
   border-width: 0.5px;
@@ -431,17 +435,32 @@ dfn {
 
 
 <xsl:template match="image">
-  <img>
-    <xsl:attribute name="src">
-        <xsl:value-of select="@source" />
-    </xsl:attribute>
-    <xsl:if test="@pause = 'yes'">
-      <xsl:attribute name="class">
-        <xsl:text>fragment</xsl:text>
+    <xsl:variable name="url">
+        <xsl:choose>
+            <xsl:when test="@source">
+                <xsl:value-of select="@source" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="@href" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <a>
+      <xsl:attribute name="href">
+        <xsl:value-of select="$url" />
       </xsl:attribute>
-    </xsl:if>
-    <xsl:apply-templates/>
-  </img>
+      <img>
+        <xsl:attribute name="src">
+            <xsl:value-of select="$url" />
+        </xsl:attribute>
+        <xsl:if test="@pause = 'yes'">
+          <xsl:attribute name="class">
+            <xsl:text>fragment</xsl:text>
+          </xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates/>
+      </img>
+    </a>
 </xsl:template>
 
 <!-- Side-By-Side -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -151,6 +151,49 @@ ul {
 dfn {
   font-weight: bold;
 }
+.pretext-content ol.no-marker,
+.pretext-content ul.no-marker,
+.pretext-content li.no-marker {
+    list-style-type: none;
+}
+
+.pretext-content ol.decimal {
+    list-style-type: decimal;
+}
+.pretext-content ol.lower-alpha {
+    list-style-type: lower-alpha;
+}
+.pretext-content ol.upper-alpha {
+    list-style-type: upper-alpha;
+}
+.pretext-content ol.lower-roman {
+    list-style-type: lower-roman;
+}
+.pretext-content ol.upper-roman {
+    list-style-type: upper-roman;
+}
+.pretext-content ul.disc {
+    list-style-type: disc;
+}
+.pretext-content ul.square {
+    list-style-type: square;
+}
+.pretext-content ul.circle {
+    list-style-type: circle;
+}
+.pretext-content ol.no-marker,
+.pretext-content ul.no-marker {
+    list-style-type: none;
+}
+.pretext-content .cols1 li,
+.pretext-content .cols2 li,
+.pretext-content .cols3 li,
+.pretext-content .cols4 li,
+.pretext-content .cols5 li,
+.pretext-content .cols6 li {
+    float: left;
+    padding-right:2em;
+}
           </style>
 
         </head>
@@ -159,7 +202,7 @@ dfn {
             <!-- For mathematics/MathJax -->
             <xsl:call-template name="latex-macros"/>
 
-            <div class="reveal">
+            <div class="reveal pretext-content">
                 <div class="slides">
                      <xsl:apply-templates select="frontmatter"/>
                     <xsl:apply-templates select="section|slide"/>
@@ -333,25 +376,6 @@ dfn {
     <xsl:apply-templates/>
   </div>
 </xsl:template>
-
-<xsl:template match="ul">
-  <ul>
-    <xsl:apply-templates/>
-  </ul>
-</xsl:template>
-
-<xsl:template match="ol">
-  <ol>
-    <xsl:apply-templates/>
-  </ol>
-</xsl:template>
-
-<xsl:template match="dl">
-  <dl>
-    <xsl:apply-templates select="li"/>
-  </dl>
-</xsl:template>
-
 
 <xsl:template match="ul/li|ol/li">
   <li>


### PR DESCRIPTION
Extends #1554, sorry.

- Centers `.figure-like`
- allows `@href` for images (since I think I recall full URLs are intended to be in `@href` not `@source`)
- Caps image height to 50% of the vertical viewport (I think this in the spirit of capping horizontal width of images in HTML pretext builds, but eventually should be configurable)
- Links images to image URL for a quick "zoom" feature