### PR TITLE
HTML: collapse stacked headings in solutions

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1448,12 +1448,40 @@ the xsltproc executable.
                     <title>Test Two</title>
 
                     <p>An intervening subsection section which contains an <tag>exercises</tag> division which must be at the level of a Subsubsubsection.</p>
+                    <exercise>
+                        <statement>
+                            <p>An inline exercise to examine any clash with divisional exercises below.</p>
+                        </statement>
+                        <answer>
+                            <p>An answer so there is something to appear in a <tag>solutions</tag>.</p>
+                        </answer>
+                    </exercise>
+
+                    <reading-questions>
+                        <title>What Did You Learn?</title>
+                        <exercise>
+                            <statement>
+                                <p>A mock exercise to appease validation.</p>
+                            </statement>
+                            <answer>
+                                <p>An answer so there is something to appear in a <tag>solutions</tag>.</p>
+                            </answer>
+                        </exercise>
+                        <exercise>
+                            <statement>
+                                <p>And a second to help with formatting the division heading.</p>
+                            </statement>
+                        </exercise>
+                    </reading-questions>
 
                     <exercises>
                         <exercise>
                             <statement>
                                 <p>A mock exercise to appease validation.</p>
                             </statement>
+                            <answer>
+                                <p>An answer so there is something to appear in a <tag>solutions</tag>.</p>
+                            </answer>
                         </exercise>
                         <exercise>
                             <statement>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3369,6 +3369,19 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="false()" />
 </xsl:template>
 
+<!-- Specialized divisions (exercises, worksheet, reading-questions) sometimes   -->
+<!-- get special handling when the parent division is unstructured.              -->
+<xsl:template match="*" mode="is-specialized-division-in-unstructured">
+    <xsl:value-of select="false()"/>
+</xsl:template>
+
+<xsl:template match="exercises|worksheet|reading-questions" mode="is-specialized-division-in-unstructured">
+    <xsl:variable name="parent-is-structured">
+        <xsl:apply-templates select="parent::*" mode="is-structured-division"/>
+    </xsl:variable>
+    <xsl:value-of select="not($parent-is-structured = 'true')"/>
+</xsl:template>
+
 <!-- Structural Leaves -->
 <!-- Some structural elements of the document tree     -->
 <!-- are the leaves of that tree, meaning they do      -->
@@ -7369,6 +7382,9 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     </xsl:apply-templates>
 </xsl:template>
 
+<!-- If not explicitly addressed in another template, dry-run returns empty -->
+<xsl:template match="*" mode="dry-run"/>
+
 <!-- This template is called for items in a worksheet that can have a  -->
 <!-- workspace specified.  It is important that this sometimes returns -->
 <!-- an empty string, since that is a signal to not construct some     -->
@@ -7492,6 +7508,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                 <xsl:with-param name="purpose" select="$purpose" />
                 <xsl:with-param name="admit"   select="$admit"/>
                 <xsl:with-param name="heading-level" select="$heading-level"/>
+                <xsl:with-param name="scope" select="$scope"/>
                 <xsl:with-param name="b-inline-statement"     select="contains(@inline,     'statement')" />
                 <xsl:with-param name="b-inline-hint"          select="contains(@inline,     'hint')"      />
                 <xsl:with-param name="b-inline-answer"        select="contains(@inline,     'answer')"    />
@@ -7520,6 +7537,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                 <xsl:with-param name="purpose" select="$purpose" />
                 <xsl:with-param name="admit"   select="$admit"/>
                 <xsl:with-param name="heading-level" select="$heading-level"/>
+                <xsl:with-param name="scope" select="ancestor::*[not(self::backmatter)][1]"/>
                 <xsl:with-param name="b-inline-statement"     select="contains(@inline,     'statement')" />
                 <xsl:with-param name="b-inline-hint"          select="contains(@inline,     'hint')"      />
                 <xsl:with-param name="b-inline-answer"        select="contains(@inline,     'answer')"    />
@@ -7574,7 +7592,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 
 <!-- Context is the originally the scope (root of subtree examined)      -->
 <!-- and is meant to be a "traditional" division, as expressed in        -->
-<!-- the schema.  However, on recusion context can be any division       -->
+<!-- the schema.  However, on recursion context can be any division      -->
 <!-- containing exercises, such as "worksheet".  We do not allow a       -->
 <!-- "solutions" division to live inside a "part", so in the default     -->
 <!-- use a part is not the context.  This is all to explain that         -->
