### PR TITLE
Bibtex-style bibliography entries

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -4173,8 +4173,27 @@ the xsltproc executable.
 
                 <biblio type="raw" xml:id="biblio-strang-article">Gilbert Strang, <title>The Fundamental Theorem of Linear Algebra</title>, <journal>The American Mathematical Monthly</journal> November 1993, <volume>100</volume> <number>9</number>, 848<ndash />855.</biblio>
 
+                <biblio type="bibtex" xml:id="CF">
+                <author>J. B. Conrey and D. W. Farmer</author>
+                <title>Mean values of <m>L</m>-functions and symmetry</title>
+                <journal>Internat. Math. Res. Notices</journal>
+                <number>17</number>
+                <year>2000</year>
+                <pages start="883" end="908"/>
+                </biblio>
+
                 <biblio type="raw" xml:id="biblio-beezer-fcla">Robert A. Beezer, <title>A First Course in Linear Algebra</title>, 3rd Edition, Congruent Press, 2012.
                 <note><p>An online, open-source offering.</p></note>
+                </biblio>
+
+                <biblio type="bibtex" xml:id="Dav">
+                <author>H. Davenport</author>
+                <title>Multiplicative Number Theory</title>
+                <series>GTM</series>
+                <volume>74</volume>
+                <publisher>Springer-Verlag New York, NY</publisher>
+                <year>2000</year>
+                <pages>xiv+177</pages>
                 </biblio>
 
                 <biblio type="raw" xml:id="biblio-rosswell-fictional">Alexander Rosswell, <title>Diffeomorphisms of Penciled Fiber Bundles</title>, <journal>Mathematicians of America</journal> <year>2020</year>, <volume>2</volume> <number>6</number>, 884<ndash />888.</biblio>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8818,6 +8818,77 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="biblio[@type='raw']/ibid">
     <xsl:text>Ibid.</xsl:text>
 </xsl:template>
+
+<!-- Fully marked-up bibtex-style bibliographic entry formatting -->
+<!-- Current treatment assumes elements are in the correct order -->
+
+<!-- Comma after author or editor -->
+<xsl:template match="biblio[@type='bibtex']/author">
+    <xsl:apply-templates />
+    <xsl:text>, </xsl:text>
+</xsl:template>
+<xsl:template match="biblio[@type='bibtex']/editor">
+    <xsl:apply-templates />
+    <xsl:text>, </xsl:text>
+</xsl:template>
+
+<!-- Title in italics -->
+<xsl:template match="biblio[@type='bibtex']/title">
+    <i><xsl:apply-templates /></i>
+    <xsl:text>, </xsl:text>
+</xsl:template>
+
+<!-- Space after journal -->
+<xsl:template match="biblio[@type='bibtex']/journal">
+    <xsl:apply-templates />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Volume in bold -->
+<xsl:template match="biblio[@type='bibtex']/volume">
+    <b><xsl:apply-templates /></b>
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Series is plain (but space after) -->
+<xsl:template match="biblio[@type='bibtex']/series">
+    <xsl:apply-templates />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Publisher is plain (but semicolon after) -->
+<xsl:template match="biblio[@type='bibtex']/publisher">
+    <xsl:apply-templates />
+    <xsl:text>; </xsl:text>
+</xsl:template>
+
+<!-- Year in parentheses -->
+<xsl:template match="biblio[@type='bibtex']/year">
+    <xsl:text>(</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>) </xsl:text>
+</xsl:template>
+
+<!-- Number: no. and comma after -->
+<xsl:template match="biblio[@type='bibtex']/number">
+    <xsl:text>no. </xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>, </xsl:text>
+</xsl:template>
+
+<!-- Pages should come last, so put a period.    -->
+<!-- Two forms: @start and @end,                 -->
+<!-- or total number as content (as for a book). -->
+<xsl:template match="biblio[@type='bibtex']/pages[not(@start)]">
+    <xsl:apply-templates />
+    <xsl:text>.</xsl:text>
+</xsl:template>
+<xsl:template match="biblio[@type='bibtex']/pages[@start]">
+    <xsl:text>pp. </xsl:text>
+    <xsl:value-of select="@start"/><xsl:text>-</xsl:text><xsl:value-of select="@end"/>
+    <xsl:text>.</xsl:text>
+</xsl:template>
+
 <!-- Index Entries -->
 <!-- Kill on sight, collect later to build index  -->
 <xsl:template match="index[not(index-list)]" />
