### PR TITLE
Give all exercisegroup a heading

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2252,7 +2252,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Title only -->
-<!-- ASIDE-LIKE, exercisegroup, dl/li -->
+<!-- ASIDE-LIKE, dl/li                -->
 <!-- proof, when optionally titled    -->
 <!-- Subsidiary to paragraphs,        -->
 <!-- and divisions of "exercises"     -->
@@ -3510,7 +3510,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- When born use this heading         -->
 <!-- Never hidden, never gets a heading -->
 <xsl:template match="exercisegroup" mode="heading-birth">
-    <xsl:apply-templates select="." mode="heading-title" />
+    <xsl:apply-templates select="." mode="heading-divisional-exercise-serial" />
 </xsl:template>
 
 <!-- Heading for interior of xref-knowl content -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -5349,11 +5349,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <!-- build it -->
     <xsl:text>\par\medskip\noindent%&#xa;</xsl:text>
+    <xsl:text>\textbf{</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number" />
+    <xsl:text>.</xsl:text>
     <xsl:if test="title">
-        <xsl:text>\textbf{</xsl:text>
+        <xsl:text> </xsl:text>
         <xsl:apply-templates select="." mode="title-full" />
-        <xsl:text>}\space\space</xsl:text>
     </xsl:if>
+    <xsl:text>}\space\space</xsl:text>
     <xsl:if test="@xml:id">
         <xsl:apply-templates select="." mode="label"/>
     </xsl:if>


### PR DESCRIPTION
In HTML, EPUB, and PDF, this PR makes it so that an exercisegroup will always start with a header like:

2–5. Optional Title

If the "exercisegroup" has no "title" and also has no "introduction", this may look strange. But it already looks strange in that situation for the problems to indent with no explanation. (Perhaps we should consider making the schema require at least one of "title" and "introduction".

This was motivated by #1570. If there is an introduction but no title, the introduction can go unnoticed by a user relying on the heading tree.