### PR TITLE
HTML: remove hN from li title

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5128,11 +5128,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:if>
                 <!-- "title" only possible for structured version of a list item -->
                 <xsl:if test="title">
-                    <h6 class="heading">
-                        <span class="title">
-                            <xsl:apply-templates select="." mode="title-full"/>
-                        </span>
-                    </h6>
+                    <span class="title">
+                        <xsl:apply-templates select="." mode="title-full"/>
+                    </span>
                 </xsl:if>
                 <!-- Unstructured list items will be output as an HTML "p"     -->
                 <!-- within the "li", much like a structured list item could   -->


### PR DESCRIPTION
This PR is for discussion. But not to the exclusion of merging if it happens to be good as is.

In an ol or ul, an li can have a title. Presently, this is realized as a heading (hN) in HTML. See item 1 and item 2.b.ii.C here:

Paragraph  
https://pretextbook.org/examples/sample-article/html/lists.html#p-516

It clutters the heading map to have these be hN. They are in the heading map, but nothing is there for other list items. Also the listings in the heading map are only the title; they exclude the list item number.

Perhaps worse, with some li having these and some not, the heading map is not mirroring the structure of the list. So this PR removes the hN from li/title. The title is still in a span.title, but is not presently styled. See this page that was built using this branch:

Paragraph 
https://spot.pcc.edu/~ajordan/temp/lists.html#p-516

So if this is merged, some attention should go to styling li > span.title.

Additional observation: in a dl, an li must have a title. This is realized as an HTML dt, with no hN. So there is no heading map issue because all description list items are left out of the heading map. But since description lists are not attempting to be mirrored in the heading map, maybe that's another reason (for consistency) to not try to follow ol or ul in the heading map either, even in the case where all of the items do have titles.

