### PR TITLE
add publisher switch to allow for continuous formatting of worksheets

### DIFF
--- a/doc/guide/publisher/publisher-file.xml
+++ b/doc/guide/publisher/publisher-file.xml
@@ -131,6 +131,15 @@
             </ul></p>
         </subsection>
 
+        <subsection xml:id="latex-worksheet-options">
+            <title><latex /> Worksheet Options</title>
+            <p>
+                By default, worksheets are formatted differently than other pages, including customizable margins, workspace between exercises, and on their own pages.  This separate formatting can be ignored, causing worksheets to be treated like any other division, using the<cd>
+                <cline>/publication/latex/worksheet/@formatted</cline>
+             </cd>attribute, setting the value to <c>no</c>.  The default value is <c>yes</c>.
+            </p>
+        </subsection>
+
         <subsection xml:id="latex-asymptote-link-options">
             <title><latex/> Asymptote Links</title>
             <idx><h>Asymptote links</h><h>LaTeX, PDF</h></idx>

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -95,6 +95,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <latex print="no" sides="two">
         <!-- these are the default alignments, given just as an example -->
         <page right-alignment="flush" bottom-alignment="ragged"/>
+        <!-- worksheets are formatted separately by default.   -->
+        <!-- change to "no" to format as regular sections.     -->
+        <worksheet formatted="yes"/>
         <asymptote links="yes"/>
     </latex>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7419,7 +7419,8 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <xsl:template match="&PROJECT-LIKE;|exercise|task" mode="sanitize-workspace">
     <!-- bail out quickly and empty if not on a worksheet    -->
     <!-- bail out if at a "task" that is not a terminal task -->
-    <xsl:if test="ancestor::worksheet and not(child::task)">
+    <!-- bail out if publisher file says to not format worksheets -->
+    <xsl:if test="ancestor::worksheet and not(child::task) and ($latex-worksheet-formatted = 'yes')">
         <!-- First element with @workspace, confined to the worksheet  -->
         <!-- Could be empty node-set, which will be empty string later -->
         <xsl:variable name="workspaced" select="ancestor-or-self::*[@workspace and ancestor::worksheet][1]"/>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -4945,7 +4945,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- NB: could be obsoleted, see single use -->
     <xsl:variable name="b-is-specialized" select="boolean(self::exercises|self::solutions[not(parent::backmatter)]|self::reading-questions|self::glossary|self::references|self::worksheet)"/>
 
-    <xsl:if test="self::worksheet">
+    <!-- change geometry if worksheet should be formatted -->
+    <xsl:if test="self::worksheet and ($latex-worksheet-formatted = 'yes')">
         <!-- \newgeometry includes a \clearpage -->
         <xsl:apply-templates select="." mode="new-geometry"/>
     </xsl:if>
@@ -5077,7 +5078,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::worksheet">
+    <xsl:if test="self::worksheet and ($latex-worksheet-formatted = 'yes')">
         <!-- \restoregeometry includes a \clearpage -->
         <xsl:text>\restoregeometry&#xa;</xsl:text>
     </xsl:if>
@@ -5140,7 +5141,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="worksheet/page">
     <xsl:apply-templates/>
-    <xsl:if test="following-sibling::page">
+    <xsl:if test="following-sibling::page and ($latex-worksheet-formatted = 'yes')">
         <xsl:text>\clearpage&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
@@ -5149,7 +5150,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- "page" element interrupted numbering of contents.   -->
 <!-- Now deprecated in favor of a proper "page" element. -->
 <xsl:template match="worksheet/pagebreak">
-    <xsl:text>\clearpage&#xa;</xsl:text>
+    <xsl:if test="$latex-worksheet-formatted = 'yes'">
+        <xsl:text>\clearpage&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- Statement -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1807,6 +1807,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
+<!-- LaTeX worksheet formatting -->
+<!-- By default, worksheets in LaTeX will be formatted -->
+<!-- with specified margins, pages, and workspace.     -->
+<!-- Publisher switch to format continuously with      -->
+<!-- other divisions here                              -->
+<xsl:variable name="latex-worksheet-formatted">
+    <xsl:choose>
+        <xsl:when test="$publication/latex/worksheet/@formatted = 'no'">
+            <xsl:text>no</xsl:text>
+        </xsl:when>
+        <!-- default -->
+        <xsl:otherwise>
+            <xsl:text>yes</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- LaTeX/Asymptote -->
 
 <!-- Add a boolean variable to toggle links for Asymptote images in PDF.    -->


### PR DESCRIPTION
The publisher switch `publication/latex/worksheet/@formatted` with value `no` allows a publisher to have worksheets formatted continuously with the surrounding sections (no new page, no difference in margins, no workspace).  

Added documentation to the guide and sample-article publication file.