### PR TITLE
Add "click to enlarge" links for asymptote figures in HTML

### DIFF
--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -111,20 +111,13 @@
 
         <subsection xml:id="latex-asymptote-link-options">
             <title><latex/> Asymptote Links</title>
-            <idx><h>Asymptote links</h><h>LaTeX, PDF, HTML</h></idx>
+            <idx><h>Asymptote links</h><h>LaTeX, PDF</h></idx>
             <idx><h>LaTeX</h><h>Asymptote links</h></idx>
             <idx><h>PDF</h><h>Asymptote links</h></idx>
-            <idx><h>HTML</h><h>Asymptote links</h></idx>
 
-            <p>When the <c>html</c> output format is selected for Asymptote graphics, each diagram will generate an <init>HTML</init> file as part of the online version of your book. In some cases you may wish to link to these files.</p>
-            <p>The conversion to <init>HTML</init> can provide a <q>Click to enlarge</q> link below each graphic that allows the reader to view a full-size version of your diagram. This is especially useful for 3D graphics, since they are interactive.</p>
-            <p>The conversion to <latex/> can also provide a link to an <init>HTML</init> version of each Asymptote graphic, allowing readers of the <init>PDF</init> version of your book to access the interactive version of the diagram.</p>
-            <p>The<cd>
-                <cline>/publication/html/asymptote/@links</cline>
-            </cd> attribute can be used to provide links in the <init>HTML</init> version of your book. The
-              <cd>
+            <p>The conversion to <latex/> can provide a link to an <init>HTML</init> version of each Asymptote graphic.  The<cd>
                 <cline>/publication/latex/asymptote/@links</cline>
-            </cd>attribute will do the same for <init>PDF</init>. Both attributes can have the value <c>yes</c> to produce links, or the value <c>no</c> to not create links.  Note that a base URL must be set for this feature to be functional (<xref ref="online-base-url"/>).  The default is <c>no</c>.  See  <xref ref="latex-asymptote-links"/> for more detail.</p>
+            </cd>attribute can have the value <c>yes</c> to produce links, or the value <c>no</c> to not create links.  Note that a base URL must be set for this feature to be functional (<xref ref="online-base-url"/>).  The default is <c>no</c>.  See  <xref ref="latex-asymptote-links"/> for more detail.</p>
         </subsection>
     </section>
 

--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -111,13 +111,20 @@
 
         <subsection xml:id="latex-asymptote-link-options">
             <title><latex/> Asymptote Links</title>
-            <idx><h>Asymptote links</h><h>LaTeX, PDF</h></idx>
+            <idx><h>Asymptote links</h><h>LaTeX, PDF, HTML</h></idx>
             <idx><h>LaTeX</h><h>Asymptote links</h></idx>
             <idx><h>PDF</h><h>Asymptote links</h></idx>
+            <idx><h>HTML</h><h>Asymptote links</h></idx>
 
-            <p>The conversion to <latex/> can provide a link to an <init>HTML</init> version of each Asymptote graphic.  The<cd>
+            <p>When the <c>html</c> output format is selected for Asymptote graphics, each diagram will generate an <init>HTML</init> file as part of the online version of your book. In some cases you may wish to link to these files.</p>
+            <p>The conversion to <init>HTML</init> can provide a <q>Click to enlarge</q> link below each graphic that allows the reader to view a full-size version of your diagram. This is especially useful for 3D graphics, since they are interactive.</p>
+            <p>The conversion to <latex/> can also provide a link to an <init>HTML</init> version of each Asymptote graphic, allowing readers of the <init>PDF</init> version of your book to access the interactive version of the diagram.</p>
+            <p>The<cd>
+                <cline>/publication/html/asymptote/@links</cline>
+            </cd> attribute can be used to provide links in the <init>HTML</init> version of your book. The
+              <cd>
                 <cline>/publication/latex/asymptote/@links</cline>
-            </cd>attribute can have the value <c>yes</c> to produce links, or the value <c>no</c> to not create links.  Note that a base URL must be set for this feature to be functional (<xref ref="online-base-url"/>).  The default is <c>no</c>.  See  <xref ref="latex-asymptote-links"/> for more detail.</p>
+            </cd>attribute will do the same for <init>PDF</init>. Both attributes can have the value <c>yes</c> to produce links, or the value <c>no</c> to not create links.  Note that a base URL must be set for this feature to be functional (<xref ref="online-base-url"/>).  The default is <c>no</c>.  See  <xref ref="latex-asymptote-links"/> for more detail.</p>
         </subsection>
     </section>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5832,7 +5832,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:value-of select="$html-filename"/>
       </xsl:variable>
       <div style="text-align: center;">
-        <a href="{$image-html-url}">Click to view full-sized image</a>
+        <a href="{$image-html-url}">Link to full-sized image</a>
       </div>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5824,6 +5824,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="archive">
         <xsl:with-param name="base-pathname" select="$base-pathname" />
     </xsl:apply-templates>
