### PR TITLE
dl example expanded to show new 'narrow' behavior

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -4589,16 +4589,26 @@ the xsltproc executable.
                         <title>Bus!</title>
                         <p>A communication pathway with a protocol specifying exactly how the pathway is used. (The punctuation is just for testing.)</p>
                     </li>
+                 <li><title><m>\displaystyle \sum_{n=0}^\infty x^n = \frac{1}{1-x}</m></title>
+<p>A geometric series.  The formula is valid if <m>|x| &lt; 1</m>.</p>
+                 </li>
                 </dl></p>
 
-                <p>Some presentations can be assisted by a hint from the author about the lengths of the titles.  You can choose to provide a <c>width</c> attribute on a <c>dl</c> element with possible values <c>narrow</c>, <c>medium</c>, and <c>wide</c>.  Conversion to <latex /> ignores this attribute, and conversion to <init>HTML</init> only reacts to <c>narrow</c> (<c>medium</c> is the default, and <c>wide</c> behaves identically).<dl width="narrow">
+                <p>Some presentations can be assisted by a hint from the author about the lengths of the titles.  You can choose to provide a <c>width</c> attribute on a <c>dl</c> element with possible values <c>narrow</c> and <c>medium</c>.
+The value refers (somewhat confusingly) to the distance between the left margin and the description.  The default is <c>medium</c>, which is illustrated above.
+Conversion to <latex /> ignores the attribute.  An example with <c>narrow</c>:
+<!--
+, and <c>wide</c>.  Conversion to <latex /> ignores this attribute, and conversion to <init>HTML</init> only reacts to <c>narrow</c> (<c>medium</c> is the default, and <c>wide</c> behaves identically).
+-->
+                <dl width="narrow">
                     <li>
                         <title>Red</title>
                         <p>The color of the sun at sunset.</p>
                     </li>
                     <li>
                         <title>Blue</title>
-                        <p>The color of a clear sky.</p>
+                        <p>The color of a clear sky. Also a synonym for <q>depressed or sad</q>, the title of a 1971 Joni Mitchell album (and more than a dozen other musical albums),
+                           the period of Picasso's work between 1901 and 1904, and much more!</p>
                     </li>
                     <li>
                         <title>Aqua</title>
@@ -4608,7 +4618,30 @@ the xsltproc executable.
                         <title>Math <m>x^2</m></title>
                         <p>Sorry, not a color but testing titles with math in them.</p>
                     </li>
-                </dl></p>
+                    <li>
+                       <title><q>i</q> before <q>e</q> except after <q>c,</q> 
+                         unless it sounds like <q>a</q> as in <q>neighbor</q> and <q>weigh</q></title>
+               <p>Get feisty about that weird counterfeit rule: seize the day and don't 
+                  have a heifer, man.</p>
+                       </li>
+                <li><title>Magenta</title>
+<p>Magenta is a color, and a character in Rocky Horror.</p>
+                 </li>
+                 <li><title>Aquamarine</title>
+<p>Aquamarine is a color, and a mineral.</p>
+                 </li>
+                 <li><title>Those who cannot remember the past are condemned to repeat it.</title>
+<p>George Santayana wrote those words in 1905.  A similar aphorism is misattributed to Winston Churchill.  The idea is embodied in the 4th principle:
+                 <pretext/> respects the good design practices which have been developed over the past centuries.</p>
+                 </li>
+                 <li><title><m>\displaystyle \zeta(s) = \sum_{n=0}^\infty n^{-s} </m></title>
+<p>The Riemann <m>\zeta</m>-function is defined by a Dirichlet series, valid for <m> \Re(s) > 1</m>.</p>
+                 </li>
+                 <li><title><c>main()</c> is a void function</title>
+<p>A <c>dl</c> with <c>width="narrow></c> might be a useful way to give commentary on a program listing.</p>
+                 </li>
+                </dl>
+              </p>
             </subsection>
 
             <subsection>


### PR DESCRIPTION
The `width="narrow"` attribute on a `dl` now adjusts to allow very long terms.
The example in the Sample Article was expanded to illustrate this behavior.

No XSL changes were needed:  just choose the `narrow` option on the `dl`.