### PR TITLE
LaTeX: par break before workspace

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6131,7 +6131,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:apply-templates>
             <!-- this is a bit rough -->
             <xsl:if test="not(task) and @workspace and ancestor::worksheet">
-                <xsl:text>\\\rule{\workspacestrutwidth}{</xsl:text>
+                <!-- par break below instead of line break, in case there is no line to end -->
+                <xsl:text>\par\rule{\workspacestrutwidth}{</xsl:text>
                 <xsl:apply-templates select="." mode="sanitize-workspace"/>
                 <xsl:text>}%&#xa;</xsl:text>
             </xsl:if>


### PR DESCRIPTION
Replacing #1593.

In one project, I have a terminal task with `@workspace` and the task ends with a `sidebyside`. This causes a `\\` following the sidebyside to give a "no line to end" error. So this PR replaces the `\\` with a paragraph break.

I think this section (workspace on tasks) is "rough" as already noted in the comments. But changing to `\par` seems good for now.