### PR TITLE
HTML: use hN for duplicate headings

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7896,7 +7896,9 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:call-template name="list-of-begin" />
     <!-- recursive procedure, starting from indicated scope -->
     <xsl:apply-templates select="$subroot" mode="list-of-content">
-        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <!-- list-of was passed a heading level that was incremented by its parent division -->
+        <!-- Since the list-of has no heading itself, we back this up by 1                  -->
+        <xsl:with-param name="heading-level" select="$heading-level - 1"/>
         <xsl:with-param name="elements" select="$elements"/>
         <xsl:with-param name="divisions" select="$divisions"/>
         <xsl:with-param name="b-empty" select="$b-empty"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -628,9 +628,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Headings for structural divisions when they are repeated: -->
 <!-- list-of, solutions                                        -->
-<!-- Use span instead of hN                                    -->
-<xsl:template match="*" mode="secondary-heading">
-    <xsl:element name="span">
+<xsl:template match="*" mode="duplicate-heading">
+    <xsl:param name="heading-level"/>
+    <xsl:variable name="hN">
+        <xsl:text>h</xsl:text>
+        <xsl:choose>
+            <xsl:when test="$heading-level > 6">
+                <xsl:text>6</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$heading-level"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:element name="{$hN}">
         <xsl:attribute name="class">
             <xsl:text>heading</xsl:text>
             <xsl:if test="not(self::chapter) or ($numbering-maxlevel = 0)">
@@ -1088,6 +1099,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- $b-has-heading will always be "false" in these situations.     -->
 <xsl:template match="book|article|part|chapter|section|subsection|subsubsection|exercises|worksheet|reading-questions" mode="division-in-solutions">
     <xsl:param name="scope" /> <!-- ignored -->
+    <xsl:param name="heading-level"/>
     <xsl:param name="b-has-heading"/>
     <xsl:param name="content" />
 
@@ -1097,7 +1109,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-has-heading">
             <!-- as a duplicate of generated content, no HTML id -->
             <section class="{local-name(.)}">
-                <xsl:apply-templates select="." mode="secondary-heading"/>
+                <xsl:apply-templates select="." mode="duplicate-heading">
+                    <xsl:with-param name="heading-level" select="$heading-level"/>
+                </xsl:apply-templates>
                 <!-- we don't do an "author-byline" here in duplication -->
                 <xsl:copy-of select="$content" />
             </section>
@@ -1124,7 +1138,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Subdivision headings in list-of's -->
 <xsl:template match="*" mode="list-of-header">
-    <xsl:apply-templates select="." mode="secondary-heading"/>
+    <xsl:param name="heading-level"/>
+    <xsl:apply-templates select="." mode="duplicate-heading">
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- Entries in list-of's -->


### PR DESCRIPTION
This returns to using hN (at the appropriate level) for headings in `list-of` and `solutions`. A chunk level 0 example is here:

http://spot.pcc.edu/~ajordan/temp/derivatives.html
(Don't click to follow links to appendices the nav column. They incorrectly point to backmatter.html which should not exist with chunk level 0.)

If you use Firefox and haven't already, I like the [headingsMap extension](https://addons.mozilla.org/en-US/firefox/addon/headingsmap/) to view the headings and their depths in a side column.

There are `solutions` in 4.2.7, and in appendices B–E.  Appendices F and G have `list-of`.

This is the same as where PR #1582 wound up, but there were too many course corrections there and the thread was confusing.

This undoes something that #1580 did, but leaves in place the infrastructure that makes it easy to switch back and forth about this and make future decisions about stacked headings (re our discussion this past Friday). 

It also corrects the value of heading-level that is passed to list-of. Since list-of doesn't have a heading, this subtracts 1 from that value before passing it down.