### PR TITLE
Updates to Guide and Glossary

### DIFF
--- a/doc/guide/appendices/glossary.xml
+++ b/doc/guide/appendices/glossary.xml
@@ -37,7 +37,7 @@
         <defined-term>
                 <idx>attribute</idx>
             <title>attribute</title>
-            <p>in XML, tags can have attributes, which provide more information about the element.  For example,
+            <p>In XML, tags can have attributes, which provide more information about the element.  For example,
                in <c>&lt;section permid="dWf"></c> the tag is <q>section</q>,
                the attribute is <q>permid</q>, and the value of that attribute is <q>dWf</q>.</p>
         </defined-term>
@@ -254,6 +254,11 @@
         </defined-term>
 
         <defined-term>
+                <idx>main branch</idx>
+            <title>main branch</title>
+            <p>In git, the name of the default branch.</p>
+        </defined-term>
+        <defined-term>
                 <idx>Markdown</idx>
             <title>Markdown</title>
             <p>A plain text markup language which is easy to use, is limited in its capabilities
@@ -269,7 +274,8 @@
         <defined-term>
                 <idx>master branch</idx>
             <title>master branch</title>
-            <p>In git, the default branch.</p>
+            <p>In git, the former name of the default branch.
+               Curently <q>main</q> is the preferred.</p>
         </defined-term>
 
         <defined-term>
@@ -281,7 +287,7 @@
         <defined-term>
                 <idx>MBX</idx>
             <title>MBX</title>
-            <p><pretext/> was once known as <q>MathBook XML</q>, commonly abbreviated as MBX.  This abbreviation appears in some historical reference.</p>
+            <p><pretext/> was once known as <q>MathBook XML</q>, commonly abbreviated as MBX.  This abbreviation appears in many historical references.</p>
         </defined-term>
 
         <defined-term>
@@ -462,8 +468,8 @@
         </defined-term>
 
         <defined-term>
-                <idx>TeX</idx>
-            <title>TeX</title>
+                <idx><tex/></idx>
+            <title><tex/></title>
             <p>A typesetting language with high-quality automatic line- and page-breaking, specifically designed for mathematics.
             </p>
         </defined-term>
@@ -514,6 +520,11 @@
             <p>A format for storing video content.
             </p>
         </defined-term>
+        <defined-term>
+                <idx><webwork/></idx>
+            <title><webwork/></title>
+            <p>An open-source online homework system for math and sciences courses.</p>
+        </defined-term>
 
         <defined-term>
                 <idx>Wolfram CDF</idx>
@@ -525,8 +536,8 @@
         </defined-term>
 
         <defined-term>
-                <idx>XeLaTex</idx>
-            <title>XeLaTex</title>
+                <idx>XeLaTeX</idx>
+            <title>XeLaTeX</title>
             <p>One of the available programs to convert <latex/> to DVI or PDF.
             </p>
         </defined-term>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1325,7 +1325,7 @@
         <title>Mathematics</title>
         <idx>mathematics</idx>
 
-        <introduction>
+        <introduction xml:id="math-intro">
             <p>As mentioned in the overview, <xref ref="overview-math" />, we use <latex /> syntax for mathematics.  In order to allow for quality display in <init>HTML</init>, and other electronic formats, this limits us to the subset of <latex /> supported by the very capable <url href="https://www.mathjax.org/">MathJax</url> Javascript library.  Generally this looks like the <c>amsmath</c><idx><c>amsmath</c></idx> package maintained by the American Mathematical Society at their <url href="http://www.ams.org/publications/authors/tex/amslatex">AMS-LaTeX page</url>.  For a complete and precise list of what MathJax supports, see MathJax's <url href="http://docs.mathjax.org/en/latest/input/tex/macros/">Supported <tex/>/<latex/> commands</url><fn><c>http://docs.mathjax.org/en/latest/input/tex/macros/</c></fn> (2019-11-10: this link may be specific to MathJax 3.0, which we have not yet adopted.)  Once you have digested this more general section, be sure to also consult <xref ref="topic-mathematics-practices"/> for some very specific suggestions.</p>
         </introduction>
 
@@ -1553,7 +1553,7 @@
         <subsection xml:id="mathematics-notes">
             <title>Notes</title>
 
