### PR TITLE
HTML: make inline math wrap span around adjacent non-whitespace

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -11706,6 +11706,7 @@ the xsltproc executable.
                 </statement>
                 <solution xml:id="solution-antiderivative">
                     <p>An antiderivative of <m>x^2</m> is <m>F(x)=x^3/3</m>, so by the FTC,<me>\definiteintegral{2}{4}{x^2}{x}=F(4)-F(2)=\frac{1}{3}\left(4^3-2^3\right)=\frac{56}{3}</me>!?!      This is indeed an exciting result, but we are mostly interested in seeing that the sentence-ending punctuation is absorbed properly into the displayed equation.</p>
+                    <p>On a related note, we are interested in seeing that math-adjacent non-whitespace characters (not counting things like quote characters introduced by a <tag>q</tag> element) do not line break awkwardly, so we present some math <m>x</m>, some irrational numbers (<m>\pi</m>, <m>e</m>), and remind you that <m>\lim_{x\to0}\frac{\sin x}{x}</m> has <q><m>0/0</m></q>-indeterminate form. Also, <q>Beware the <m>x</m>-axis!</q></p>
                 </solution>
             </exercise>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1393,7 +1393,7 @@ Book (with parts), "section" at level 3
 <!--                                                     -->
 <!-- This is fairly simple.  Differences are             -->
 <!--   (1) Some conversions require different delimiters -->
-<!--   (2) We adjust punctuation for HTML, but not Latex -->
+<!--   (2) We wrap math-adjacent text for HTML           -->
 <!--                                                     -->
 <!-- Abstract Templates                                  -->
 <!--                                                     -->
@@ -1405,6 +1405,9 @@ Book (with parts), "section" at level 3
 <!--       then look for leading punctuation, and        -->
 <!--       bring into math with \text() wrapper          -->
 <!--       when  $math.punctuation.include  indicates    -->
+<!-- (3) begin-, end-math-adjacent-text                  -->
+<!--       The delimiters to surround math-adjacent text -->
+<!--       for the purposes of preventing line breaks    -->
 
 <!-- $debug.displaystyle defaults to yes for testing -->
 
@@ -1424,12 +1427,18 @@ Book (with parts), "section" at level 3
                 <xsl:apply-templates select="text()|fillin" />
             </xsl:otherwise>
         </xsl:choose>
-        <!-- look ahead to absorb immediate clause-ending punctuation   -->
-        <!-- this is useful for HTML/MathJax to prevent bad line breaks -->
-        <!-- The template here in -common is generally useful, but      -->
-        <!-- for LaTeX we override to be a no-op, since not necessary   -->
-        <xsl:apply-templates select="." mode="get-clause-punctuation" />
     </xsl:variable>
+    <xsl:variable name="text-before">
+        <xsl:apply-templates select="." mode="get-text-before"/>
+    </xsl:variable>
+    <xsl:variable name="text-after">
+        <xsl:apply-templates select="." mode="get-text-after"/>
+    </xsl:variable>
+    <xsl:variable name="b-math-adjacent-text" select="not($text-before = '' and $text-after = '')"/>
+    <xsl:if test="$b-math-adjacent-text">
+        <xsl:call-template name="begin-math-adjacent-text" />
+        <xsl:value-of select="$text-before"/>
+    </xsl:if>
     <!-- wrap tightly in math delimiters -->
     <xsl:call-template name="begin-inline-math" />
     <!-- Prefix will normally be empty and have no effect.  We also have  -->
@@ -1449,17 +1458,25 @@ Book (with parts), "section" at level 3
         <xsl:with-param name="text" select="$raw-latex" />
     </xsl:call-template>
     <xsl:call-template name="end-inline-math" />
+    <xsl:if test="$b-math-adjacent-text">
+        <xsl:value-of select="$text-after"/>
+        <xsl:call-template name="end-math-adjacent-text" />
+    </xsl:if>
 </xsl:template>
 
 <xsl:template name="begin-inline-math">
-     <xsl:message>PTX:ERROR:   the "begin-inline-math" template needs an implementation in the current conversion</xsl:message>
-     <xsl:text>[[[</xsl:text>
- </xsl:template>
+    <xsl:message>PTX:ERROR:   the "begin-inline-math" template needs an implementation in the current conversion</xsl:message>
+    <xsl:text>[[[</xsl:text>
+</xsl:template>
 
 <xsl:template name="end-inline-math">
-     <xsl:message>PTX:ERROR:   the "end-inline-math" template needs an implementation in the current conversion</xsl:message>
-     <xsl:text>]]]</xsl:text>
- </xsl:template>
+    <xsl:message>PTX:ERROR:   the "end-inline-math" template needs an implementation in the current conversion</xsl:message>
+    <xsl:text>]]]</xsl:text>
+</xsl:template>
+
+<!-- These can be overridden where needed, eg HTML -->
+<xsl:template name="begin-math-adjacent-text"/>
+<xsl:template name="end-math-adjacent-text"/>
 
 <!-- Display Style LaTeX markup for inline math -->
 <!--                                                     -->
