### PR TITLE
Doc: clean up incorrect use of 'attr'

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -227,26 +227,26 @@
         creates an input field answer blank that expects the variable with that <attr>name</attr> to be the answer.
       </p>
       <p>
-        A <tag>var</tag> can have <attr>form="essay"</attr>, in which case it need not have a <attr>name</attr> attribute.
+        A <tag>var</tag> can have <attr>form</attr> with value <c>essay</c>, in which case it need not have a <attr>name</attr> attribute.
         This is for open-ended questions that must be graded by a human.
         The form field will be an expandable input block if the question is served to an authenticated user within <webwork/>.
         But for the <webwork/> cells in <pretext/> HTML output,
         there will just be a message explaining that there is no place to enter an answer.
       </p>
       <p>
-        A <tag>var</tag> can have <attr>form="array"</attr>.
+        A <tag>var</tag> can have <attr>form</attr> with value <c>array</c>.
         You would use this when the answer is a Matrix or Vector MathObject (a <webwork/> classification)
         to cause the input form to be an array of smaller fields instead of one big field.
       </p>
       <p>
-        A <tag>var</tag> can have <attr>form="popup"</attr> or <attr>form="buttons"</attr> for multiple choice questions.
+        A <tag>var</tag> can have <attr>form</attr> with value <c>popup</c> or <c>buttons</c> for multiple choice questions.
       </p>
       <p>
         If you are familiar with PG, then in your <tag>pg-code</tag> you might write a custom evaluator
         (a combination of a custom answer checker, post filters, pre filters, <etc/>).
         If you store this similar to
         <cd>$my_evaluator = $answer -> cmp(...);</cd>
-        then the <tag>var</tag> can have <attr>evaluator="$my_evaluator"</attr>.
+        then the <tag>var</tag> can have <attr>evaluator</attr> with value <c>$my_evaluator</c>.
       </p>
       <p>
         An <tag>instruction</tag> is specific instructions for how the reader might type or otherwise electronically submit their answer.

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -838,7 +838,7 @@
       <p>
           <idx><h sortby="cols"><attr>cols</attr></h><h>of an exercise group</h></idx>
         If you want the contents of an <tag>exercisegroup</tag> to be put in multiple columns,
-        you can add a <attr>cols</attr> attribute to the <tag>exercisegroup</tag> of the form <attr>cols="3"</attr>.
+        you can add a <attr>cols</attr> attribute to the <tag>exercisegroup</tag> with value (for example) <c>3</c>.
         The integer value of <attr>cols</attr> must be between 2 and 6
         (inclusive).
             <idx><h sortby="exercisegroup"><tag>exercisegroup</tag></h><h>columns</h></idx>
@@ -1036,7 +1036,7 @@
       <p>Because of the range of divisions that can contain an
       <tag>exercise</tag> element with different names displayed (such
       as <q>Checkpoint</q> for an inline exercise), one cannot simply
-      use <attr>element="exercise"</attr> in a <tag>rename</tag>
+      use <attr>element</attr> with value <c>exercise</c> in a <tag>rename</tag>
       element. The value of <attr>element</attr> to rename an
       <tag>exercise</tag> is as follows:
       <ul>
@@ -1540,7 +1540,7 @@
         So we can type <tage>xref ref="basics-s-xref"</tage> to create a reference to this subsection:
         <xref ref="basics-s-xref"/>.
         There are lots of options to control what text and number appear when you use <tag>xref</tag>.