@@ -11967,7 +12038,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{$html.js.server}/js/lib/jquery.sticky.js" ></script>
     <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
-    <script>miniversion=0.6</script>
+    <script>miniversion=0.674</script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js?x=1"></script>
 </xsl:template>
 
@@ -11983,7 +12054,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Hypothes.is Annotations -->
 <!-- Configurations are the defaults as of 2016-11-04   -->
-<!-- async="" is a guessed-hack, docs ahve no attribute -->
+<!-- async="" is a guessed-hack, docs have no attribute -->
 <xsl:template name="hypothesis-annotation">
     <xsl:if test="$b-activate-hypothesis">
         <script type="application/json" class="js-hypothesis-config">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -10974,7 +10974,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- As an item of a description list, but       -->
 <!-- compatible with thebibliography environment -->
-<xsl:template match="biblio[@type='raw']">
+<xsl:template match="biblio[@type='raw'] | biblio[@type='bibtex']">
     <!-- begin the list with first item -->
     <xsl:if test="not(preceding-sibling::biblio)">
         <xsl:text>%% If this is a top-level references&#xa;</xsl:text>
@@ -11038,6 +11038,79 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Ibid, nee ibidem, handle TeX period idosyncracy, empty element -->
 <xsl:template match="biblio[@type='raw']/ibid">
     <xsl:text>Ibid.\@\,</xsl:text>
+</xsl:template>
+
+<!-- Fully marked-up bibtex-style bibliographic entry formatting. -->
+<!-- Current treatment assumes elements are in the correct order. -->
+
+<!-- Comma after author or editor -->
+<xsl:template match="biblio[@type='bibtex']/author">
+    <xsl:apply-templates />
+    <xsl:text>, </xsl:text>
+</xsl:template>
+<xsl:template match="biblio[@type='bibtex']/editor">
+    <xsl:apply-templates />
+    <xsl:text>, </xsl:text>
+</xsl:template>
+
+<!-- Title in italics, followed by comma -->
+<xsl:template match="biblio[@type='bibtex']/title">
+    <xsl:text>\textit{</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>}, </xsl:text>
+</xsl:template>
+
+<!-- Space after journal -->
+<xsl:template match="biblio[@type='bibtex']/journal">
+    <xsl:apply-templates />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Volume in bold -->
+<xsl:template match="biblio[@type='bibtex']/volume">
+    <xsl:text>\textbf{</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>} </xsl:text>
+</xsl:template>
+
+<!-- Series is plain (but space after) -->
+<xsl:template match="biblio[@type='bibtex']/series">
+    <xsl:apply-templates />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Publisher is plain (but semicolon after) -->
+<xsl:template match="biblio[@type='bibtex']/publisher">
+    <xsl:apply-templates />
+    <xsl:text>; </xsl:text>
+</xsl:template>
+
+<!-- Year in parentheses -->
+<xsl:template match="biblio[@type='bibtex']/year">
+    <xsl:text>(</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>) </xsl:text>
+</xsl:template>
+
+<!-- Number, handle TeX period idosyncracy -->
+<xsl:template match="biblio[@type='bibtex']/number">
+    <xsl:text>no.\@\,</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!-- Pages should come last, so put a period.    -->
+<!-- Two forms: @start and @end,                 -->
+<!-- or total number as content (as for a book). -->
+<xsl:template match="biblio[@type='bibtex']/pages[not(@start)]">
+    <xsl:apply-templates />
+    <xsl:text>.</xsl:text>
+</xsl:template>
+<!-- For page range, put pp. and handle TeX period -->
+<xsl:template match="biblio[@type='bibtex']/pages[@start]">
+    <xsl:text>pp.\@\,</xsl:text>
+    <xsl:value-of select="@start"/><xsl:text>-</xsl:text><xsl:value-of select="@end"/>
+    <xsl:text>.</xsl:text>
 </xsl:template>
 
 


### PR DESCRIPTION
Within `<biblio type="bibtex">` there are new tags available, sufficient for
bibliography entries in a typical math paper.  It is expected that all content is
tagged, with no text elements.  Output preserves the order of the tags in the
source.

Examples added to the sample article.  Tested in HTML and LaTeX.

Update to the schema will be submitted in an issue.