### PR TITLE
Add CodeChat project configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ script/mjsre/package-lock.json
 pretext/__pycache__/**
 .vscode
 **/_build
+**/output

--- a/examples/humanities/codechat_config.yaml
+++ b/examples/humanities/codechat_config.yaml
@@ -1,0 +1,43 @@
+# .. Copyright (C) 2012-2020 Bryan A. Jones.
+#
+#  This file is part of the CodeChat System.
+#
+#  The CodeChat System is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  The CodeChat System is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with the CodeChat System.  If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# ************************************************
+# |docname| - Configuration for a CodeChat project
+# ************************************************
+# This file defines the configuration for a CodeChat project. It contains a working `Sphinx <https://www.sphinx-doc.org/>`_ configuration.
+#
+# ``source_path``: optional; defaults to ``.`` (the current directory). A path to the root of the source tree. Relative paths are rooted in the directory containing this configuration file.
+source_path: source
+
+# ``output_path``: required. A path to the root of the HTML output produced by this renderer. Relative paths are rooted in the directory containing this configuration file.
+output_path: output/html
+
+# ``args``: required string or sequence of strings. This provides the arguments to invoke the renderer. These strings may optionally contain the following replacement values:
+#
+# - ``{project_path}``: an absolute path to the directory containing this file.
+# - ``{source_path}``: the ``source_path`` above, but as an absolute path.
+# - ``{output_path}``: the ``output_path`` above, but as an absolute path.
+#
+# The line below could also be written ``args: sphinx-build . _build``.
+args: pretext build html
+
+# ``html_ext``: optional; defaults to ``.html``. The extension used by this renderer when generating HTML files.
+#html_ext: .html
+
+# ``project_type``: optional; defaults to ``general``. Define the project type, which enables special processing based on the type. Valid values are ``general`` (no special processing), ``Doxygen``, and ``PreTeXt``.
+project_type: PreTeXt

--- a/examples/minimal/codechat_config.yaml
+++ b/examples/minimal/codechat_config.yaml
@@ -1,0 +1,43 @@
+# .. Copyright (C) 2012-2020 Bryan A. Jones.
+#
+#  This file is part of the CodeChat System.
+#
+#  The CodeChat System is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  The CodeChat System is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with the CodeChat System.  If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# ************************************************
+# |docname| - Configuration for a CodeChat project
+# ************************************************
+# This file defines the configuration for a CodeChat project. It contains a working `Sphinx <https://www.sphinx-doc.org/>`_ configuration.
+#
+# ``source_path``: optional; defaults to ``.`` (the current directory). A path to the root of the source tree. Relative paths are rooted in the directory containing this configuration file.
+source_path: source
+
+# ``output_path``: required. A path to the root of the HTML output produced by this renderer. Relative paths are rooted in the directory containing this configuration file.
+output_path: output/html
+
+# ``args``: required string or sequence of strings. This provides the arguments to invoke the renderer. These strings may optionally contain the following replacement values:
+#
+# - ``{project_path}``: an absolute path to the directory containing this file.
+# - ``{source_path}``: the ``source_path`` above, but as an absolute path.
+# - ``{output_path}``: the ``output_path`` above, but as an absolute path.
+#
+# The line below could also be written ``args: sphinx-build . _build``.
+args: pretext build html
+
+# ``html_ext``: optional; defaults to ``.html``. The extension used by this renderer when generating HTML files.
+#html_ext: .html
+
+# ``project_type``: optional; defaults to ``general``. Define the project type, which enables special processing based on the type. Valid values are ``general`` (no special processing), ``Doxygen``, and ``PreTeXt``.
+project_type: PreTeXt

--- a/examples/sample-book/codechat_config.yaml
+++ b/examples/sample-book/codechat_config.yaml
@@ -34,7 +34,7 @@ output_path: _build
 # - ``{output_path}``: the ``output_path`` above, but as an absolute path.
 #
 # The line below could also be written ``args: sphinx-build . _build``.
-args: python3 ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml
+args: c:/Users/bjones/documents/git/CodeChat_System/.venv/Scripts/python ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml
 
 # ``html_ext``: optional; defaults to ``.html``. The extension used by this renderer when generating HTML files.
 #html_ext: .html

--- a/examples/sample-book/codechat_config.yaml
+++ b/examples/sample-book/codechat_config.yaml
@@ -1,0 +1,43 @@
+# .. Copyright (C) 2012-2020 Bryan A. Jones.
+#
+#  This file is part of the CodeChat System.
+#
+#  The CodeChat System is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  The CodeChat System is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with the CodeChat System.  If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# ************************************************
+# |docname| - Configuration for a CodeChat project
+# ************************************************
+# This file defines the configuration for a CodeChat project. It contains a working `Sphinx <https://www.sphinx-doc.org/>`_ configuration.
+#
+# ``source_path``: optional; defaults to ``.`` (the current directory). A path to the root of the source tree. Relative paths are rooted in the directory containing this configuration file.
+#source_path: .
+
+# ``output_path``: required. A path to the root of the HTML output produced by this renderer. Relative paths are rooted in the directory containing this configuration file.
+output_path: _build
+
+# ``args``: required string or sequence of strings. This provides the arguments to invoke the renderer. These strings may optionally contain the following replacement values:
+#
+# - ``{project_path}``: an absolute path to the directory containing this file.
+# - ``{source_path}``: the ``source_path`` above, but as an absolute path.
+# - ``{output_path}``: the ``output_path`` above, but as an absolute path.
+#
+# The line below could also be written ``args: sphinx-build . _build``.
+args: python3 ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml
+
+# ``html_ext``: optional; defaults to ``.html``. The extension used by this renderer when generating HTML files.
+#html_ext: .html
+
+# ``project_type``: optional; defaults to ``general``. Define the project type, which enables special processing based on the type. Valid values are ``general`` (no special processing), ``Doxygen``, and ``PreTeXt``.
+project_type: PreTeXt


### PR DESCRIPTION
This PR adds CodeChat project configuration files for three of the example books:

- `examples/minimal` and `examples/humanities`, both using the PreTeXt CLI.
- `examples/sample-book`, using the PreTeXt script. It assumes that `python3` will execute a Python interpreter where all the necessary libraries are installed (lxml, etc.). If PreTeXt is installed in a venv, perform the following edit to `examples/sample-book/codechat_config.yaml`:

   Change line 37, which is:

    `args: python3 ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml`

    to (for Linux/OS X):

    `args: C:/path/to/venv/bin/python ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml`

    or (for Windows):

    `args: /path/to/venv/Scripts/python ../../pretext/pretext --component all --format html --directory {output_path} sample-book.xml`

    For Windows, replace the drive letter (`C:` in the example above) as necessary. Note that forward slashes (`/`) work on Windows in this context.