@@ -7583,13 +7601,15 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- On first call, the placing division should have a descriptive       -->
 <!-- title from the author, such as "Solutions to Chapter Exercises",    -->
 <!-- when placed at the level of a section (and assuming default scope). -->
-<!-- So the "b-has-heading" should default to false, *and should not     -->
-<!-- be overridden*.  Recursive calls will set this variable to true,    -->
-<!-- and then there will be sectioning of the solutions.                 -->
 <!--                                                                     -->
-<!-- Similarly, "scope" is set to the context on first call, then        -->
-<!-- replicated/preserved/remembered in recursive calls, so do not       -->
-<!-- pass in a different value.                                          -->
+<!-- "scope" is replicated/preserved/remembered in recursive calls.      -->
+<!--                                                                     -->
+<!-- "heading-stack" is a node set consisting of all divisional nodes    -->
+<!-- between the current node and the scope that warrant having their    -->
+<!-- heading printed when the "leaf" division is finally dropping its    -->
+<!-- content. It includes the "scope" even though the scope's heading    -->
+<!-- may ultimately not be printed. The "division-in-solutions"          -->
+<!-- template can cut scope from the heading-stack when desired.         -->
 <!--                                                                     -->
 <!-- NB: this template is used/called directly by the                    -->
 <!-- "solution-manual-latex.xsl" stylesheet, so coordinate               -->
@@ -7599,8 +7619,8 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:param name="purpose"/>
     <xsl:param name="admit"/>
     <xsl:param name="heading-level"/>
-    <xsl:param name="b-has-heading" select="false()"/>
-    <xsl:param name="scope" select="."/>
+    <xsl:param name="heading-stack" select="."/>
+    <xsl:param name="scope"/>
     <xsl:param name="b-inline-statement"     />
     <xsl:param name="b-inline-hint"          />
     <xsl:param name="b-inline-answer"        />
@@ -7650,6 +7670,38 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
             <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
         </xsl:apply-templates>
     </xsl:variable>
+
+    <!-- Now apply dry-run to preceding-siblings. If this comes back empty, -->
+    <!-- we know that this division should pass along the heading-stack     -->
+    <!-- node set of ancestors for grouping stacked headings.               -->
+    <!-- Otherwise, set the heading-stack to just this division.            -->
+    <xsl:variable name="preceding-sibling-dry-run">
+        <xsl:apply-templates select="preceding-sibling::*" mode="dry-run">
+            <xsl:with-param name="admit"                  select="$admit"/>
+            <xsl:with-param name="b-inline-statement"     select="$b-inline-statement" />
+            <xsl:with-param name="b-inline-answer"        select="$b-inline-answer" />
+            <xsl:with-param name="b-inline-hint"          select="$b-inline-hint" />
+            <xsl:with-param name="b-inline-solution"      select="$b-inline-solution" />
+            <xsl:with-param name="b-divisional-statement" select="$b-divisional-statement" />
+            <xsl:with-param name="b-divisional-answer"    select="$b-divisional-answer" />
+            <xsl:with-param name="b-divisional-hint"      select="$b-divisional-hint" />
+            <xsl:with-param name="b-divisional-solution"  select="$b-divisional-solution" />
+            <xsl:with-param name="b-worksheet-statement"  select="$b-worksheet-statement" />
+            <xsl:with-param name="b-worksheet-answer"     select="$b-worksheet-answer" />
+            <xsl:with-param name="b-worksheet-hint"       select="$b-worksheet-hint" />
+            <xsl:with-param name="b-worksheet-solution"   select="$b-worksheet-solution" />
+            <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
+            <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
+            <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
+            <xsl:with-param name="b-reading-solution"     select="$b-worksheet-solution" />
+            <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
+            <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
+            <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
+            <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
+        </xsl:apply-templates>
+    </xsl:variable>
+    <xsl:variable name="b-preceding-empty" select="$preceding-sibling-dry-run = ''"/>
+    <xsl:variable name="next-heading-stack" select=".|ancestor::*[$b-preceding-empty and (count(.|$heading-stack) = count($heading-stack))]"/>
 
     <xsl:if test="not($dry-run = '')">
         <!-- We call the only real abstract template, it simply        -->
@@ -7702,7 +7754,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         <xsl:apply-templates select="." mode="division-in-solutions">
             <xsl:with-param name="scope" select="$scope" />
             <xsl:with-param name="heading-level" select="$heading-level"/>
