### PR TITLE
WeBWorK: use the problem id as problemUUID

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -678,7 +678,8 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                          ('course_password',course_password),
                          ('outputformat','ptx'),
                          server_params_source,
-                         ('problemSeed',seed[problem]))
+                         ('problemSeed',seed[problem]),
+                         ('problemUUID',problem))
 
         msg = "sending {} to server to save in {}: origin is '{}'"
         _verbose(msg.format(problem, dest_dir, origin[problem]))


### PR DESCRIPTION
When sending a request to the WW server, there is parameter `&problemUUID` that we have not used up to now. It did not exist when we first started WW-PTX, and I've been slow to come back to using it. This PR uses it, using the PTX visible-id of the problem.

I recently discovered that this is really needed. Take a look at:
https://pretextbook.org/examples/webwork/sample-chapter/html/section-9.html

Open checkpoint 9.1 and you will see the wrong graph. It's a graph of a cubic function that belongs in checkpoint 9.3. The explanation is that not using `problemUUID`, image files are overwriting each other on the server. Caching of image files with the same name compounds the issue, so even if you make that problem live, you still may see the wrong graph. But with `problemUUID` in use, `make sample-chapter-representations` is returning the correct image files.

Note: does your build script copy image files from the representations folder to where the public sample chapter HTML can get them? If not, then after this is merged, you will need to copy those image files over once manually. (But writing that into the build script would be good, in case other work brings in more image files.)

Note: now I will move to use `problemUUID`in the PTX-WW javascript too. Without that, I think that the live versions will still show wrong graphs in some cases.

Note: @sean-fitzpatrick the previous paragraph probably addresses the thing where if seeds are the same, we get images replacing each other.