@@ -3122,7 +3139,7 @@ Book (with parts), "section" at level 3
 <!-- A corresponding event happens with the following    -->
 <!-- text() node: the punctuation will get scrubbed      -->
 <!-- from there iff the punctuation migrates in this     -->
-<xsl:template match="m|me|men|md|mdn" mode="get-clause-punctuation">
+<xsl:template match="me|men|md|mdn" mode="get-clause-punctuation">
     <xsl:if test="(self::m and $b-include-inline) or ((self::me|self::men|self::md|self::mdn) and $b-include-display)">
         <xsl:variable name="trailing-text" select="following-sibling::node()[1]/self::text()" />
         <xsl:variable name="punctuation">
@@ -3138,6 +3155,108 @@ Book (with parts), "section" at level 3
     </xsl:if>
 </xsl:template>
 
+<!-- In cases where we need to wrap math-adjacent text, -->
+<!-- get the before- and after-text                     -->
+<xsl:template match="m" mode="get-text-after">
+    <xsl:variable name="following-text" select="following-sibling::node()[1]/self::text()" />
+    <xsl:call-template name="leading-non-whitespace">
+        <xsl:with-param name="text" select="$following-text" />
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="m" mode="get-text-before">
+    <xsl:variable name="preceding-text" select="preceding-sibling::node()[1]/self::text()" />
+    <xsl:call-template name="trailing-non-whitespace">
+        <xsl:with-param name="text" select="$preceding-text" />
+    </xsl:call-template>
+</xsl:template>
+
+<!-- This collects non-whitespace text             -->
+<!-- from the *front* of a text node.  It does not -->
+<!-- change the text node, but simply outputs the  -->
+<!-- punctuation for use by another template       -->
+<xsl:template name="leading-non-whitespace">
+    <xsl:param name="text" />
+    <xsl:variable name="first-char" select="substring($text, 1, 1)" />
+    <xsl:choose>
+        <!-- empty, quit -->
+        <xsl:when test="not($first-char)" />
+        <!-- if not whitespace, output and recurse -->
+        <!-- else silently quit recursion          -->
+        <xsl:when test="not(contains($whitespaces, $first-char))">
+        <xsl:value-of select="$first-char" />
+            <xsl:call-template name="leading-non-whitespace">
+                <xsl:with-param name="text" select="substring($text, 2)" />
+            </xsl:call-template>
+        </xsl:when>
+        <!-- consecutive only, stop collecting -->
+        <xsl:otherwise />
+    </xsl:choose>
+</xsl:template>
+
+<!-- This collects non-whitespace text             -->
+<!-- from the *end* of a text node.  It does not   -->
+<!-- change the text node, but simply outputs the  -->
+<!-- punctuation for use by another template       -->
+<xsl:template name="trailing-non-whitespace">
+    <xsl:param name="text" />
+    <xsl:variable name="last-char" select="substring($text, string-length($text))" />
+    <xsl:choose>
+        <!-- empty, quit -->
+        <xsl:when test="not($last-char)" />
+        <!-- if not whitespace, output and recurse -->
+        <!-- else silently quit recursion          -->
+        <xsl:when test="not(contains($whitespaces, $last-char))">
+        <xsl:value-of select="$last-char" />
+            <xsl:call-template name="trailing-non-whitespace">
+                <xsl:with-param name="text" select="substring($text, 1, string-length($text) - 1)" />
+            </xsl:call-template>
+        </xsl:when>
+        <!-- consecutive only, stop collecting -->
+        <xsl:otherwise />
+    </xsl:choose>
+</xsl:template>
+
+<!-- If we collect nonwhitespace, we need to scrub it by   -->
+<!-- examining and manipulating the text node with         -->
+<!-- those characters.  We drop consecutive nonwhitespace. -->
+<xsl:template name="drop-leading-non-whitespace">
+    <xsl:param name="text" />
+    <xsl:variable name="first-char" select="substring($text, 1, 1)" />
+    <xsl:choose>
+        <!-- if empty, done -->
+        <xsl:when test="not($first-char)" />
+        <!-- first character is nonwhitespace, drop it, recurse -->
+        <xsl:when test="not(contains($whitespaces, $first-char))">
+            <xsl:call-template name="drop-leading-non-whitespace">
+                <xsl:with-param name="text" select="substring($text, 2)" />
+            </xsl:call-template>
+        </xsl:when>
+        <!-- no more nonwhitespace, output as-is -->
+        <xsl:otherwise>
+            <xsl:value-of select="$text" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="drop-trailing-non-whitespace">
+    <xsl:param name="text" />
+    <xsl:variable name="last-char" select="substring($text, string-length($text))" />
+    <xsl:choose>
+        <!-- if empty, done -->
+        <xsl:when test="not($last-char)" />
+        <!-- last character is nonwhitespace, drop it, recurse -->
+        <xsl:when test="not(contains($whitespaces, $last-char))">
+            <xsl:call-template name="drop-trailing-non-whitespace">
+                <xsl:with-param name="text" select="substring($text, 1, string-length($text) - 1)" />
+            </xsl:call-template>
+        </xsl:when>
+        <!-- no more nonwhitespace, output as-is -->
+        <xsl:otherwise>
+            <xsl:value-of select="$text" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
 
 
 <!-- ################################## -->
