### PR TITLE
HTML: straighten out heading level for block elements

### DIFF
--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -71,6 +71,8 @@
 <!-- statement + proof -->
 <!ENTITY THEOREM-LIKE "theorem|corollary|lemma|algorithm|proposition|claim|fact|identity">
 <!ENTITY THEOREM-FILTER "self::theorem or self::corollary or self::lemma or self::algorithm or self::proposition or self::claim or self::fact or self::identity">
+<!-- catch a proof that is inside THEOREM-LIKE -->
+<!ENTITY INNER-PROOF-FILTER "self::proof and (parent::theorem or parent::corollary or parent::lemma or parent::algorithm or parent::proposition or parent::claim or parent::fact or parent::identity)">
 
 <!-- a mathematical statement, but never with a proof -->
 <!ENTITY AXIOM-LIKE "axiom|conjecture|principle|heuristic|hypothesis|assumption">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7760,14 +7760,32 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         </xsl:variable>
         <xsl:variable name="b-component-heading" select="string-length($variety) &gt; 1"/>
 
+        <!-- Specialized divisions in unstructured divisions have a heading   -->
+        <!-- level that is 2 deeper from invoking "solutions".                -->
+        <!-- Other leaf divisions are 1 deeper than the invoking "solutions". -->
+        <xsl:variable name="is-specialized-division-in-unstructured">
+            <xsl:apply-templates select="." mode="is-specialized-division-in-unstructured"/>
+        </xsl:variable>
+        <xsl:variable name="next-heading-level">
+            <xsl:choose>
+                <xsl:when test="$is-specialized-division-in-unstructured = 'true'">
+                    <xsl:value-of select="$heading-level + 2"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$heading-level + 1"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
         <xsl:apply-templates select="." mode="division-in-solutions">
             <xsl:with-param name="scope" select="$scope" />
-            <xsl:with-param name="heading-level" select="$heading-level"/>
+            <xsl:with-param name="heading-level" select="$next-heading-level"/>
             <xsl:with-param name="heading-stack" select="$next-heading-stack"/>
             <xsl:with-param name="content">
 
                 <!-- N.B.: inline exercises and PROJECT-LIKE can be   -->
                 <!-- "hidden" inside the "paragraphs" pseudo-division -->
+                <!-- Everything below is 1 deeper than the division's heading -->
                 <xsl:for-each select="exercise|subexercises|exercisegroup|&PROJECT-LIKE;|paragraphs/exercise|paragraphs/*[&PROJECT-FILTER;]|self::worksheet//exercise">
                      <xsl:choose>
                         <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;)">
@@ -7775,6 +7793,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose" />
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-inline-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-inline-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-inline-hint" />
@@ -7786,6 +7805,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose"/>
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
@@ -7797,6 +7817,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose"/>
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
@@ -7808,6 +7829,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose"/>
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-worksheet-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint" />
@@ -7819,6 +7841,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose"/>
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-reading-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-reading-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-reading-hint" />
@@ -7830,6 +7853,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
                                 <xsl:with-param name="purpose" select="$purpose"/>
                                 <xsl:with-param name="admit"   select="$admit"/>
                                 <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
                                 <xsl:with-param name="b-has-statement" select="$b-project-statement" />
                                 <xsl:with-param name="b-has-answer"    select="$b-project-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-project-hint" />
@@ -7893,8 +7917,13 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         <xsl:apply-templates select="." mode="is-specialized-division-in-unstructured"/>
     </xsl:variable>
 
-    <!-- We cut "scope" from heading-stack.                                          -->
-    <xsl:variable name="final-heading-stack" select="ancestor-or-self::*[(count(.|$heading-stack) = count($heading-stack)) and (count(.|$scope) != count($scope))]"/>
+    <!-- We cut "scope" from heading-stack if needed.                    -->
+    <!-- Or reset stack if specialized division in unstructured division -->
+    <xsl:variable name="final-heading-stack" select=".|ancestor-or-self::*[
+        $is-specialized-division-in-unstructured != 'true'
+        and (count(.|$heading-stack) = count($heading-stack))
+        and (count(.|$scope) != count($scope))]"
+    />
 
     <!-- A structured division cannot have children that have solution-like things   -->
     <!-- So we withhold headings for such divisions, passing to the "leaf" division, -->
@@ -7903,20 +7932,9 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         <xsl:when test="count($final-heading-stack) = 0">
             <xsl:copy-of select="$content" />
         </xsl:when>
-        <!-- Specialize subdivisions in unstructured divisions               -->
-        <!-- have a heading level that is 2 deeper from invoking "solutions" -->
-        <!-- and their heading does not carry the heading stack.             -->
-        <xsl:when test="$is-specialized-division-in-unstructured = 'true'">
-            <xsl:apply-templates select="." mode="duplicate-heading">
-                <xsl:with-param name="heading-level" select="$heading-level + 2"/>
-            </xsl:apply-templates>
-            <xsl:copy-of select="$content" />
-        </xsl:when>
-        <!-- Other leaf divisions do carry a heading stack       -->
-        <!-- and are only 1 deeper than the invoking "solutions" -->
         <xsl:when test="not($is-structured = 'true')">
             <xsl:apply-templates select="." mode="duplicate-heading">
-                <xsl:with-param name="heading-level" select="$heading-level + 1"/>
+                <xsl:with-param name="heading-level" select="$heading-level"/>
                 <xsl:with-param name="heading-stack" select="$final-heading-stack"/>
             </xsl:apply-templates>
             <xsl:copy-of select="$content" />


### PR DESCRIPTION
This puts the appropriate heading level on all of the hN for block objects in HTML. It's all controlled by the modal `hN` template which essentially counts ancestors that would appear on the page with a heading already.

Things I've tested:

- A diff on the before/after HTML output only has good changes. That diff is a monster, so if you want to look at it too, I pre-processed the files before making the diff. I changed `h\d` to `hN` so it wouldn't show lines where only the N changed.
- As noted in a thread, in the knowl files, an svg namespace is either moved or dropped altogether. Seems harmless.
- I inspected the headings all the way through the sample article HTML output, both at chunk level 0 and chunk level 1. The heading tree tool shows no invalid heading depth jumps. And I manually looked for other inappropiate things like jumping down in depth by 1 when that shouldn't happen. Or jumping up in depth when that shouldn't happen. Seems to be all good.
- I ran a validator on EPUB output for the epub sampler and it is has 40 validation errors! But presently, those are there with the dev branch too, and I don't think this PR makes it worse. So there is something to look into and fix, but it is unrelated to this. And perhaps epub validation checking needs to become more routine.

There is a list of heading issues in HTML yet to address. I'll list them here. I think that they are separate projects, but if you are looking at the output here, you might notice some of these "definciencies".

- In list-of output, we still have "stacked headings".
- In the index, I think that we should make it more navigable by making each letter be in an hN.
- In a solutions, exercises with tasks are still a source of stacked headings. Like Exercise 47, task (a), subtask (i) may have an answer to print. But task (a) does not need to be have its own heading.
- Related, tasks in solutions come out (with this PR's commit) labeled like "4.10.c.i". Maybe they will look better just as "(i)" or something like that. But it's something to tackle at the same time as the previous item.