### PR TITLE
Slideshow: update Reveal.js version

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -88,16 +88,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- load reveal.js resources             -->
             <xsl:choose>
                 <xsl:when test="$b-reveal-minified">
-                    <link href="{$reveal-root}/css/reset.min.css" rel="stylesheet"></link>
-                    <link href="{$reveal-root}/css/reveal.min.css" rel="stylesheet"></link>
-                    <link href="{$reveal-root}/css/theme/{$reveal-theme}.min.css" rel="stylesheet"></link>
-                    <script src="{$reveal-root}/js/reveal.min.js"></script>
+                    <link href="{$reveal-root}/reset.min.css" rel="stylesheet"></link>
+                    <link href="{$reveal-root}/reveal.min.css" rel="stylesheet"></link>
+                    <link href="{$reveal-root}/theme/{$reveal-theme}.min.css" rel="stylesheet"></link>
+                    <script src="{$reveal-root}/reveal.min.js"></script>
                 </xsl:when>
                 <xsl:otherwise>
-                    <link href="{$reveal-root}/css/reset.css" rel="stylesheet"></link>
-                    <link href="{$reveal-root}/css/reveal.css" rel="stylesheet"></link>
-                    <link href="{$reveal-root}/css/theme/{$reveal-theme}.css" rel="stylesheet"></link>
-                    <script src="{$reveal-root}/js/reveal.js"></script>
+                    <link href="{$reveal-root}/reset.css" rel="stylesheet"></link>
+                    <link href="{$reveal-root}/reveal.css" rel="stylesheet"></link>
+                    <link href="{$reveal-root}/theme/{$reveal-theme}.css" rel="stylesheet"></link>
+                    <script src="{$reveal-root}/reveal.js"></script>
                 </xsl:otherwise>
             </xsl:choose>
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1960,7 +1960,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- CDN is used twice, so just edit here -->
     <!-- NB: deprecation is frozen -->
     <xsl:variable name="cdn-url">
-        <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0</xsl:text>
+        <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2</xsl:text>
     </xsl:variable>
 
     <xsl:choose>


### PR DESCRIPTION
Updates to load the most recent reveal.js on the cloudflare cdn (4.1.2).

Recent versions in the cdn do not have `css` and `js` folders. You just go straight to the css and js files you are after.

Also [the actual repo](https://github.com/hakimel/reveal.js/tree/master/dist) has a `dist` folder that has the necessary js and css files instead of using css and js subfolders for these. So if you provide locally, you would drop these files all together in your reveal-root folder instead of using the intermediate folders.

Since revealjs slideshows are provisionally supported, not sure what other things I should do at the same time. The current section about revealjs in the doc doesn't appear to get into the details of having a `css` and `js` subfolder. 

BTW, I was writing a revealjs slideshow through PTX, trying to use a newer feature of revealjs, and it wasn't working. That is what led me to make this update. Now it's working: [live background page on a slide](https://spot.pcc.edu/~ajordan/MHECWWdemo/slideshow.html#/1/1).