@@ -3154,6 +3273,9 @@ Book (with parts), "section" at level 3
 <!-- it to adjust for clause-ending punctuation       -->
 <!-- being absorbed elsewhere into math, so we place  -->
 <!-- this near math handling.                         -->
+<!-- For inline math, rather than just clause-ending  -->
+<!-- punctuation, we are adjusting all adjacent       -->
+<!-- nonwhitespace.                                   -->
 <!--                                                  -->
 <!-- Later Strategy                                   -->
 <!--                                                  -->
@@ -3166,14 +3288,16 @@ Book (with parts), "section" at level 3
 <!-- with some whitespace consolidated                -->
 
 <xsl:template match="text()">
-    <!-- Scrub clause-ending punctuation immediately after math  -->
+    <!-- Scrub clause-ending punctuation immediately after display math  -->
+    <!-- and nonwhitespace characters immediately after inline math      -->
     <!-- It migrates and is absorbed in math templates elsewhere -->
     <!-- Side-effect: resulting leading whitespace is scrubbed   -->
     <!-- for displayed mathematics (only) as it is irrelevant    -->
     <xsl:variable name="first-char" select="substring(., 1, 1)" />
-    <xsl:variable name="math-punctuation">
+    <xsl:variable name="last-char" select="substring(., string-length(.))" />
+    <xsl:variable name="math-start-trimmed">
         <xsl:choose>
-            <!-- drop punctuation after display math, if moving to math -->
+            <!-- drop punctuation after display math -->
             <xsl:when test="$b-include-display and contains($clause-ending-marks, $first-char) and preceding-sibling::node()[1][self::me|self::men|self::md|self::mdn]">
                 <xsl:call-template name="strip-leading-whitespace">
                     <xsl:with-param name="text">
@@ -3183,14 +3307,27 @@ Book (with parts), "section" at level 3
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
-            <!-- drop punctuation after inline math, if moving to math -->
-            <xsl:when test="$b-include-inline and contains($clause-ending-marks, $first-char) and preceding-sibling::node()[1][self::m]">
-                <xsl:call-template name="drop-clause-punctuation">
+            <!-- drop nonwhitespace after inline math -->
+            <xsl:when test="not(contains($whitespaces, $first-char)) and preceding-sibling::node()[1][self::m]">
+                <xsl:call-template name="drop-leading-non-whitespace">
                     <xsl:with-param name="text" select="." />
                 </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:value-of select="." />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="math-trimmed">
+        <xsl:choose>
+            <!-- drop nonwhitespace before inline math -->
+            <xsl:when test="not(contains($whitespaces, $last-char)) and following-sibling::node()[1][self::m]">
+                <xsl:call-template name="drop-trailing-non-whitespace">
+                    <xsl:with-param name="text" select="$math-start-trimmed" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$math-start-trimmed" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -3208,11 +3345,11 @@ Book (with parts), "section" at level 3
         <xsl:choose>
             <xsl:when test="not(parent::m|parent::me|parent::men|parent::mrow)">
                 <xsl:call-template name="text-processing">
-                    <xsl:with-param name="text" select="$math-punctuation"/>
+                    <xsl:with-param name="text" select="$math-trimmed"/>
                 </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="$math-punctuation"/>
+                <xsl:value-of select="$math-trimmed"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5253,6 +5253,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\)</xsl:text>
 </xsl:template>
 
+<!-- These two templates wrap math adjacent text in a span -->
+<!-- to prevent unwanted line breaks.                      -->
+<xsl:template name="begin-math-adjacent-text">
+    <xsl:text disable-output-escaping="yes"><![CDATA[<span class="mathword">]]></xsl:text>
+</xsl:template>
+<xsl:template name="end-math-adjacent-text">
+    <xsl:text disable-output-escaping="yes"><![CDATA[</span>]]></xsl:text>
+</xsl:template>
+
+
 <!-- Displayed Single-Line Math ("me", "men") -->
 
 <!-- All displayed mathematics is wrapped by a div,    -->


### PR DESCRIPTION
For discussion. Here is one page where this is in effect: http://spot.pcc.edu/~ajordan/temp/exercises.html

Open the solution to "42a" to see math with adjacent text. For me in Firefox at default Zoom, there is an `x,` at the right edge, and if I narrow the browser they stick together (the comma never moves by itself to the next line). Also there is an example of a right quote from a `q` that does move to the next line. Inspect the HTML to see that `span.mathword` is only used where needed.