-        The default is <attr>text="type-gobal"</attr>,
+        The default is <attr>text</attr> with value <c>type-gobal</c>,
         which produces something like <q>Subsection 3.3</q> or <q>Theorem 3.1.4</q>.
         The type is <q>Subsection</q> or <q>Theorem</q>,
         and the <em>global</em> number is 3.3 or 3.1.4. (Global is in contrast to local,

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3840,37 +3840,37 @@ the xsltproc executable.
 
                 <sbsgroup>
                     <sidebyside>
-                        <p>No description, no <attr>decorative="yes"</attr></p>
+                        <p>No description, no <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png"/>
-                        <p>No description, <attr>decorative="yes"</attr></p>
+                        <p>No description, <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png" decorative="yes"/>
                     </sidebyside>
                     <sidebyside>
-                        <p>Empty description, no <attr>decorative="yes"</attr></p>
+                        <p>Empty description, no <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png">
                             <description/>
                         </image>
-                        <p>Empty description, <attr>decorative="yes"</attr></p>
+                        <p>Empty description, <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png" decorative="yes">
                             <description/>
                         </image>
                     </sidebyside>
                     <sidebyside>
-                        <p>Too long description, no <attr>decorative="yes"</attr></p>
+                        <p>Too long description, no <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png">
                             <description>This description is too long because when alt text is longer than 125 characters, some scren readers will cut off reading the alt text after the 125th character.</description>
                         </image>
-                        <p>Too long description, <attr>decorative="yes"</attr></p>
+                        <p>Too long description, <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png" decorative="yes">
                             <description>This description is too long because when alt text is longer than 125 characters, some scren readers will cut off reading the alt text after the 125th character.</description>
                         </image>
                     </sidebyside>
                     <sidebyside>
-                        <p>Good description, no <attr>decorative="yes"</attr></p>
+                        <p>Good description, no <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png">
                             <description>A white square outlined in blue covered by a black X</description>
                         </image>
-                        <p>Good description, <attr>decorative="yes"</attr></p>
+                        <p>Good description, <attr>decorative</attr> set to <c>yes</c></p>
                         <image source="images/cross-square.png" decorative="yes">
                             <description>A white square outlined in blue covered by a black X</description>
                         </image>
@@ -6106,7 +6106,7 @@ the xsltproc executable.
 
                 <p><url href="https://jsxgraph.uni-bayreuth.de/wp/docs_jessiecode/">JessieCode</url> is a scripting language for JSXGraph. It provides the core geometric and graphing features of JSXGraph without accessing the underlying JavaScript. In order to use JessieCode, you simply create the HTML <tag>div</tag> element as you would for any other JSXGraph interactive plot and then provide the JessieCode script, which focuses on the geometric elements.</p>
 
-                <p>Because JessieCode is provided by JSXGraph, the interactive platform is <c>jsxgraph</c>. The <tag>slate</tag>, however, uses <attr>surface="jessiecode"</attr>. The script can be embedded directly in your code. As usual, you would need to remember to escape the special characters. JessieCode uses <c>&lt;</c> and <c>&gt;</c> for inequalities as well as for declaring objects used to style geometric elements, and <c>&amp;&amp;</c> is the boolean AND operator. Alternatively, you can provide the file as a separate resource, providing the URL with a <attr>source</attr> attribute. Attributes defining the JSXBoard at the time it is created should be included as attributes of the <tag>slate</tag>, including <attr>boundingbox</attr>, <attr>axis</attr>, and <attr>grid</attr>.</p>
+                <p>Because JessieCode is provided by JSXGraph, the interactive platform is <c>jsxgraph</c>. The <tag>slate</tag>, however, uses <attr>surface</attr> with value <c>jessiecode</c>. The script can be embedded directly in your code. As usual, you would need to remember to escape the special characters. JessieCode uses <c>&lt;</c> and <c>&gt;</c> for inequalities as well as for declaring objects used to style geometric elements, and <c>&amp;&amp;</c> is the boolean AND operator. Alternatively, you can provide the file as a separate resource, providing the URL with a <attr>source</attr> attribute. Attributes defining the JSXBoard at the time it is created should be included as attributes of the <tag>slate</tag>, including <attr>boundingbox</attr>, <attr>axis</attr>, and <attr>grid</attr>.</p>
 
                 <p>For this first example, the JessieCode was included directly in the XML source as the contents of the associated slate.</p>
 


### PR DESCRIPTION
I think I keep being led to write like `<attr>key=value</attr>` because I look up other instances and see it there, and think it is an OK thing to do. So this commit removes those instances.