### PR TITLE
Guide: multiline math, paragraphs, long titles

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -74,6 +74,12 @@
 
         <p>Many, many other structures admit titles.  Experiment, or look at specific descriptions of the structure you are interested in.  Titles are very integral to <pretext />, much like cross-references.  Titles migrate to the Table of Contents, get used in page headers for print output, can be used in lists (such as a List of Figures), and can be used as the text of a cross-reference, instead of a number.  You might not be inclined to give a <tag>remark</tag> a title, but it would be good practice to do so.  If you use knowls in your <init>HTML</init> output for structures such as <tag>example</tag> (or if somebody else may someday choose to), then your readers will be spared a lot of confusion if you supply informative titles for each. Your electronic outputs will be much more useful to your readers if you routinely title every structure that allows it (perhaps excepting <tag>exercise</tag> which can be known by their number).</p>
 
+<p>If a title is very long, the <tag>line</tag> element can be used to indicate how the title should appear on multiple lines.
+Note: does not apply to all output formats.
+<idx><h>title</h><h>very long</h></idx>
+<idx>line</idx>
+</p>
+
         <note xml:id="best-practice-titles">
             <title>Provide Informative Titles Liberally</title>
             <p>Provisions for titles in many situations is a key <pretext/> feature.  And then they are used for various purposes to benefit readers.  A good example is when the <init>HTML</init> conversion is used to place content in a <term>knowl</term>, a unit of content that begins hidden, but can be revealed (and hidden again) with one click of a mouse.  Since a reader cannot see the content originally, we will migrate a title into the clickable text.  But we cannot read your mind<mdash/>it is your job as the author to provide a title, and to provide a good one.</p>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1379,7 +1379,10 @@
         <subsection xml:id="topic-display-math">
             <title>Multi-line Display Mathematics</title>
 
-            <p>We begin with a pure container, either <tag>md</tag> or <tag>mdn</tag>.  The former numbers no lines, the latter numbers every line.  Within the container, content, on a per-line basis, goes into a <tag>mrow</tag> element.  You can think of <tag>mrow</tag> as being very similar to <tag>me</tag>.  If you are tempted to put a <latex /> <c>\\</c> into an <tag>mrow</tag>, think twice.</p>
+            <p>We begin with a pure container, either <tag>md</tag> or <tag>mdn</tag>.  The former numbers no lines, the latter numbers every line.  Within the container, content, on a per-line basis, goes into a <tag>mrow</tag> element.  You can think of <tag>mrow</tag> as being very similar to <tag>me</tag>.
+In a <latex/> <c>align</c> the <c>\\</c> mark the end of a displayed line.  In <pretext/> each <tag>mrow</tag> delimits a
+displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignment point.
+<idx>aligned math</idx><idx>\amp, math alignment</idx></p>
 
             <p>On any given <tag>mrow</tag> you can place the <attr>number</attr> attribute, with allowable values of <c>yes</c> and <c>no</c>.  These will typically be used to override the behavior inherited by the container, but there is no harm if they are redundant.  A given line of the display may be the target of a cross-reference, though the numbering flexibility means you can try (and fail) to target an unnumbered equation.</p>
 

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -166,6 +166,25 @@
     </paragraphs>
 
     <paragraphs>
+      <title>Paragraphs: like an un-numbered (sub)section</title>
+      <idx>paragraphs</idx>
+      <idx><h sortby="paragraphs">paragraphs</h></idx>
+      <p>
+        It can be useful to gather a few items and give them a title,
+        but perhaps those items do not merit their own (sub)section.
+        The <tag>paragraphs</tag> serves that purpose.  A <tag>title</tag>
+        is required.</p>
+
+      <p>
+        This <tag>paragraphs</tag> contains two <tag>p</tag>s.  Immediately before,
+        and immediately after this <tag>paragraphs</tag> there are <tag>paragraphs</tag>
+        which each contain one <tag>p</tag>.  A <tag>paragraphs</tag> can contain pretty
+        much anything except for a division.
+      </p>
+    </paragraphs>
+
+
+    <paragraphs>
       <title>The role of <tag>p</tag> tags</title>
       <idx>paragraph</idx>
       <idx sortby="p"><tag>p</tag></idx>


### PR DESCRIPTION
A few items added to documentation:

-the `paragraphs` element
-more details about multiline math
-how to break long titles into lines