### PR TITLE
Upgrade CSS

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2683,7 +2683,7 @@ the xsltproc executable.
             <subsection>
                 <title><init>HTML</init> and accidental mathematics</title>
 
-                <p>We render mathematics in web pages with the fantastic MathJax Javascript library.  Simplifying just a bit, it recognizes <latex/> syntax within a page, takes control of that text, and replaces it wth nice fonts and formatting.  Now, if you write about <latex/> you might well have some mathematics in your examples.  Best practice would be to use verbatim text for that, and we mark off such text as being off-limits to MathJax.</p>
+                <p>We render mathematics in web pages with the fantastic MathJax Javascript library.  Simplifying just a bit, it recognizes <latex/> syntax within a page, takes control of that text, and replaces it with nice fonts and formatting.  Now, if you write about <latex/> you might well have some mathematics in your examples.  Best practice would be to use verbatim text for that, and we mark off such text as being off-limits to MathJax.</p>
 
                 <p>But if you are writing running text, then you can (accidentally) author some text which MathJax recognizes and converts to something (unintended).  And if you are doing this intentionally, then you have ignored <pretext/> markup for mathematics, and are missing out on some features.</p>
 
@@ -2693,6 +2693,17 @@ the xsltproc executable.
 
                 <p>Display mathematics: \begin{align}x^2+y^2=z^2\end{align}</p>
             </subsection>
+
+            <paragraphs><title>Accidental <latex/></title>
+                <p>The way <latex/> does <q>smart quotes,</q> ``like this,''
+                   causes a conflict with MathJax <ndash/> the backtick is
+                   the delimeter for AsciiMath.  This page may have an
+                   error in the math rendering, or the backticks may not appear,
+                   until this issue is resolved.
+                </p>
+
+                <p>Also check on the multiple backticks a few paragraphs above.</p>
+             </paragraphs>
         </section>
 
         <section xml:id="graphics">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -89,7 +89,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- visit the "css" directory and make an update there      -->
 <!-- for the benefit of offline formats                      -->
 <xsl:param name="html.css.server" select="'https://pretextbook.org'" />
-<xsl:param name="html.css.version" select="'0.31'" />
+<xsl:param name="html.css.version" select="'0.4'" />
 <xsl:param name="html.js.server" select="'https://pretextbook.org'" />
 <xsl:param name="html.js.version" select="'0.13'" />
 


### PR DESCRIPTION
Issues with stacked headings required a non-backward-compatible change to the CSS.
Upgrading the CSS version only involved changing one line.

I also started work on issue #1620 which concerns backticks.  Since the introduction
of MathJax3 there had been a problem with backticks, which was visible in the HTML
of the text-in-paragraphs section of the sample article, but nobody noticed it.  So I
added more to that section.

Don't accept this pull request yet, because I may be close to figuring out how to
change the MathJax configuration to fixing this problem.  If I do, I'll add that to this
pull request.