-            <xsl:with-param name="b-has-heading" select="$b-has-heading"/>
+            <xsl:with-param name="heading-stack" select="$next-heading-stack"/>
             <xsl:with-param name="content">
 
                 <xsl:for-each select="exercise|subexercises|exercisegroup|&PROJECT-LIKE;|paragraphs/exercise|self::worksheet//exercise">
@@ -7782,13 +7834,15 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <!-- On every recursion (not initial call) we request a heading  -->
     <!-- and we pass in the scope of original call for help deciding -->
     <!-- the level of headings given surroundings.                   -->
-    <!-- This is recurrence, so increment $heading-level.            -->
+    <!-- This is recurrence, so one might expect to increment $heading-level. -->
+    <!-- But to collapse stacked headings, we leave heading-level stable at   -->
+    <!-- the "solutions" level and the output stylesheet should increment 1.  -->
     <!-- NB: $b-component-heading is recomputed, so is not passed    -->
     <xsl:apply-templates select="book|article|part|chapter|section|subsection|subsubsection|exercises|worksheet|reading-questions" mode="solutions-generator">
         <xsl:with-param name="purpose" select="$purpose" />
         <xsl:with-param name="admit"   select="$admit"/>
-        <xsl:with-param name="heading-level" select="$heading-level + 1"/>
-        <xsl:with-param name="b-has-heading" select="true()" />
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:with-param name="heading-stack" select="$next-heading-stack"/>
         <xsl:with-param name="scope" select="$scope" />
         <xsl:with-param name="b-inline-statement"     select="$b-inline-statement" />
         <xsl:with-param name="b-inline-answer"        select="$b-inline-answer" />
@@ -7811,6 +7865,56 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
         <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
     </xsl:apply-templates>
+</xsl:template>
+
+<!-- An abstract outer template for each division when repeated in the solutions.                             -->
+<!-- This calls "duplicate-heading" modal template, which implements output-specific mechanisms for headings. -->
+
+<xsl:template match="book|article|part|chapter|section|subsection|subsubsection|exercises|worksheet|reading-questions" mode="division-in-solutions">
+    <xsl:param name="scope" />
+    <xsl:param name="heading-level"/>
+    <xsl:param name="heading-stack"/>
+    <xsl:param name="content" />
+    <xsl:variable name="is-structured">
+        <xsl:apply-templates select="." mode="is-structured-division"/>
+    </xsl:variable>
+    <xsl:variable name="is-specialized-division-in-unstructured">
+        <xsl:apply-templates select="." mode="is-specialized-division-in-unstructured"/>
+    </xsl:variable>
+
+    <!-- We cut "scope" from heading-stack.                                          -->
+    <xsl:variable name="final-heading-stack" select="ancestor-or-self::*[(count(.|$heading-stack) = count($heading-stack)) and (count(.|$scope) != count($scope))]"/>
+
+    <!-- A structured division cannot have children that have solution-like things   -->
+    <!-- So we withhold headings for such divisions, passing to the "leaf" division, -->
+    <!-- which must itself be unstructured.                                          -->
+    <xsl:choose>
+        <xsl:when test="count($final-heading-stack) = 0">
+            <xsl:copy-of select="$content" />
+        </xsl:when>
+        <!-- Specialize subdivisions in unstructured divisions               -->
+        <!-- have a heading level that is 2 deeper from invoking "solutions" -->
+        <!-- and their heading does not carry the heading stack.             -->
+        <xsl:when test="$is-specialized-division-in-unstructured = 'true'">
+            <xsl:apply-templates select="." mode="duplicate-heading">
+                <xsl:with-param name="heading-level" select="$heading-level + 2"/>
+            </xsl:apply-templates>
+            <xsl:copy-of select="$content" />
+        </xsl:when>
+        <!-- Other leaf divisions do carry a heading stack       -->
+        <!-- and are only 1 deeper than the invoking "solutions" -->
+        <xsl:when test="not($is-structured = 'true')">
+            <xsl:apply-templates select="." mode="duplicate-heading">
+                <xsl:with-param name="heading-level" select="$heading-level + 1"/>
+                <xsl:with-param name="heading-stack" select="$final-heading-stack"/>
+            </xsl:apply-templates>
+            <xsl:copy-of select="$content" />
+        </xsl:when>
+        <!-- Content in something structred should just be recursing down to unstructured leaves. -->
+        <xsl:otherwise>
+            <xsl:copy-of select="$content" />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -4534,75 +4534,75 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Solutions Divisions, Content Generation -->
 <!-- ####################################### -->
 
