### PR TITLE
HTML: merge task headers

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2187,6 +2187,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="list-number" />
             <xsl:text>)</xsl:text>
         </span>
+        <xsl:if test="title">
+            <xsl:call-template name="space-styled"/>
+            <span class="title">
+                <xsl:apply-templates select="." mode="title-full"/>
+            </span>
+        </xsl:if>
     </h6>
 </xsl:template>
 
@@ -3951,14 +3957,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original" select="true()" />
     <xsl:param name="block-type"/>
 
-    <!-- *Something* is being output, so include an (optional) title -->
-    <xsl:if test="title">
-        <h6 class="heading">
-            <span class="title">
-                <xsl:apply-templates select="." mode="title-full"/>
-            </span>
-        </h6>
-    </xsl:if>
     <xsl:choose>
         <!-- introduction?, task+, conclusion? -->
         <xsl:when test="task">
@@ -4046,14 +4044,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <article class="exercise-like">
             <xsl:apply-templates select="." mode="heading-birth" />
 
-            <!-- *Something* is being output, so include an (optional) title -->
-            <xsl:if test="title">
-                <h6 class="heading">
-                    <span class="title">
-                        <xsl:apply-templates select="." mode="title-full"/>
-                    </span>
-                </h6>
-            </xsl:if>
             <xsl:choose>
                 <!-- introduction?, task+, conclusion? -->
                 <xsl:when test="task">


### PR DESCRIPTION
Work on hN revealed what I think is a mistake, fixed here.

See 
Exercise 4.10: A very structured exercise 
https://pretextbook.org/examples/sample-article/html/interesting-corollary.html#exercise-structured

Inspect the HTML and note that task (a) has two h6 elements. One for "(a)" and one for the title. This PR merges them into one.

The same issue is present in the solutions at
https://pretextbook.org/examples/sample-article/html/solutions-backmatter.html

So there is an addition here that adds the title to the right h6. And then two removals, removing the other title where born and when part of a solutions.