### PR TITLE
WeBWorK: copy problems that use tasks

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -202,7 +202,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- @name -> @xml:id  mapping until we are done assembling -->
                     <xsl:variable name="target" select="id(@copy)"/>
                     <xsl:choose>
-                        <xsl:when test="$target/statement|$target/stage">
+                        <xsl:when test="$target/statement|$target/task|$target/stage">
                             <xsl:copy>
                                 <xsl:attribute name="copied-from">
                                     <xsl:value-of select="@copy"/>


### PR DESCRIPTION
The `@copy` mechanism was not upgraded to handle WW exercises with tasks. This commit does that.