-<!-- We pass in the "scope", which will be a traditional division   -->
-<!-- and then can create an appropriate size for a heading (without -->
-<!-- needing to deal with specialized divisions possibly appearing  -->
-<!-- at most any level).                                            -->
-<!-- "book" and "article" need to be in the match so this template  -->
-<!-- is defined for those top-level (whole document) cases, even if -->
-<!-- $b-has-heading will always be "false" in these situations.     -->
-<!-- TODO: this could be an xparse environment, perhaps -->
-<!-- with a key indicating fontsize or division level   -->
-<xsl:template match="book|article|part|chapter|section|subsection|subsubsection|exercises|worksheet|reading-questions" mode="division-in-solutions">
-    <xsl:param name="scope" />
-    <xsl:param name="b-has-heading"/>
-    <xsl:param name="content" />
-    <!-- Usually we create an automatic heading,  -->
-    <!-- but not at the root division -->
-    <xsl:if test="$b-has-heading">
-        <xsl:variable name="font-size">
-            <xsl:choose>
-                <!-- backmatter placement gets appendix like chapter -->
-                <xsl:when test="$scope/self::book">
-                    <xsl:text>\Large</xsl:text>
-                </xsl:when>
-                <!-- backmatter placement gets appendix like section -->
-                <xsl:when test="$scope/self::article">
-                    <xsl:text>\large</xsl:text>
-                </xsl:when>
-                <!-- divisional placement is one level less -->
-                <xsl:when test="$scope/self::chapter">
-                    <xsl:text>\Large</xsl:text>
-                </xsl:when>
-                <xsl:when test="$scope/self::section">
-                    <xsl:text>\large</xsl:text>
-                </xsl:when>
-                <xsl:when test="$scope/self::subsection">
-                    <xsl:text>\normalsize</xsl:text>
-                </xsl:when>
-                <xsl:when test="$scope/self::subsubsection">
-                    <xsl:text>\normalsize</xsl:text>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:message>PTX:BUG:     "solutions" division title does not have a font size</xsl:message>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
+<!-- The "division-in-solutions" modal template from -common   -->
+<!-- calls the "duplicate-heading" modal template.             -->
+<!-- Stacked headings are all \Large, regardless of which      -->
+<!-- level of depth they reflect. This is consistent with      -->
+<!-- treating stacked headings as a single "squashed" heading. -->
 
-        <!-- Is the current division part of a structured division  -->
-        <!-- and hence display its number at birth?  (Not as simple -->
-        <!-- as: does it *have* a number?)                          -->
-        <xsl:variable name="is-structured">
-            <xsl:apply-templates select="parent::*" mode="is-structured-division"/>
-        </xsl:variable>
-        <xsl:variable name="b-is-structured" select="$is-structured = 'true'"/>
-
-        <!-- LaTeX heading, possibly with hard-coded number -->
-        <xsl:text>\par\smallskip&#xa;\noindent\textbf{</xsl:text>
-        <xsl:value-of select="$font-size" />
-        <!-- A structured division has numbered subdivisions              -->
-        <!-- Otherwise "exercises" do not display their number at "birth" -->
-        <xsl:if test="$b-is-structured">
-            <xsl:text>{}</xsl:text>
-            <xsl:apply-templates select="." mode="number" />
-            <xsl:text>\space</xsl:text>
-        </xsl:if>
-        <xsl:text>\textperiodcentered\space{}</xsl:text>
-        <xsl:apply-templates select="." mode="title-full" />
-        <xsl:text>}&#xa;\par\smallskip&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:copy-of select="$content" />
+<xsl:template match="*" mode="duplicate-heading">
+    <xsl:param name="heading-level"/>
+    <xsl:param name="heading-stack" select="."/>
+    <xsl:variable name="text-size">
+        <xsl:call-template name="get-heading-text-size">
+            <xsl:with-param name="heading-level" select="$heading-level"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:text>\par\medskip&#xa;\noindent\textbf{</xsl:text>
+    <xsl:value-of select="$text-size"/>
+    <xsl:text>{}</xsl:text>
+    <xsl:apply-templates select="$heading-stack" mode="duplicate-heading-content">
+        <xsl:with-param name="heading-stack" select="$heading-stack"/>
+    </xsl:apply-templates>
+    <xsl:text>}&#xa;</xsl:text>
 </xsl:template>
