### PR TITLE
HTML: give a class name respecting depth for duplicate heading spans

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7892,7 +7892,9 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:call-template name="list-of-begin" />
     <!-- recursive procedure, starting from indicated scope -->
     <xsl:apply-templates select="$subroot" mode="list-of-content">
-        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <!-- list-of was passed a heading level that was incremented by its parent division -->
+        <!-- Since the list-of has no heading itself, we back this up by 1                  -->
+        <xsl:with-param name="heading-level" select="$heading-level - 1"/>
         <xsl:with-param name="elements" select="$elements"/>
         <xsl:with-param name="divisions" select="$divisions"/>
         <xsl:with-param name="b-empty" select="$b-empty"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -623,9 +623,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Headings for structural divisions when they are repeated: -->
 <!-- list-of, solutions                                        -->
-<!-- Use span instead of hN                                    -->
-<xsl:template match="*" mode="secondary-heading">
-    <xsl:element name="span">
+<xsl:template match="*" mode="duplicate-heading">
+    <xsl:param name="heading-level"/>
+    <xsl:variable name="hN">
+        <xsl:text>h</xsl:text>
+        <xsl:choose>
+            <xsl:when test="$heading-level > 6">
+                <xsl:text>6</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$heading-level"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:element name="{$hN}">
         <xsl:attribute name="class">
             <xsl:text>heading</xsl:text>
             <xsl:if test="not(self::chapter) or ($numbering-maxlevel = 0)">
@@ -1083,6 +1094,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- $b-has-heading will always be "false" in these situations.     -->
 <xsl:template match="book|article|part|chapter|section|subsection|subsubsection|exercises|worksheet|reading-questions" mode="division-in-solutions">
     <xsl:param name="scope" /> <!-- ignored -->
+    <xsl:param name="heading-level"/>
     <xsl:param name="b-has-heading"/>
     <xsl:param name="content" />
 
@@ -1092,7 +1104,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-has-heading">
             <!-- as a duplicate of generated content, no HTML id -->
             <section class="{local-name(.)}">
-                <xsl:apply-templates select="." mode="secondary-heading"/>
+                <xsl:apply-templates select="." mode="duplicate-heading">
+                    <xsl:with-param name="heading-level" select="$heading-level"/>
+                </xsl:apply-templates>
                 <!-- we don't do an "author-byline" here in duplication -->
                 <xsl:copy-of select="$content" />
             </section>
@@ -1119,7 +1133,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Subdivision headings in list-of's -->
 <xsl:template match="*" mode="list-of-header">
-    <xsl:apply-templates select="." mode="secondary-heading"/>
+    <xsl:param name="heading-level"/>
+    <xsl:apply-templates select="." mode="duplicate-heading">
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- Entries in list-of's -->


### PR DESCRIPTION
This follows up on #1580.

Not important changes: Rob's xslt-fu for a `span` element. And changed "secondary-heading" to "duplicate-heading".

Collateral correction: the `list-of` generator in -common was bumping up the heading level by 1 more than it should. 

Important change: The duplicate headings (which appear inside `list-of` or `solutions` output) are still spans, but they have additional classes on them like `heading4`, `heading5`, etc, indicating their depth on the page. So they could be styled to reflect their depth.  If the class would be `heading7`, `heading8`, etc. it just prints `heading6`. This is to be consistent with what I have coming up for `hN` headings, and also to limit the number of classes @davidfarmer  has to work with.

As a reminder, we are not using actual `hN` because in these places, it would clutter up the heading tree without offering much in terms of better navigation.

An example, built with chunk level 0: http://spot.pcc.edu/~ajordan/temp/derivatives.html

Appendices F and G have `list-of`. Appendices B–E have `solutions`. Section 4.2.7 is also a "solutions".
