### PR TITLE
Add experimental stringparam `debug.skip-knowls` to skip building knowls

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1109,6 +1109,13 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <xsl:param name="debug.knowl-production" select="'all'"/>
 <xsl:variable name="b-knowls-new" select="not($debug.knowl-production = 'all')"/>
 
+<!-- 2021-07-30: HTML only, experimental -->
+<!-- Switch to kill all knowls, intended to facilitate -->
+<!-- quick preview builds for use while authoring. -->
+<!-- Change to non-empty string to enable -->
+<xsl:param name="debug.skip-knowls" select="''"/>
+<xsl:variable name="b-skip-knowls" select="not($debug.skip-knowls = '')"/>
+
 <!-- HTML only, experimental -->
 <!-- Temporary, undocumented, and experimental           -->
 <!-- Makes randomization buttons for inline WW probmlems -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1756,7 +1756,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:value-of select="$b-commentary" />
 </xsl:template>
 <xsl:template match="fn|p|blockquote|biblio|biblio/note|defined-term|&DEFINITION-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|task|&FIGURE-LIKE;|&THEOREM-LIKE;|proof|case|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&ASIDE-LIKE;|poem|assemblage|paragraphs|&GOAL-LIKE;|exercise|hint|answer|solution|exercisegroup|men|mrow|li[not(parent::var)]|contributor|fragment" mode="xref-as-knowl">
-    <xsl:value-of select="true()" />
+    <xsl:value-of select="not($b-skip-knowls)" />
 </xsl:template>
 
 <!-- build xref-knowl, and optionally a hidden-knowl duplicate       -->


### PR DESCRIPTION
Intended to speed up quick preview builds in HTML.

See discussion in https://groups.google.com/g/pretext-dev/c/JhcdoGU3nWk/m/8oeJDRMGCQAJ