### PR TITLE
Give exercisegroup a default title

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3690,7 +3690,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Some items have default titles that make sense         -->
 <!-- Typically these are one-off subdivisions (eg preface), -->
 <!-- or repeated generic divisions (eg exercises)           -->
-<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|references|glossary|exercises|worksheet|reading-questions|solutions|backmatter|index-part|index[index-list]|case" mode="has-default-title">
+<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|references|glossary|exercises|worksheet|reading-questions|exercisegroup|solutions|backmatter|index-part|index[index-list]|case" mode="has-default-title">
     <xsl:text>true</xsl:text>
 </xsl:template>
 <xsl:template match="*" mode="has-default-title">
@@ -3885,7 +3885,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Miscellaneous -->
-<xsl:template match="paragraphs|proof|case|defined-term" mode="title-wants-punctuation">
+<xsl:template match="paragraphs|proof|case|defined-term|exercisegroup" mode="title-wants-punctuation">
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Titled: list items, tasks of exercise, PROJECT-LIKE, EXAMPLE-LIKE -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2266,7 +2266,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and divisions of "exercises"     -->
 <!-- No title, then nothing happens   -->
 <xsl:template match="*" mode="heading-title">
-    <xsl:if test="title/*|title/text()">
+    <xsl:variable name="has-default-title">
+        <xsl:apply-templates select="." mode="has-default-title"/>
+    </xsl:variable>
+    <xsl:if test="title/*|title/text() or $has-default-title = 'true'">
         <h6 class="heading">
             <span class="title">
                 <xsl:apply-templates select="." mode="title-full" />

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -5349,11 +5349,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <!-- build it -->
     <xsl:text>\par\medskip\noindent%&#xa;</xsl:text>
-    <xsl:if test="title">
-        <xsl:text>\textbf{</xsl:text>
-        <xsl:apply-templates select="." mode="title-full" />
-        <xsl:text>}\space\space</xsl:text>
-    </xsl:if>
+    <xsl:text>\textbf{</xsl:text>
+    <!-- title may be default title -->
+    <xsl:apply-templates select="." mode="title-full" />
+    <xsl:text>}\space\space</xsl:text>
     <xsl:if test="@xml:id">
         <xsl:apply-templates select="." mode="label"/>
     </xsl:if>


### PR DESCRIPTION
This is an alternative to #1572. In this branch, where an exercisegroup is born, either its authored title is printed, or if there is no authored title, the default tile ("Exercise Group", localized) is used.

Some screenshots of a local project. PDF:

<img width="667" alt="Screen Shot 2021-08-10 at 3 27 32 PM" src="https://user-images.githubusercontent.com/4732672/128943053-4aea6149-1253-41d3-99d8-1c76dd44f8aa.png">

HTML:

<img width="714" alt="Screen Shot 2021-08-10 at 3 28 10 PM" src="https://user-images.githubusercontent.com/4732672/128943056-7c84087c-de6b-4a5e-b839-4d68386b1d72.png">