+
+<xsl:template match="*" mode="duplicate-heading-content">
+    <xsl:param name="heading-stack"/>
+    <xsl:variable name="is-specialized-division-in-unstructured">
+        <xsl:apply-templates select="." mode="is-specialized-division-in-unstructured"/>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="$is-specialized-division-in-unstructured = 'true'">
+            <xsl:text>\textperiodcentered\space{}</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="number" />
+            <xsl:text>\space\textperiodcentered\space{}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates select="." mode="title-full" />
+    <!-- line break, but not on last -->
+    <xsl:if test="count(descendant::*[count(.|$heading-stack) = count($heading-stack)]) > 0">
+        <xsl:text>\\&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="get-heading-text-size">
+    <xsl:param name="heading-level" select="6"/>
+    <xsl:choose>
+        <xsl:when test="$heading-level = 1">
+            <xsl:text>\Huge</xsl:text>
+        </xsl:when>
+        <xsl:when test="$heading-level = 2">
+            <xsl:text>\huge</xsl:text>
+        </xsl:when>
+        <xsl:when test="$heading-level = 3">
+            <xsl:text>\Large</xsl:text>
+        </xsl:when>
+        <xsl:when test="$heading-level = 4">
+            <xsl:text>\large</xsl:text>
+        </xsl:when>
+        <xsl:when test="$heading-level = 5">
+            <xsl:text>\normalsize</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>\normalsize</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+
 
 <!-- ############### -->
 <!-- Arbitrary Lists -->
@@ -4827,7 +4827,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- "solutions" content needs to call content generator       -->
     <xsl:choose>
         <xsl:when test="self::solutions">
-            <xsl:apply-templates select="." mode="solutions" />
+            <xsl:apply-templates select="." mode="solutions">
+                <xsl:with-param name="heading-level">
+                    <xsl:choose>
+                        <xsl:when test="parent::book">1</xsl:when>
+                        <xsl:when test="parent::part">2</xsl:when>
+                        <xsl:when test="parent::article">3</xsl:when>
+                        <xsl:when test="parent::chapter">3</xsl:when>
+                        <xsl:when test="parent::section">4</xsl:when>
+                        <xsl:when test="parent::subsection">5</xsl:when>
+                        <xsl:when test="parent::subsubsection">6</xsl:when>
+                        <xsl:when test="parent::backmatter and $document-root/self::book">2</xsl:when>
+                        <xsl:when test="parent::backmatter and $document-root/self::article">3</xsl:when>
+                        <xsl:when test="parent::appendix and $document-root/self::book">3</xsl:when>
+                        <xsl:when test="parent::appendix and $document-root/self::article">4</xsl:when>
+                        <xsl:otherwise>6</xsl:otherwise>
+                    </xsl:choose>
+                </xsl:with-param>
+            </xsl:apply-templates>
         </xsl:when>
         <xsl:otherwise>
             <xsl:apply-templates/>


### PR DESCRIPTION
This PR is perhaps just for discussion.

This commit collapses stacked headings in "solutions". For example, look at the current:

https://pretextbook.org/examples/sample-article/html/solutions-backmatter.html

As I inspect that page now, none of the:
```
4 An Interesting Corollary
4.2 A Pedagogical Note about Subsection 4.1
4.2.1 Symbolic and Numerical Integrals
```
use hN. But I think the sample article has not been rebuilt following the merge of #1598. And with that merged, this is currently coming out as:
```
(h3) 4 An Interesting Corollary
(h4) 4.2 A Pedagogical Note about Subsection 4.1
(h5) 4.2.1 Symbolic and Numerical Integrals
```

This commit collapses that into:
```
(h3) 4.2.1 Symbolic and Numerical Integrals
```

And the whole page of headings becomes:
```
(h3) 4.2.1 Symbolic and Numerical Integrals
(h3) 4.2.3 Advice
(h3) 4.2.4 Exercises
(h3) 4.6.2 Test Two [appears because of answers added in this commit]
(h3) 11.3 More Exercises
(h3) 21 Program Listings
...
```

So, all styled the same and all at h3, even though there are different logical depths. The benefit is that heading tree has been simplified.

One reason that this is just for discussion is because maybe instead of:
```
(h3) 4.2.1 Symbolic and Numerical Integrals
```
people would prefer something like:
```
(h3) 4 An Interesting Corollary
     4.2 A Pedagogical Note about Subsection 4.1
     4.2.1 Symbolic and Numerical Integrals (/h3)
```
Personally I feel that is too busy, but I could understand wanting to show all the titles that lead up to the "leaf" division.