+    <!-- possibly provide link to full size image -->
+    <!-- need to set html/asymptote@links="yes" in publisher file to enable -->
+    <xsl:if test="$b-asymptote-html-links">
+      <xsl:variable name="image-html-url">
+          <xsl:value-of select="$baseurl"/>
+          <xsl:value-of select="$html-filename"/>
+      </xsl:variable>
+      <div style="text-align: center;">
+        <a href="{$image-html-url}">Click to view full-sized image</a>
+      </div>
+    </xsl:if>
 </xsl:template>
 
 <!-- A named template creates the infrastructure for an SVG image -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -3328,7 +3328,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="&EXAMPLE-LIKE;" mode="is-hidden">
     <xsl:value-of select="$knowl-example = 'yes'" />
     <!-- Preserving a way to not knowl anything in a worksheet -->
-    <!-- 
+    <!--
     <xsl:choose>
         <xsl:when test="ancestor::worksheet">
             <xsl:value-of select="false()"/>
@@ -6767,7 +6767,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <div class="hidden-content">
                 <!-- Hidden content in here                   -->
                 <!-- Turn autoplay on, else two clicks needed -->
-                <iframe id="{$hid}" class="video" 
+                <iframe id="{$hid}" class="video"
                     allowfullscreen="" src="{$source-url-autoplay-on}">
                     <xsl:apply-templates select="." mode="video-iframe-attributes">
                         <xsl:with-param name="autoplay" select="'true'"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5783,7 +5783,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- failure -->
             <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   the Asympote diagram produced in "<xsl:value-of select="$html-filename"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its width cannot be determined (which you might report as a bug).  We might be able to procede as if the diagram is square, but results can be unpredictable.</xsl:message>
+                <xsl:message>PTX:ERROR:   the Asymptote diagram produced in "<xsl:value-of select="$html-filename"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its width cannot be determined (which you might report as a bug).  We might be able to procede as if the diagram is square, but results can be unpredictable.</xsl:message>
                 <!-- reasonable guess at points/pixels -->
                 <xsl:text>400</xsl:text>
             </xsl:otherwise>
@@ -5805,7 +5805,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- failure -->
             <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   the Asympote diagram produced in "<xsl:value-of select="$html-filename"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its height cannot be determined (which you might report as a bug).  We might be able to procede as if the diagram is square, but results can be unpredictable.</xsl:message>
+                <xsl:message>PTX:ERROR:   the Asymptote diagram produced in "<xsl:value-of select="$html-filename"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its height cannot be determined (which you might report as a bug).  We might be able to procede as if the diagram is square, but results can be unpredictable.</xsl:message>
                 <!-- reasonable guess at points/pixels -->
                 <xsl:text>400</xsl:text>
             </xsl:otherwise>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1752,6 +1752,40 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="b-asymptote-links" select="$asymptote-links = 'yes'"/>
 
+<!-- Add another boolean to turn on links in html -->
+<!-- so reader can click to open a larger version -->
+
+<xsl:variable name="asymptote-html-links">
+    <xsl:choose>
+        <!-- proceed when requested, so long as there is a base URL -->
+        <xsl:when test="$publication/html/asymptote/@links = 'yes'">
+            <xsl:choose>
+                <!-- fail when no base URL is given -->
+                <xsl:when test="$baseurl = ''">
+                    <xsl:message>PTX WARNING: baseurl must be set in publisher file to enable links from Asymptote images</xsl:message>
+                    <xsl:text>no</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>yes</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
+        <xsl:when test="$publication/html/asymptote/@links = 'no'">
+            <xsl:text>no</xsl:text>
+        </xsl:when>
+        <!-- set, but not correct, so inform and use default -->
+        <xsl:when test="$publication/latex/asymptote/@links">
+            <xsl:message>PTX WARNING: HTML links to Asymptote publisher file should be "yes" (adds link below image) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
+            <xsl:text>no</xsl:text>
+        </xsl:when>
+        <!-- unset, use the default, which is "no" since -->
+        <!-- it also needs action to set base URL        -->
+        <xsl:otherwise>
+            <xsl:text>no</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="b-asymptote-html-links" select="$asymptote-html-links = 'yes'"/>
 
 <!-- ########################### -->
 <!-- Reveal.js Slideshow Options -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1774,7 +1774,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>no</xsl:text>
         </xsl:when>
         <!-- set, but not correct, so inform and use default -->
-        <xsl:when test="$publication/latex/asymptote/@links">
+        <xsl:when test="$publication/html/asymptote/@links">
             <xsl:message>PTX WARNING: HTML links to Asymptote publisher file should be "yes" (adds link below image) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
             <xsl:text>no</xsl:text>
         </xsl:when>


### PR DESCRIPTION
Here's another crack at this.

This time I also made a separate publisher variable so html links are controlled separately from pdf.