-            <p>As mentioned at the start of this section, your use of <latex/> needs to also be supported by MathJax so that it may be rendered as part of an <init>HTML</init> page displayed in a web broswer.  In addition to the information at the start of <xref ref="topic-mathematics"/>, this subsection has some notes that may help you navigate this situation.<ol>
+            <p>As mentioned at the <xref ref="math-intro" text="custom">start of this section</xref>, your use of <latex/> needs to also be supported by MathJax so that it may be rendered as part of an <init>HTML</init> page displayed in a web browser.  In addition to the information at the start of <xref ref="topic-mathematics"/>, this subsection has some notes that may help you navigate this situation.<ol>
                 <li>Generally, MathJax supports commands available in the <c>amsmath</c> package.</li>
                 <li>You can construct, and use, your own macros, <em>but only for mathematics</em>, not for document structure or document management.  See <xref ref="mathematics-macros"/>.</li>
                 <li>Support for loading <q>extra</q> packages is extremely limited.  See <xref ref="mathematics-latex-packages"/>.</li>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1326,7 +1326,7 @@
         <idx>mathematics</idx>
 
         <introduction xml:id="math-intro">
-            <p>As mentioned in the overview, <xref ref="overview-math" />, we use <latex /> syntax for mathematics.  In order to allow for quality display in <init>HTML</init>, and other electronic formats, this limits us to the subset of <latex /> supported by the very capable <url href="https://www.mathjax.org/">MathJax</url> Javascript library.  Generally this looks like the <c>amsmath</c><idx><c>amsmath</c></idx> package maintained by the American Mathematical Society at their <url href="http://www.ams.org/publications/authors/tex/amslatex">AMS-LaTeX page</url>.  For a complete and precise list of what MathJax supports, see MathJax's <url href="http://docs.mathjax.org/en/latest/input/tex/macros/">Supported <tex/>/<latex/> commands</url><fn><c>http://docs.mathjax.org/en/latest/input/tex/macros/</c></fn> (2019-11-10: this link may be specific to MathJax 3.0, which we have not yet adopted.)  Once you have digested this more general section, be sure to also consult <xref ref="topic-mathematics-practices"/> for some very specific suggestions.</p>
+            <p>As mentioned in the overview, <xref ref="overview-math" />, we use <latex /> syntax for mathematics.  In order to allow for quality display in <init>HTML</init>, and other electronic formats, this limits us to the subset of <latex /> supported by the very capable <url href="https://www.mathjax.org/">MathJax</url> Javascript library.  Generally this looks like the <c>amsmath</c><idx><c>amsmath</c></idx> package maintained by the American Mathematical Society at their <url href="http://www.ams.org/publications/authors/tex/amslatex">AMS-LaTeX page</url>.  For a complete and precise list of what MathJax supports, see MathJax's <url href="http://docs.mathjax.org/en/latest/input/tex/macros/">Supported <tex/>/<latex/> commands</url><fn><c>http://docs.mathjax.org/en/latest/input/tex/macros/</c></fn>. Once you have digested this more general section, be sure to also consult <xref ref="topic-mathematics-practices"/> for some very specific suggestions.</p>
         </introduction>
 
         <subsection>
@@ -1390,8 +1390,6 @@
             <title>Color in Mathematics</title>
 
             <p>There is a temptation to use color to indicate or highlight portions of mathematics, especially for electronic outputs where color is easy and cheap.  But before you leap, how will this work in black-and-white printed output?  How will it work for a blind reader using a screen-reader or a braille version?</p>
-
-            <p>If you must, be aware that for older versions of MathJax that we support for HTML output (v2.7, as of 2020-08-19), the relevant macros have slightly different behavior than for standard <latex/>.  But you can make both work if you are careful.  This should not be an issue with MathJax 3.</p>
 
             <p>With careful use of <tex/> grouping (<c>{...}</c>) you can make the two behaviors of <c>\color</c> effective.  For example, go:<cd>
                 <cline>{\color{blue}{x^2}}</cline>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3889,7 +3889,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Miscellaneous -->
-<xsl:template match="paragraphs|proof|case|defined-term|exercisegroup" mode="title-wants-punctuation">
+<xsl:template match="paragraphs|proof|case|exercisegroup" mode="title-wants-punctuation">
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Titled: list items, tasks of exercise, PROJECT-LIKE, EXAMPLE-LIKE -->


### PR DESCRIPTION
In the Guide:
Add xref to a section introduction, update the glossary, and omit references to MathJax 2.

In pretext-common:
Omit period at end of glossary terms