### PR TITLE
Add documentation for HTML Asymptote link option

### DIFF
--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -67,9 +67,23 @@
             <p>Within the <tag>publication</tag> element of your publisher file include an <tag>html</tag> element, with a child element <tag>video</tag> having an attribute <attr>privacy</attr>.
             The value must be either <c>yes</c> (use enhanced privacy, if available), or <c>no</c> (allow all tracking cookies).
             If your publisher file does not have this element (or you do not have a publisher file) you will get a warning message, and the default will be used.  See <xref ref="embedded-video-privacy-options"/> for details on specifying this option.</p>
-          </subsection>
-    </section>
+        </subsection>
 
+        <subsection xml:id="html-asymptote-links">
+            <title>Links to full-size versions of Asymptote diagrams</title>
+            <idx><h>Asymptote links</h><h>HTML</h></idx>
+            <idx><h>HTML</h><h>Asymptote links</h></idx>
+
+            <p>Asymptote diagrams are embedded in <init>HTML</init> as a <c>canvas</c> element within an <c>iframe</c>.
+            Unlike <c>image</c> elements, web browsers will not provide the option to <q>view image</q>, and clicking on the image will not enlarge it.
+            Since 3D Asymptote diagrams are interactive, a reader may wish that they could interact with a larger version of the graphic.</p>
+
+            <p>You may elect to place a <q>Click to view full-size image</q> link below each Asymptote diagram.
+            Clicking on the link will open the Asymptote <init>HTML</init> file directly, and the digram will be displayed at a much larger size.</p>
+
+            <p>See <xref ref="html-asymptote-link-options"/> for the specifics of this entry.  This feature is off by default.</p>
+        </subsection>
+    </section>
     <section xml:id="knowled-content">
         <title>Knowled Content</title>
 

--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -362,6 +362,16 @@
                 <li><attr>privacy</attr>: allowed values are <c>yes</c> or <c>no</c>.</li>
             </ul>Setting this to yes (the default) prevents certain tracking cookies from being used. Currently only supported for videos from YouTube. See <xref ref="video-embedding"/> for more.</p>
         </subsection>
+
+        <subsection xml:id="html-asymptote-link-options">
+            <title><latex/> Asymptote <q>Click to Enlarge</q> Links</title>
+            <idx><h>Asymptote links</h><h>HTML</h></idx>
+            <idx><h>HTML</h><h>Asymptote links</h></idx>
+
+            <p>The conversion to <init>HTML</init> can provide a <q>Click to view full-sized image</q> link below each Asymptote graphic.  The<cd>
+                <cline>/publication/html/asymptote/@links</cline>
+            </cd>attribute can have the value <c>yes</c> to produce links, or the value <c>no</c> to not create links.  Note that a base URL must be set for this feature to be functional (<xref ref="online-base-url"/>).  The default is <c>no</c>.  See  <xref ref="html-asymptote-links"/> for more detail.</p>
+        </subsection>
     </section>
 
     <section xml:id="publisher-file-revealjs">


### PR DESCRIPTION
This time with documentation in the right place, and in two places: Conversion to online HTML and Publisher file reference.